### PR TITLE
Integrate fitness-driven budgeting mechanics

### DIFF
--- a/index.html
+++ b/index.html
@@ -202,6 +202,14 @@
             <button type="submit" class="btn primary">Add</button>
           </form>
         </div>
+        <div class="card" id="fitnessSummaryCard" style="margin-bottom:1rem;">
+          <h3 style="margin:0 0 0.5rem 0; font-size:1.1rem; font-weight:600;">Fitness &amp; Budget Summary</h3>
+          <div id="fitnessSummaryContent" class="fitness-summary"></div>
+        </div>
+        <div class="card" id="fitnessSettingsCard" style="margin-bottom:1rem;">
+          <h3 style="margin:0 0 0.5rem 0; font-size:1.1rem; font-weight:600;">Fitness Settings</h3>
+          <div id="fitnessSettingsContent"></div>
+        </div>
         <!-- List of workouts -->
         <div class="card" id="todoListContainer">
           <h3 style="margin:0 0 0.5rem 0; font-size:1.1rem; font-weight:600;">Your Workouts</h3>
@@ -224,6 +232,11 @@
               <option value="weekly">Weekly</option>
               <option value="monthly">Monthly</option>
               <option value="biannual">Biannual</option>
+            </select>
+            <select id="groceryCategory" style="width:7rem; padding:0.5rem; border:1px solid #cbd5e1; border-radius:0.375rem;">
+              <option value="standard">Standard</option>
+              <option value="treat">Treat</option>
+              <option value="essential">Essential</option>
             </select>
             <button type="submit" class="btn primary">Add</button>
           </form>
@@ -289,52 +302,410 @@
             return v.toString(16);
           });
         }
-        // Load and save data
-        function loadData() {
-          const raw = localStorage.getItem('timekeeperDataPro');
-          if (!raw) return { projects: [], entries: [], todos: [] };
-          try {
-            const parsed = JSON.parse(raw);
+        const FITNESS_MODES = {
+          gentle: { label: 'Gentle (6% / 4%)', alpha: 0.06, beta: 0.04 },
+          normal: { label: 'Normal (8% / 6%)', alpha: 0.08, beta: 0.06 },
+          strict: { label: 'Strict (10% / 8%)', alpha: 0.10, beta: 0.08 }
+        };
+        function makeDefaultFitness() {
+          return {
+            mode: 'normal',
+            alpha: FITNESS_MODES.normal.alpha,
+            beta: FITNESS_MODES.normal.beta,
+            currentMultiplier: 1,
+            nextMultiplier: 1,
+            lastProcessedMonday: null,
+            wellnessCredits: 0,
+            creditsCap: 1000,
+            creditSettings: {
+              base: 50,
+              extra: 25,
+              penalty: 40,
+              weeklyBonus: 50,
+              streakBonus: 100
+            },
+            streakCount: 0,
+            pausedWeeks: {},
+            weekendBoostEnabled: true,
+            weekendBoostPercent: 0.1,
+            weekendBoostUnlockedWeek: null,
+            lastWeekSummary: null
+          };
+        }
+        function applyFitnessDefaults(obj) {
+          const defaults = makeDefaultFitness();
+          if (!obj || typeof obj !== 'object') return defaults;
+          const merged = Object.assign({}, defaults, obj);
+          merged.creditSettings = Object.assign({}, defaults.creditSettings, obj.creditSettings || {});
+          merged.pausedWeeks = Object.assign({}, defaults.pausedWeeks, obj.pausedWeeks || {});
+          if (typeof merged.alpha !== 'number' || !isFinite(merged.alpha)) merged.alpha = defaults.alpha;
+          if (typeof merged.beta !== 'number' || !isFinite(merged.beta)) merged.beta = defaults.beta;
+          if (typeof merged.currentMultiplier !== 'number' || !isFinite(merged.currentMultiplier)) merged.currentMultiplier = defaults.currentMultiplier;
+          if (typeof merged.nextMultiplier !== 'number' || !isFinite(merged.nextMultiplier)) merged.nextMultiplier = defaults.nextMultiplier;
+          if (typeof merged.creditsCap !== 'number' || !isFinite(merged.creditsCap)) merged.creditsCap = defaults.creditsCap;
+          if (typeof merged.wellnessCredits !== 'number' || !isFinite(merged.wellnessCredits)) merged.wellnessCredits = defaults.wellnessCredits;
+          if (typeof merged.weekendBoostPercent !== 'number' || !isFinite(merged.weekendBoostPercent)) merged.weekendBoostPercent = defaults.weekendBoostPercent;
+          if (typeof merged.streakCount !== 'number' || !isFinite(merged.streakCount)) merged.streakCount = defaults.streakCount;
+          return merged;
+        }
+        function ensureFitnessDefaults() {
+          data.fitness = applyFitnessDefaults(data.fitness);
+          return data.fitness;
+        }
+        function clampMultiplier(value) {
+          const val = typeof value === 'number' && isFinite(value) ? value : 1;
+          return Math.min(1.2, Math.max(0.9, val));
+        }
+        function getWeekStart(date) {
+          const d = new Date(date);
+          const dow = d.getDay();
+          const diffToMonday = (dow + 6) % 7;
+          const monday = new Date(d.getFullYear(), d.getMonth(), d.getDate() - diffToMonday);
+          monday.setHours(0, 0, 0, 0);
+          return monday;
+        }
+        function getWeekKey(date) {
+          return getWeekStart(date).toISOString().split('T')[0];
+        }
+        function computeFitnessSummary(stats, alpha, beta) {
+          let totalPenalty = 0;
+          let totalOverage = 0;
+          let complianceSum = 0;
+          let workoutsCount = 0;
+          let totalTargets = 0;
+          let totalActual = 0;
+          stats.forEach(stat => {
+            const target = stat && typeof stat.target === 'number' ? stat.target : 0;
+            const actual = stat && typeof stat.actual === 'number' ? stat.actual : 0;
+            if (target <= 0) return;
+            const ratio = target > 0 ? actual / target : 0;
+            const compliance = Math.min(1, Math.max(0, ratio));
+            const overage = Math.max(0, ratio - 1);
+            const penalty = 1 - compliance;
+            totalPenalty += penalty;
+            totalOverage += overage;
+            complianceSum += compliance;
+            workoutsCount += 1;
+            totalTargets += target;
+            totalActual += actual;
+          });
+          const adjPercent = (alpha * totalOverage) - (beta * totalPenalty);
+          return {
+            adjPercent,
+            totalPenalty,
+            totalOverage,
+            complianceAvg: workoutsCount > 0 ? complianceSum / workoutsCount : 1,
+            workoutsCount,
+            totalTargets,
+            totalActual
+          };
+        }
+        function computeCreditsDelta(stats, fitness) {
+          const defaults = makeDefaultFitness();
+          const settings = fitness && fitness.creditSettings ? Object.assign({}, defaults.creditSettings, fitness.creditSettings) : defaults.creditSettings;
+          let baseEarned = 0;
+          let extraEarned = 0;
+          let penalties = 0;
+          let workoutsWithTargets = 0;
+          let metAll = true;
+          stats.forEach(stat => {
+            const target = stat && typeof stat.target === 'number' ? stat.target : 0;
+            const actual = stat && typeof stat.actual === 'number' ? stat.actual : 0;
+            if (target <= 0) return;
+            workoutsWithTargets += 1;
+            const baseSessions = Math.min(actual, target);
+            const extraSessions = Math.max(0, actual - target);
+            const missedSessions = Math.max(0, target - actual);
+            baseEarned += baseSessions * settings.base;
+            extraEarned += extraSessions * settings.extra;
+            penalties += missedSessions * settings.penalty;
+            if (actual < target) metAll = false;
+          });
+          let streakCount = fitness && typeof fitness.streakCount === 'number' ? fitness.streakCount : 0;
+          let bonus = 0;
+          if (metAll && workoutsWithTargets > 0) {
+            bonus += settings.weeklyBonus;
+            streakCount += 1;
+            if (streakCount > 0 && streakCount % 4 === 0) {
+              bonus += settings.streakBonus;
+            }
+          } else if (fitness) {
+            streakCount = 0;
+          }
+          const rawDelta = baseEarned + extraEarned - penalties + bonus;
+          const currentCredits = fitness && typeof fitness.wellnessCredits === 'number' ? fitness.wellnessCredits : 0;
+          const cap = fitness && typeof fitness.creditsCap === 'number' ? fitness.creditsCap : defaults.creditsCap;
+          const newCredits = Math.max(0, Math.min(cap, currentCredits + rawDelta));
+          const delta = newCredits - currentCredits;
+          return {
+            delta,
+            newCredits,
+            streakCount,
+            baseEarned,
+            extraEarned,
+            penalties,
+            bonus,
+            metAllTargets: metAll && workoutsWithTargets > 0,
+            workoutsWithTargets
+          };
+        }
+        function collectWorkoutStats(options = {}) {
+          const start = options.start ? new Date(options.start) : getWeekStart(new Date());
+          const end = options.end ? new Date(options.end) : null;
+          if (isNaN(start.getTime())) {
+            throw new Error('Invalid start date for workout stats');
+          }
+          const todos = Array.isArray(data.todos) ? data.todos : [];
+          const stats = todos.map(todo => {
+            if (!Array.isArray(todo.logs)) todo.logs = [];
+            if (todo.carryOver === undefined) todo.carryOver = 0;
+            const target = typeof todo.weeklyTarget === 'number' ? Math.max(0, todo.weeklyTarget) : 0;
+            let actual = 0;
+            todo.logs.forEach(log => {
+              const dt = new Date(log);
+              if (isNaN(dt.getTime())) return;
+              if (dt >= start && (!end || dt <= end)) {
+                actual += 1;
+              }
+            });
             return {
-              projects: Array.isArray(parsed.projects) ? parsed.projects : [],
-              entries: Array.isArray(parsed.entries) ? parsed.entries : [],
-              // Workouts (formerly todos). Ensure an array and attach carryOver property if missing.
-              todos: Array.isArray(parsed.todos) ? parsed.todos.map(t => {
-                if (t.carryOver === undefined) t.carryOver = 0;
-                if (!Array.isArray(t.logs)) t.logs = [];
-                return t;
-              }) : [],
-              // Grocery items: weekly/monthly shopping list with carryOver and purchasedCount.
-              groceries: Array.isArray(parsed.groceries) ? parsed.groceries.map(g => {
-                // Migrate legacy properties to new structure. Each item should have a name and frequency.
-                if (!g.name) g.name = '';
-                if (!g.frequency) g.frequency = 'weekly';
-                // In the new structure, we track whether an item has been archived and when it was purchased. Default false/null.
-                if (g.archived === undefined) g.archived = false;
-                if (g.purchasedDate === undefined) g.purchasedDate = null;
-                // Remove legacy fields carryOver and purchasedCount if present
-                if (g.hasOwnProperty('carryOver')) delete g.carryOver;
-                if (g.hasOwnProperty('purchasedCount')) delete g.purchasedCount;
-                return g;
-              }) : [],
-              // Removed single-item purchase quotas: budgets control spend, not counts.  Carry-over counts for
-              // purchases are no longer used, so we omit them from persisted data.
-        // Budgeting values: base budgets per period (weekly, monthly, biannual) and their carry-overs.
-        groceryBudgetWeekly: typeof parsed.groceryBudgetWeekly === 'number' ? parsed.groceryBudgetWeekly : 1000,
-        groceryBudgetMonthly: typeof parsed.groceryBudgetMonthly === 'number' ? parsed.groceryBudgetMonthly : 4000,
-        groceryBudgetBiYearly: typeof parsed.groceryBudgetBiYearly === 'number' ? parsed.groceryBudgetBiYearly : 20000,
-        groceryBudgetWeeklyCarry: typeof parsed.groceryBudgetWeeklyCarry === 'number' ? parsed.groceryBudgetWeeklyCarry : 0,
-        groceryBudgetMonthlyCarry: typeof parsed.groceryBudgetMonthlyCarry === 'number' ? parsed.groceryBudgetMonthlyCarry : 0,
-        groceryBudgetBiYearlyCarry: typeof parsed.groceryBudgetBiYearlyCarry === 'number' ? parsed.groceryBudgetBiYearlyCarry : 0,
-        // Start date for budgeting periods (YYYY-MM-DD); defaults to null to use current date on first run
-        groceryBudgetStartDate: parsed.groceryBudgetStartDate || null,
-              // Preserve additional persisted properties like backupDirName if present in saved data
-              backupDirName: parsed.backupDirName || null
+              id: todo.id,
+              name: todo.name || '',
+              target,
+              actual
             };
-          } catch (err) {
-            return { projects: [], entries: [], todos: [], groceries: [], backupDirName: null };
+          });
+          return { stats, start, end };
+        }
+        function isWeekPaused(weekKey) {
+          const fitness = ensureFitnessDefaults();
+          return !!(fitness.pausedWeeks && fitness.pausedWeeks[weekKey]);
+        }
+        function setWeekPaused(weekKey, paused) {
+          const fitness = ensureFitnessDefaults();
+          if (!fitness.pausedWeeks) fitness.pausedWeeks = {};
+          if (paused) {
+            fitness.pausedWeeks[weekKey] = true;
+          } else {
+            delete fitness.pausedWeeks[weekKey];
           }
         }
+        function finalizeFitnessWeek(weeklyStats, lastMonday, thisMonday) {
+          const fitness = ensureFitnessDefaults();
+          const lastMondayKey = getWeekKey(lastMonday);
+          const thisMondayKey = getWeekKey(thisMonday);
+          const prevNext = typeof fitness.nextMultiplier === 'number' ? fitness.nextMultiplier : 1;
+          fitness.currentMultiplier = clampMultiplier(prevNext);
+          const pausedWeeks = fitness.pausedWeeks || {};
+          const wasPaused = !!pausedWeeks[lastMondayKey];
+          if (wasPaused) {
+            delete pausedWeeks[lastMondayKey];
+            fitness.pausedWeeks = pausedWeeks;
+          }
+          const hasTargets = Array.isArray(weeklyStats) && weeklyStats.some(stat => stat.target > 0);
+          if (!hasTargets) {
+            fitness.nextMultiplier = fitness.currentMultiplier;
+            fitness.lastWeekSummary = {
+              weekStart: lastMondayKey,
+              weekEnd: thisMonday.toISOString().split('T')[0],
+              adjPercent: 0,
+              totalPenalty: 0,
+              totalOverage: 0,
+              complianceAvg: 1,
+              totalTargets: 0,
+              totalActual: 0,
+              creditsDelta: 0,
+              baseCredits: 0,
+              extraCredits: 0,
+              penalties: 0,
+              bonus: 0,
+              metAllTargets: false,
+              paused: wasPaused
+            };
+          } else if (wasPaused) {
+            fitness.nextMultiplier = fitness.currentMultiplier;
+            fitness.lastWeekSummary = {
+              weekStart: lastMondayKey,
+              weekEnd: thisMonday.toISOString().split('T')[0],
+              adjPercent: 0,
+              totalPenalty: 0,
+              totalOverage: 0,
+              complianceAvg: 1,
+              totalTargets: 0,
+              totalActual: 0,
+              creditsDelta: 0,
+              baseCredits: 0,
+              extraCredits: 0,
+              penalties: 0,
+              bonus: 0,
+              metAllTargets: false,
+              paused: true
+            };
+          } else {
+            const summary = computeFitnessSummary(weeklyStats, fitness.alpha, fitness.beta);
+            const nextMultiplier = clampMultiplier(1 + summary.adjPercent);
+            const creditsInfo = computeCreditsDelta(weeklyStats, fitness);
+            fitness.nextMultiplier = nextMultiplier;
+            fitness.wellnessCredits = creditsInfo.newCredits;
+            fitness.streakCount = creditsInfo.streakCount;
+            fitness.lastWeekSummary = {
+              weekStart: lastMondayKey,
+              weekEnd: thisMonday.toISOString().split('T')[0],
+              adjPercent: summary.adjPercent,
+              totalPenalty: summary.totalPenalty,
+              totalOverage: summary.totalOverage,
+              complianceAvg: summary.complianceAvg,
+              totalTargets: summary.totalTargets,
+              totalActual: summary.totalActual,
+              creditsDelta: creditsInfo.delta,
+              baseCredits: creditsInfo.baseEarned,
+              extraCredits: creditsInfo.extraEarned,
+              penalties: creditsInfo.penalties,
+              bonus: creditsInfo.bonus,
+              metAllTargets: creditsInfo.metAllTargets,
+              paused: false
+            };
+          }
+          fitness.weekendBoostUnlockedWeek = null;
+          fitness.lastProcessedMonday = thisMondayKey;
+        }
+        function evaluateWeekendBoostUnlock() {
+          const fitness = ensureFitnessDefaults();
+          if (!fitness.weekendBoostEnabled) return false;
+          const weekKey = getWeekKey(new Date());
+          if (fitness.weekendBoostUnlockedWeek === weekKey) return true;
+          const monday = getWeekStart(new Date());
+          const fridayCutoff = new Date(monday);
+          fridayCutoff.setDate(fridayCutoff.getDate() + 4);
+          fridayCutoff.setHours(18, 0, 0, 0);
+          const now = new Date();
+          if (now < fridayCutoff) return false;
+          const statsInfo = collectWorkoutStats({ start: monday, end: fridayCutoff });
+          let totalTarget = 0;
+          let totalActual = 0;
+          statsInfo.stats.forEach(stat => {
+            if (stat.target > 0) {
+              totalTarget += stat.target;
+              totalActual += Math.min(stat.actual, stat.target);
+            }
+          });
+          if (totalTarget > 0 && totalActual >= totalTarget) {
+            fitness.weekendBoostUnlockedWeek = weekKey;
+            saveData();
+            return true;
+          }
+          return false;
+        }
+        function isWeekendBoostActive() {
+          const fitness = ensureFitnessDefaults();
+          if (!fitness.weekendBoostEnabled) return false;
+          const weekKey = getWeekKey(new Date());
+          if (fitness.weekendBoostUnlockedWeek !== weekKey) {
+            return evaluateWeekendBoostUnlock();
+          }
+          const now = new Date();
+          const monday = getWeekStart(now);
+          const friday = new Date(monday);
+          friday.setDate(friday.getDate() + 4);
+          friday.setHours(18, 0, 0, 0);
+          const sunday = new Date(monday);
+          sunday.setDate(sunday.getDate() + 6);
+          sunday.setHours(23, 59, 59, 999);
+          return now >= friday && now <= sunday;
+        }
+        function formatPercent(value, decimals = 1) {
+          if (!isFinite(value)) return '0%';
+          return (value * 100).toFixed(decimals) + '%';
+        }
+        function formatSignedCurrency(value, decimals = -1) {
+          if (!isFinite(value) || value === 0) {
+            return '0 SEK';
+          }
+          const formatted = formatCurrency(Math.abs(value), decimals).replace(' kr', '');
+          return (value >= 0 ? '+' : '−') + formatted + ' SEK';
+        }
+        // Load and save data
+
+function loadData() {
+  const raw = localStorage.getItem('timekeeperDataPro');
+  if (!raw) {
+    return {
+      projects: [],
+      entries: [],
+      todos: [],
+      groceries: [],
+      groceryBudgetWeekly: 1000,
+      groceryBudgetMonthly: 4000,
+      groceryBudgetBiYearly: 20000,
+      groceryBudgetWeeklyCarry: 0,
+      groceryBudgetMonthlyCarry: 0,
+      groceryBudgetBiYearlyCarry: 0,
+      groceryBudgetStartDate: null,
+      backupDirName: null,
+      fitness: makeDefaultFitness()
+    };
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    return {
+      projects: Array.isArray(parsed.projects) ? parsed.projects : [],
+      entries: Array.isArray(parsed.entries) ? parsed.entries : [],
+      // Workouts (formerly todos). Ensure an array and attach carryOver property if missing.
+      todos: Array.isArray(parsed.todos) ? parsed.todos.map(t => {
+        if (t.carryOver === undefined) t.carryOver = 0;
+        if (!Array.isArray(t.logs)) t.logs = [];
+        return t;
+      }) : [],
+      // Grocery items: weekly/monthly shopping list with carryOver and purchasedCount.
+      groceries: Array.isArray(parsed.groceries) ? parsed.groceries.map(g => {
+        // Migrate legacy properties to new structure. Each item should have a name and frequency.
+        if (!g.name) g.name = '';
+        if (!g.frequency) g.frequency = 'weekly';
+        // In the new structure, we track whether an item has been archived and when it was purchased. Default false/null.
+        if (g.archived === undefined) g.archived = false;
+        if (g.purchasedDate === undefined) g.purchasedDate = null;
+        if (!g.category) g.category = 'standard';
+        if (g.originalCost === undefined && typeof g.cost === 'number') g.originalCost = g.cost;
+                if (g.appliedCredits === undefined) g.appliedCredits = 0;
+                if (g.boostApplied === undefined) g.boostApplied = false;
+                if (g.boostPercentApplied === undefined) g.boostPercentApplied = 0;
+        // Remove legacy fields carryOver and purchasedCount if present
+        if (g.hasOwnProperty('carryOver')) delete g.carryOver;
+        if (g.hasOwnProperty('purchasedCount')) delete g.purchasedCount;
+        return g;
+      }) : [],
+      // Removed single-item purchase quotas: budgets control spend, not counts.  Carry-over counts for
+      // purchases are no longer used, so we omit them from persisted data.
+      groceryBudgetWeekly: typeof parsed.groceryBudgetWeekly === 'number' ? parsed.groceryBudgetWeekly : 1000,
+      groceryBudgetMonthly: typeof parsed.groceryBudgetMonthly === 'number' ? parsed.groceryBudgetMonthly : 4000,
+      groceryBudgetBiYearly: typeof parsed.groceryBudgetBiYearly === 'number' ? parsed.groceryBudgetBiYearly : 20000,
+      groceryBudgetWeeklyCarry: typeof parsed.groceryBudgetWeeklyCarry === 'number' ? parsed.groceryBudgetWeeklyCarry : 0,
+      groceryBudgetMonthlyCarry: typeof parsed.groceryBudgetMonthlyCarry === 'number' ? parsed.groceryBudgetMonthlyCarry : 0,
+      groceryBudgetBiYearlyCarry: typeof parsed.groceryBudgetBiYearlyCarry === 'number' ? parsed.groceryBudgetBiYearlyCarry : 0,
+      // Start date for budgeting periods (YYYY-MM-DD); defaults to null to use current date on first run
+      groceryBudgetStartDate: parsed.groceryBudgetStartDate || null,
+      // Preserve additional persisted properties like backupDirName if present in saved data
+      backupDirName: parsed.backupDirName || null,
+      fitness: applyFitnessDefaults(parsed.fitness)
+    };
+  } catch (err) {
+    return {
+      projects: [],
+      entries: [],
+      todos: [],
+      groceries: [],
+      groceryBudgetWeekly: 1000,
+      groceryBudgetMonthly: 4000,
+      groceryBudgetBiYearly: 20000,
+      groceryBudgetWeeklyCarry: 0,
+      groceryBudgetMonthlyCarry: 0,
+      groceryBudgetBiYearlyCarry: 0,
+      groceryBudgetStartDate: null,
+      backupDirName: null,
+      fitness: makeDefaultFitness()
+    };
+  }
+}
         function saveData() {
           localStorage.setItem('timekeeperDataPro', JSON.stringify(data));
           // Mark data as needing backup
@@ -348,6 +719,7 @@
           return 1 / (1 + (n - 1) / 3);
         }
         let data = loadData();
+        ensureFitnessDefaults();
         // Initialize backup and sync flags before they are referenced in saveData().
         // needsBackup tracks whether the data has changed and needs to be exported.
         // autoSyncEnabled indicates whether automatic export is enabled.
@@ -455,6 +827,7 @@
               const lastMonday = new Date(monday);
               lastMonday.setDate(monday.getDate() - 7);
               lastMonday.setHours(0, 0, 0, 0);
+              const weeklyStats = [];
               data.todos.forEach(t => {
                 // Ensure properties exist
                 if (typeof t.weeklyTarget !== 'number' || t.weeklyTarget < 1) {
@@ -471,6 +844,7 @@
                   const dt = new Date(log);
                   return dt >= lastMonday && dt < monday;
                 }).length;
+                weeklyStats.push({ id: t.id, name: t.name || '', target: Math.max(0, t.weeklyTarget), actual: sessionsLastWeek });
                 // Dynamic target for the previous week
                 const dynamicTarget = t.weeklyTarget + t.carryOver;
                 // Determine carryOver for the new week based on difference between target and actual sessions
@@ -485,6 +859,7 @@
                   return dt >= monday;
                 });
               });
+              finalizeFitnessWeek(weeklyStats, lastMonday, monday);
             }
             localStorage.setItem('todoResetDatePro', mondayStr);
             saveData();
@@ -591,6 +966,297 @@
         // relative to the weekly target and provide buttons to log a session,
         // edit the target, or delete the workout. The UI resets weekly on
         // Mondays by filtering logs before this week.
+        function updateFitnessCards(statsInfo) {
+          const summaryEl = document.getElementById('fitnessSummaryContent');
+          const settingsEl = document.getElementById('fitnessSettingsContent');
+          const fitness = ensureFitnessDefaults();
+          const statsData = statsInfo || collectWorkoutStats();
+          const stats = Array.isArray(statsData.stats) ? statsData.stats : [];
+          const hasTargets = stats.some(stat => stat.target > 0);
+          const summary = hasTargets ? computeFitnessSummary(stats, fitness.alpha, fitness.beta) : {
+            adjPercent: 0,
+            totalPenalty: 0,
+            totalOverage: 0,
+            complianceAvg: 1,
+            totalTargets: 0,
+            totalActual: 0
+          };
+          const currentMultiplier = clampMultiplier(fitness.currentMultiplier || 1);
+          const nextMultiplier = clampMultiplier(typeof fitness.nextMultiplier === 'number' ? fitness.nextMultiplier : currentMultiplier);
+          const projectedMultiplier = clampMultiplier(1 + summary.adjPercent);
+          const weeklyBaseBudget = (data.groceryBudgetWeekly || 0) + (data.groceryBudgetWeeklyCarry || 0);
+          const currentBudget = weeklyBaseBudget * currentMultiplier;
+          const nextBudget = weeklyBaseBudget * nextMultiplier;
+          const projectedBudget = weeklyBaseBudget * projectedMultiplier;
+          const totalTargetSessions = stats.reduce((acc, stat) => stat.target > 0 ? acc + stat.target : acc, 0);
+          const totalActualSessions = stats.reduce((acc, stat) => stat.target > 0 ? acc + stat.actual : acc, 0);
+          const complianceRatio = totalTargetSessions > 0 ? totalActualSessions / totalTargetSessions : 0;
+          const pausedThisWeek = isWeekPaused(getWeekKey(new Date()));
+          const boostEnabled = fitness.weekendBoostEnabled;
+          const boostActive = isWeekendBoostActive();
+          const boostUnlocked = fitness.weekendBoostUnlockedWeek === getWeekKey(new Date());
+          const boostPercent = Math.round((fitness.weekendBoostPercent || 0) * 100);
+          const defaultCreditSettings = makeDefaultFitness().creditSettings;
+          const creditSettings = Object.assign({}, defaultCreditSettings, fitness.creditSettings || {});
+          const formatAmount = (num) => {
+            const str = formatCurrency(num, -1);
+            return str ? str.replace(' kr', ' SEK') : '0 SEK';
+          };
+          if (summaryEl) {
+            summaryEl.innerHTML = '';
+            const grid = document.createElement('div');
+            grid.className = 'fitness-summary-grid';
+            function createRow(label, value, subText) {
+              const row = document.createElement('div');
+              row.className = 'fitness-summary-row';
+              const labelEl = document.createElement('div');
+              labelEl.className = 'fitness-summary-label';
+              labelEl.textContent = label;
+              const valueEl = document.createElement('div');
+              valueEl.className = 'fitness-summary-value';
+              valueEl.textContent = value;
+              row.appendChild(labelEl);
+              row.appendChild(valueEl);
+              if (subText) {
+                const sub = document.createElement('div');
+                sub.className = 'fitness-summary-sub';
+                sub.textContent = subText;
+                row.appendChild(sub);
+              }
+              grid.appendChild(row);
+            }
+            createRow('Current multiplier', currentMultiplier.toFixed(2) + '×', 'Weekly budget ' + formatAmount(currentBudget));
+            const projectedDelta = projectedBudget - weeklyBaseBudget;
+            if (hasTargets) {
+              createRow('Projected (if week ended today)', projectedMultiplier.toFixed(2) + '×', formatSignedCurrency(projectedDelta));
+            }
+            const lastWeek = fitness.lastWeekSummary;
+            const nextDelta = nextBudget - weeklyBaseBudget;
+            let nextSub = formatSignedCurrency(nextDelta);
+            if (lastWeek && !lastWeek.paused) {
+              const bonusPct = fitness.alpha * lastWeek.totalOverage;
+              const penaltyPct = fitness.beta * lastWeek.totalPenalty;
+              nextSub += ' • Last week ' + formatPercent(bonusPct, 1) + ' bonus, ' + formatPercent(penaltyPct, 1) + ' penalty';
+            } else if (lastWeek && lastWeek.paused) {
+              nextSub += ' • Last week paused';
+            }
+            createRow('Next week (locked)', nextMultiplier.toFixed(2) + '×', nextSub);
+            if (hasTargets) {
+              createRow('Weekly compliance', totalActualSessions + ' / ' + totalTargetSessions + ' sessions', formatPercent(Math.min(complianceRatio, 1), 1));
+            } else {
+              createRow('Weekly compliance', 'No targets', null);
+            }
+            const creditsRow = document.createElement('div');
+            creditsRow.className = 'fitness-pill-row';
+            const creditsPill = document.createElement('span');
+            creditsPill.className = 'fitness-pill';
+            creditsPill.textContent = 'Wellness Credits: ' + formatCurrency(fitness.wellnessCredits || 0, -1).replace(' kr', ' SEK');
+            creditsRow.appendChild(creditsPill);
+            if (fitness.creditsCap) {
+              const capPill = document.createElement('span');
+              capPill.className = 'fitness-pill muted';
+              capPill.textContent = 'Cap ' + formatCurrency(fitness.creditsCap, -1).replace(' kr', ' SEK');
+              creditsRow.appendChild(capPill);
+            }
+            if (fitness.streakCount && fitness.streakCount > 0) {
+              const streakPill = document.createElement('span');
+              streakPill.className = 'fitness-pill warm';
+              streakPill.textContent = '🔥 Streak ' + fitness.streakCount + ' week' + (fitness.streakCount === 1 ? '' : 's');
+              creditsRow.appendChild(streakPill);
+            }
+            summaryEl.appendChild(grid);
+            summaryEl.appendChild(creditsRow);
+            const boostRow = document.createElement('div');
+            boostRow.className = 'fitness-summary-row';
+            const boostLabel = document.createElement('div');
+            boostLabel.className = 'fitness-summary-label';
+            boostLabel.textContent = 'Weekend boost';
+            const boostValue = document.createElement('div');
+            boostValue.className = 'fitness-summary-value';
+            if (!boostEnabled) {
+              boostValue.textContent = 'Disabled';
+            } else if (boostActive) {
+              boostValue.textContent = 'Unlocked: +' + boostPercent + '% on Treats';
+            } else if (boostUnlocked) {
+              boostValue.textContent = 'Unlocked – waiting for weekend (+' + boostPercent + '%)';
+            } else if (hasTargets && totalTargetSessions > 0) {
+              const remaining = Math.max(0, totalTargetSessions - totalActualSessions);
+              boostValue.textContent = 'Locked – ' + remaining + ' session' + (remaining === 1 ? '' : 's') + ' to unlock +' + boostPercent + '%';
+            } else {
+              boostValue.textContent = 'Locked';
+            }
+            boostRow.appendChild(boostLabel);
+            boostRow.appendChild(boostValue);
+            summaryEl.appendChild(boostRow);
+            const pauseRow = document.createElement('div');
+            pauseRow.className = 'fitness-summary-row';
+            const pauseLabel = document.createElement('div');
+            pauseLabel.className = 'fitness-summary-label';
+            pauseLabel.textContent = 'Sick / travel pause';
+            const pauseValue = document.createElement('div');
+            pauseValue.className = 'fitness-summary-value';
+            const pauseToggle = document.createElement('label');
+            pauseToggle.className = 'switch-label';
+            const pauseCheckbox = document.createElement('input');
+            pauseCheckbox.type = 'checkbox';
+            pauseCheckbox.checked = pausedThisWeek;
+            pauseCheckbox.addEventListener('change', () => {
+              setWeekPaused(getWeekKey(new Date()), pauseCheckbox.checked);
+              saveData();
+              updateTodoSection();
+              updateGrocerySection();
+            });
+            const toggleSpan = document.createElement('span');
+            toggleSpan.textContent = pauseCheckbox.checked ? 'Paused' : 'Active';
+            pauseCheckbox.addEventListener('change', () => {
+              toggleSpan.textContent = pauseCheckbox.checked ? 'Paused' : 'Active';
+            });
+            pauseToggle.appendChild(pauseCheckbox);
+            pauseToggle.appendChild(toggleSpan);
+            pauseValue.appendChild(pauseToggle);
+            pauseRow.appendChild(pauseLabel);
+            pauseRow.appendChild(pauseValue);
+            summaryEl.appendChild(pauseRow);
+            if (creditSettings) {
+              const ratesRow = document.createElement('div');
+              ratesRow.className = 'fitness-summary-row muted';
+              ratesRow.textContent = `Credits: +${creditSettings.base} up to target, +${creditSettings.extra} extra, −${creditSettings.penalty} missed`;
+              summaryEl.appendChild(ratesRow);
+            }
+          }
+          if (settingsEl) {
+            settingsEl.innerHTML = '';
+            const settingsGrid = document.createElement('div');
+            settingsGrid.className = 'fitness-settings-grid';
+            function appendSetting(labelText, control) {
+              const row = document.createElement('div');
+              row.className = 'fitness-setting-row';
+              const label = document.createElement('label');
+              label.textContent = labelText;
+              row.appendChild(label);
+              row.appendChild(control);
+              settingsGrid.appendChild(row);
+            }
+            const modeSelect = document.createElement('select');
+            Object.entries(FITNESS_MODES).forEach(([key, cfg]) => {
+              const option = document.createElement('option');
+              option.value = key;
+              option.textContent = cfg.label;
+              modeSelect.appendChild(option);
+            });
+            const customOption = document.createElement('option');
+            customOption.value = 'custom';
+            customOption.textContent = 'Custom';
+            modeSelect.appendChild(customOption);
+            modeSelect.value = FITNESS_MODES[fitness.mode] ? fitness.mode : 'custom';
+            modeSelect.addEventListener('change', () => {
+              const val = modeSelect.value;
+              if (FITNESS_MODES[val]) {
+                fitness.mode = val;
+                fitness.alpha = FITNESS_MODES[val].alpha;
+                fitness.beta = FITNESS_MODES[val].beta;
+              } else {
+                fitness.mode = 'custom';
+              }
+              saveData();
+              updateTodoSection();
+              updateGrocerySection();
+            });
+            appendSetting('Budget mode', modeSelect);
+            const alphaInput = document.createElement('input');
+            alphaInput.type = 'number';
+            alphaInput.step = '0.1';
+            alphaInput.min = '0';
+            alphaInput.value = (fitness.alpha * 100).toFixed(1);
+            alphaInput.addEventListener('change', () => {
+              const val = parseFloat(alphaInput.value);
+              if (!isNaN(val)) {
+                fitness.alpha = val / 100;
+                fitness.mode = 'custom';
+                saveData();
+                updateTodoSection();
+                updateGrocerySection();
+              }
+            });
+            appendSetting('Multiplier bonus α (%)', alphaInput);
+            const betaInput = document.createElement('input');
+            betaInput.type = 'number';
+            betaInput.step = '0.1';
+            betaInput.min = '0';
+            betaInput.value = (fitness.beta * 100).toFixed(1);
+            betaInput.addEventListener('change', () => {
+              const val = parseFloat(betaInput.value);
+              if (!isNaN(val)) {
+                fitness.beta = val / 100;
+                fitness.mode = 'custom';
+                saveData();
+                updateTodoSection();
+                updateGrocerySection();
+              }
+            });
+            appendSetting('Penalty weight β (%)', betaInput);
+            function numberSetting(label, initial, onChange) {
+              const input = document.createElement('input');
+              input.type = 'number';
+              input.step = '1';
+              input.value = String(initial);
+              input.addEventListener('change', () => {
+                const val = parseFloat(input.value);
+                if (!isNaN(val)) {
+                  onChange(val);
+                  saveData();
+                  updateTodoSection();
+                  updateGrocerySection();
+                }
+              });
+              appendSetting(label, input);
+            }
+            numberSetting('Credits per session (up to target)', creditSettings.base, (val) => {
+              fitness.creditSettings.base = val;
+            });
+            numberSetting('Credits per extra session', creditSettings.extra, (val) => {
+              fitness.creditSettings.extra = val;
+            });
+            numberSetting('Penalty per missed session', creditSettings.penalty, (val) => {
+              fitness.creditSettings.penalty = val;
+            });
+            numberSetting('Weekly bonus', creditSettings.weeklyBonus, (val) => {
+              fitness.creditSettings.weeklyBonus = val;
+            });
+            numberSetting('Streak bonus (4 weeks)', creditSettings.streakBonus, (val) => {
+              fitness.creditSettings.streakBonus = val;
+            });
+            numberSetting('Credits cap', fitness.creditsCap, (val) => {
+              fitness.creditsCap = Math.max(0, val);
+            });
+            const boostToggle = document.createElement('input');
+            boostToggle.type = 'checkbox';
+            boostToggle.checked = boostEnabled;
+            boostToggle.addEventListener('change', () => {
+              fitness.weekendBoostEnabled = boostToggle.checked;
+              saveData();
+              updateTodoSection();
+              updateGrocerySection();
+            });
+            appendSetting('Enable weekend boost', boostToggle);
+            const boostPercentInput = document.createElement('input');
+            boostPercentInput.type = 'number';
+            boostPercentInput.step = '1';
+            boostPercentInput.min = '0';
+            boostPercentInput.value = boostPercent;
+            boostPercentInput.addEventListener('change', () => {
+              const val = parseFloat(boostPercentInput.value);
+              if (!isNaN(val)) {
+                fitness.weekendBoostPercent = Math.max(0, val) / 100;
+                saveData();
+                updateTodoSection();
+                updateGrocerySection();
+              }
+            });
+            appendSetting('Weekend boost percent', boostPercentInput);
+            settingsEl.appendChild(settingsGrid);
+          }
+        }
         function updateTodoSection() {
           const listEl = document.getElementById('todoList');
           if (!listEl) return;
@@ -602,17 +1268,24 @@
           const diffToMonday = (dow + 6) % 7;
           const monday = new Date(now.getFullYear(), now.getMonth(), now.getDate() - diffToMonday);
           monday.setHours(0, 0, 0, 0);
-          todos.forEach((todo, index) => {
-            // Ensure workout properties exist
+          todos.forEach(todo => {
             if (typeof todo.weeklyTarget !== 'number' || todo.weeklyTarget < 1) {
               todo.weeklyTarget = 1;
             }
-            if (!Array.isArray(todo.logs)) {
-              todo.logs = [];
-            }
-            if (todo.carryOver === undefined) {
-              todo.carryOver = 0;
-            }
+            if (!Array.isArray(todo.logs)) todo.logs = [];
+            if (todo.carryOver === undefined) todo.carryOver = 0;
+          });
+          const statsInfo = collectWorkoutStats({ start: monday });
+          updateFitnessCards(statsInfo);
+          const statsById = new Map(statsInfo.stats.map(stat => [stat.id, stat]));
+          const fitness = ensureFitnessDefaults();
+          const alpha = fitness.alpha;
+          const beta = fitness.beta;
+          const currentSummary = computeFitnessSummary(statsInfo.stats, alpha, beta);
+          const currentAdjPercent = currentSummary.adjPercent;
+          const creditSettings = Object.assign({}, makeDefaultFitness().creditSettings, fitness.creditSettings || {});
+          todos.forEach((todo, index) => {
+            // Ensure workout properties exist
             // Dynamic target for this week includes spillover from previous weeks
             const dynamicTarget = Math.max(0, todo.weeklyTarget + todo.carryOver);
             // Count sessions completed this week by filtering logs on or after Monday
@@ -620,6 +1293,14 @@
               const t = new Date(log);
               return t >= monday;
             }).length;
+            const statInfo = statsById.get(todo.id) || { target: todo.weeklyTarget, actual: sessionsThisWeek };
+            const baseTarget = statInfo.target;
+            const actualSessions = statInfo.actual;
+            const withOneMoreStats = statsInfo.stats.map(stat => stat.id === todo.id ? Object.assign({}, stat, { actual: stat.actual + 1 }) : Object.assign({}, stat));
+            const projectedSummary = computeFitnessSummary(withOneMoreStats, alpha, beta);
+            const projectedDeltaPercent = (projectedSummary.adjPercent - currentAdjPercent) * 100;
+            const impactText = (baseTarget > 0 && Math.abs(projectedDeltaPercent) >= 0.05) ? `Budget impact: ${projectedDeltaPercent > 0 ? '+' : ''}${projectedDeltaPercent.toFixed(1)}% next week` : 'Budget impact: already maxed';
+            const nextCredit = baseTarget > 0 ? (actualSessions < baseTarget ? creditSettings.base : creditSettings.extra) : 0;
             // Create list item container
             const li = document.createElement('li');
             li.style.display = 'flex';
@@ -708,6 +1389,16 @@
             text.style.fontSize = '0.75rem';
             text.textContent = sessionsThisWeek + ' / ' + dynamicTarget + ' sessions';
             progressContainer.appendChild(text);
+            const impactLine = document.createElement('div');
+            impactLine.className = 'fitness-impact-line';
+            impactLine.textContent = impactText;
+            progressContainer.appendChild(impactLine);
+            if (nextCredit > 0) {
+              const creditLine = document.createElement('div');
+              creditLine.className = 'fitness-credit-line';
+              creditLine.textContent = 'Wellness Credits: +' + nextCredit + ' SEK on next session';
+              progressContainer.appendChild(creditLine);
+            }
             li.appendChild(progressContainer);
             listEl.appendChild(li);
           });
@@ -746,18 +1437,32 @@
             e.preventDefault();
             const nameInput = document.getElementById('groceryName');
             const freqSelect = document.getElementById('groceryFreq');
+            const categorySelect = document.getElementById('groceryCategory');
             const name = nameInput.value.trim();
             const freq = freqSelect.value;
+            const category = categorySelect ? categorySelect.value : 'standard';
             if (!name) return;
             if (!Array.isArray(data.groceries)) {
               data.groceries = [];
             }
             // When adding a new grocery item, initialise it as not archived with no purchase date.
-            data.groceries.push({ id: uuid(), name: name, frequency: freq, archived: false, purchasedDate: null });
+            data.groceries.push({
+              id: uuid(),
+              name: name,
+              frequency: freq,
+              category: category,
+              archived: false,
+              purchasedDate: null,
+              originalCost: 0,
+              appliedCredits: 0,
+              boostApplied: false,
+              boostPercentApplied: 0
+            });
             saveData();
             updateGrocerySection();
             nameInput.value = '';
             freqSelect.value = 'weekly';
+            if (categorySelect) categorySelect.value = 'standard';
           });
         }
 
@@ -874,9 +1579,26 @@
               const dt = new Date(archItem.purchasedDate);
               dateStr = dt.toLocaleDateString();
             }
-            const costString = typeof archItem.cost === 'number' ? formatCurrency(archItem.cost, -1) + ' SEK' : '0 SEK';
-            detailsSpan.textContent = `${archItem.name} – ${costString} – ${archItem.frequency} – ${dateStr}`;
+            const costString = typeof archItem.cost === 'number' ? formatCurrency(archItem.cost, -1).replace(' kr', ' SEK') : '0 SEK';
+            const parts = [`${archItem.name}`, costString];
+            if (typeof archItem.originalCost === 'number' && archItem.originalCost !== archItem.cost) {
+              const originalString = formatCurrency(archItem.originalCost, -1).replace(' kr', ' SEK');
+              let creditNote = `original ${originalString}`;
+              if (typeof archItem.appliedCredits === 'number' && archItem.appliedCredits > 0) {
+                creditNote += `, credits −${formatCurrency(archItem.appliedCredits, -1).replace(' kr', ' SEK')}`;
+              }
+              parts.push(creditNote);
+            }
+            parts.push(archItem.frequency);
+            if (dateStr) parts.push(dateStr);
+            detailsSpan.textContent = parts.join(' – ');
             rowArch.appendChild(detailsSpan);
+            if (archItem.boostApplied && archItem.boostPercentApplied) {
+              const boostNote = document.createElement('div');
+              boostNote.className = 'treat-note archived';
+              boostNote.textContent = 'Weekend Boost covered ' + Math.round((archItem.boostPercentApplied || fitness.weekendBoostPercent || 0) * 100) + '%';
+              liArch.appendChild(boostNote);
+            }
             // Action buttons for archived items
             const btnGroupArch = document.createElement('div');
             // Edit archived item: allows editing cost
@@ -919,12 +1641,17 @@
           });
         }
           // Dynamic budgets = base + carry
+          const fitness = ensureFitnessDefaults();
+          const currentMultiplier = clampMultiplier(fitness.currentMultiplier || 1);
+          const nextMultiplier = clampMultiplier(typeof fitness.nextMultiplier === 'number' ? fitness.nextMultiplier : currentMultiplier);
           const weeklyBaseBudget = data.groceryBudgetWeekly || 0;
           const monthlyBaseBudget = data.groceryBudgetMonthly || 0;
           const biBaseBudget = data.groceryBudgetBiYearly || 0;
-          const weeklyDynamicBudget = weeklyBaseBudget + (data.groceryBudgetWeeklyCarry || 0);
+          const weeklyBaseWithCarry = weeklyBaseBudget + (data.groceryBudgetWeeklyCarry || 0);
           const monthlyDynamicBudget = monthlyBaseBudget + (data.groceryBudgetMonthlyCarry || 0);
           const biDynamicBudget = biBaseBudget + (data.groceryBudgetBiYearlyCarry || 0);
+          const weeklyDynamicBudget = weeklyBaseWithCarry * currentMultiplier;
+          const nextWeekBudget = weeklyBaseWithCarry * nextMultiplier;
           // Time progress for budgets (fraction of period elapsed)
           const weekTimeProgress = (now - weekStart) / (weekEnd - weekStart);
           const monthTimeProgress = (now - monthStart) / (monthEnd - monthStart);
@@ -970,6 +1697,14 @@
             summaryCard.appendChild(pb);
           }
           addBudgetLine('Weekly', weeklySpent, weeklyDynamicBudget, weeklyExpectedSpent);
+          const multiplierLine = document.createElement('div');
+          multiplierLine.className = 'fitness-summary-sub';
+          multiplierLine.textContent = 'Fitness Multiplier next week: ' + nextMultiplier.toFixed(2) + '× (' + formatSignedCurrency(nextWeekBudget - weeklyBaseWithCarry) + ')';
+          summaryCard.appendChild(multiplierLine);
+          const creditsLine = document.createElement('div');
+          creditsLine.className = 'fitness-summary-sub';
+          creditsLine.textContent = 'Wellness Credits: ' + formatCurrency(fitness.wellnessCredits || 0, -1).replace(' kr', ' SEK') + ' (auto-applied)';
+          summaryCard.appendChild(creditsLine);
           addBudgetLine('Monthly', monthlySpent, monthlyDynamicBudget, monthlyExpectedSpent);
           addBudgetLine('Biannual', biannualSpent, biDynamicBudget, biExpectedSpent);
           // Add edit buttons for budgets and start date
@@ -1031,6 +1766,10 @@
           // purchase quotas, and buy buttons remain enabled regardless of
           // how many items have been purchased.
           // Render unarchived items
+          const boostEnabled = fitness.weekendBoostEnabled;
+          const boostActive = isWeekendBoostActive();
+          const boostUnlocked = fitness.weekendBoostUnlockedWeek === getWeekKey(new Date());
+          const boostPercentDisplay = Math.round((fitness.weekendBoostPercent || 0) * 100);
           groceries.forEach((item, index) => {
             if (item.archived) return;
             const li = document.createElement('li');
@@ -1047,6 +1786,19 @@
             const nameSpan = document.createElement('span');
             nameSpan.textContent = item.name;
             nameSpan.style.fontWeight = '600';
+            if (item.category === 'treat') {
+              const tag = document.createElement('span');
+              tag.className = 'treat-tag';
+              tag.textContent = 'Treat';
+              tag.style.marginLeft = '0.35rem';
+              nameSpan.appendChild(tag);
+            } else if (item.category === 'essential') {
+              const tag = document.createElement('span');
+              tag.className = 'treat-tag muted';
+              tag.textContent = 'Essential';
+              tag.style.marginLeft = '0.35rem';
+              nameSpan.appendChild(tag);
+            }
             row.appendChild(nameSpan);
             const btnGroup = document.createElement('div');
             // Buy button (log purchase with cost). In budget-only mode there is
@@ -1062,11 +1814,41 @@
               if (costStr === null) return;
               let costVal = parseFloat(costStr);
               if (isNaN(costVal)) costVal = 0;
+              const fitnessData = ensureFitnessDefaults();
+              let originalCost = costVal;
+              let creditsUsed = 0;
+              let boostCreditsUsed = 0;
+              let boostPercentApplied = 0;
+              if (item.frequency === 'weekly') {
+                const availableCredits = fitnessData.wellnessCredits || 0;
+                let remainingCredits = availableCredits;
+                if (fitnessData.weekendBoostEnabled && item.category === 'treat' && isWeekendBoostActive()) {
+                  const boostPct = Math.max(0, fitnessData.weekendBoostPercent || 0);
+                  if (boostPct > 0) {
+                    const discount = originalCost * boostPct;
+                    boostCreditsUsed = Math.min(discount, remainingCredits);
+                    creditsUsed += boostCreditsUsed;
+                    remainingCredits -= boostCreditsUsed;
+                    boostPercentApplied = boostPct;
+                  }
+                }
+                const additionalCredits = Math.min(remainingCredits, Math.max(0, originalCost - creditsUsed));
+                creditsUsed += additionalCredits;
+                fitnessData.wellnessCredits = Math.max(0, (fitnessData.wellnessCredits || 0) - creditsUsed);
+                costVal = Math.max(0, originalCost - creditsUsed);
+              }
+              item.originalCost = originalCost;
               item.cost = costVal;
+              item.appliedCredits = creditsUsed;
+              item.boostApplied = boostCreditsUsed > 0;
+              item.boostPercentApplied = boostPercentApplied;
               item.archived = true;
               item.purchasedDate = new Date().toISOString();
               saveData();
               updateGrocerySection();
+              if (typeof updateTodoSection === 'function') {
+                updateTodoSection();
+              }
               if (typeof provideHaptic === 'function') {
                 provideHaptic('beep');
               }
@@ -1086,6 +1868,13 @@
               if (newFreq !== null && (newFreq === 'weekly' || newFreq === 'monthly' || newFreq === 'biannual')) {
                 item.frequency = newFreq;
               }
+              const newCategory = prompt('Category (standard/treat/essential)', item.category || 'standard');
+              if (newCategory) {
+                const cleaned = newCategory.toLowerCase();
+                if (cleaned === 'standard' || cleaned === 'treat' || cleaned === 'essential') {
+                  item.category = cleaned;
+                }
+              }
               saveData();
               updateGrocerySection();
             });
@@ -1103,6 +1892,20 @@
             btnGroup.appendChild(delBtn);
             row.appendChild(btnGroup);
             li.appendChild(row);
+            if (item.category === 'treat') {
+              const note = document.createElement('div');
+              note.className = 'treat-note';
+              if (!boostEnabled) {
+                note.textContent = 'Treat item';
+              } else if (boostActive) {
+                note.textContent = 'Weekend Boost applied: −' + boostPercentDisplay + '% from credits';
+              } else if (boostUnlocked) {
+                note.textContent = 'Weekend Boost unlocked: +' + boostPercentDisplay + '% on Treats this weekend';
+              } else {
+                note.textContent = 'Treat item – unlock +' + boostPercentDisplay + '% by Friday 18:00';
+              }
+              li.appendChild(note);
+            }
             // Append to appropriate list
             if (item.frequency === 'monthly') {
               monthlyListEl.appendChild(li);
@@ -1112,6 +1915,7 @@
               weeklyListEl.appendChild(li);
             }
           });
+          updateFitnessCards();
         }
 
         // Reset grocery counts each Monday for weekly items and on the first day of the month for monthly items.

--- a/style.css
+++ b/style.css
@@ -163,6 +163,127 @@ body {
   z-index: 2;
 }
 
+.fitness-summary-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.35rem;
+  margin-bottom: 0.5rem;
+}
+.fitness-summary-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.5rem;
+  font-size: 0.8rem;
+  color: #475569;
+}
+.fitness-summary-row.muted {
+  font-size: 0.75rem;
+  color: #64748b;
+}
+.fitness-summary-label {
+  font-weight: 600;
+  color: #475569;
+}
+.fitness-summary-value {
+  font-weight: 600;
+  color: #0f172a;
+  text-align: right;
+}
+.fitness-summary-sub {
+  font-size: 0.75rem;
+  color: #475569;
+  margin: 0.25rem 0;
+}
+.fitness-pill-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin: 0.35rem 0;
+}
+.fitness-pill {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 9999px;
+  background: #e0e7ff;
+  color: #1e3a8a;
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.2rem 0.6rem;
+}
+.fitness-pill.muted {
+  background: #e2e8f0;
+  color: #475569;
+}
+.fitness-pill.warm {
+  background: #fef3c7;
+  color: #b45309;
+}
+.fitness-impact-line {
+  font-size: 0.72rem;
+  color: #2563eb;
+}
+.fitness-credit-line {
+  font-size: 0.72rem;
+  color: #0f766e;
+}
+.fitness-settings-grid {
+  display: grid;
+  gap: 0.5rem;
+}
+.fitness-setting-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.8rem;
+}
+.fitness-setting-row label {
+  flex: 1;
+  font-weight: 600;
+  color: #475569;
+}
+.fitness-setting-row input,
+.fitness-setting-row select {
+  flex: 1;
+  padding: 0.35rem 0.45rem;
+  border: 1px solid #cbd5e1;
+  border-radius: 0.375rem;
+  font-size: 0.8rem;
+}
+.treat-tag {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 9999px;
+  background: #fce7f3;
+  color: #be185d;
+  font-size: 0.65rem;
+  font-weight: 600;
+  padding: 0.15rem 0.4rem;
+}
+.treat-tag.muted {
+  background: #e2e8f0;
+  color: #475569;
+}
+.treat-note {
+  font-size: 0.7rem;
+  color: #7c3aed;
+  background: #ede9fe;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.375rem;
+}
+.treat-note.archived {
+  margin-top: 0.25rem;
+  color: #6b21a8;
+  background: #f5f3ff;
+}
+.switch-label {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  cursor: pointer;
+}
+
 /* Project status overview */
 .project-list {
   background-color: #ffffff;


### PR DESCRIPTION
## Summary
- add persisted fitness budget settings, weekly rollover scoring, and weekend boost tracking so workouts drive the discretionary multiplier and credits
- surface a workouts summary card with multiplier/credits projections plus per-workout budget impact messaging and settings controls
- extend budgeting to show next-week fitness adjustments, apply wellness credits on purchases, and highlight treat items with boost indicators

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cacc4cc220832d9893994c670615fe