### PR TITLE
Fix budget carryover calculation

### DIFF
--- a/index.html
+++ b/index.html
@@ -2159,27 +2159,34 @@ function loadData() {
           const lastWeekReset = localStorage.getItem('groceryWeeklyResetPro');
           if (lastWeekReset !== mondayStr) {
             // Determine the boundaries of last week [prevMonday, thisMonday)
-          const prevMonday = new Date(thisMonday.getTime() - 7 * 24 * 60 * 60 * 1000);
+            const prevMonday = new Date(thisMonday.getTime() - 7 * 24 * 60 * 60 * 1000);
             // Compute the total spent on weekly items in the previous week
             let weeklySpentPrev = 0;
             if (Array.isArray(data.groceries)) {
+              const legacyFallbackDate = new Date(thisMonday.getTime() - 1);
               data.groceries.forEach(item => {
-                if (item.archived && item.purchasedDate) {
+                if (!item || !item.archived || item.frequency !== 'weekly') return;
+                if (typeof item.cost !== 'number') return;
+                if (item.purchasedDate) {
                   const pd = new Date(item.purchasedDate);
                   // Accumulate spend on weekly items purchased last week
-                  if (item.frequency === 'weekly' && pd >= prevMonday && pd < thisMonday) {
-                    if (typeof item.cost === 'number') {
-                      weeklySpentPrev += item.cost;
-                    }
+                  if (pd >= prevMonday && pd < thisMonday) {
+                    weeklySpentPrev += item.cost;
                   }
+                } else {
+                  // Legacy purchases without a recorded purchase date should still be
+                  // counted once. Assign them to the previous period so they don't
+                  // permanently inflate the carry-over balance.
+                  item.purchasedDate = legacyFallbackDate.toISOString();
+                  weeklySpentPrev += item.cost;
                 }
               });
             }
-            // Update budget carry-over: newCarryBudget = oldCarryBudget + (dynamicBudgetPrev - spentPrev)
+            // Update budget carry-over to reflect the remaining budget from last week
             const baseBudget = typeof data.groceryBudgetWeekly === 'number' ? data.groceryBudgetWeekly : 0;
             const oldBudgetCarry = typeof data.groceryBudgetWeeklyCarry === 'number' ? data.groceryBudgetWeeklyCarry : 0;
             const dynamicPrevBudget = baseBudget + oldBudgetCarry;
-            data.groceryBudgetWeeklyCarry = oldBudgetCarry + (dynamicPrevBudget - weeklySpentPrev);
+            data.groceryBudgetWeeklyCarry = dynamicPrevBudget - weeklySpentPrev;
             // Persist the reset date
             localStorage.setItem('groceryWeeklyResetPro', mondayStr);
             saveData();
@@ -2200,15 +2207,22 @@ function loadData() {
             // We no longer track purchase counts for item quotas
             let biSpentPrev = 0;
             if (Array.isArray(data.groceries)) {
+              const legacyFallbackDate = new Date(thisMonthStart.getTime() - 1);
               data.groceries.forEach(item => {
-                if (item.archived && item.purchasedDate) {
+                if (!item || !item.archived || item.frequency !== 'monthly') return;
+                if (typeof item.cost !== 'number') return;
+                if (item.purchasedDate) {
                   const pd = new Date(item.purchasedDate);
                   // Monthly
-                  if (item.frequency === 'monthly' && pd >= prevMonthStart && pd < prevMonthEnd) {
-                    if (typeof item.cost === 'number') {
-                      monthlySpentPrev += item.cost;
-                    }
+                  if (pd >= prevMonthStart && pd < prevMonthEnd) {
+                    monthlySpentPrev += item.cost;
                   }
+                } else {
+                  // Legacy monthly purchases without a stored date should be
+                  // attributed to the most recent completed month so the carry
+                  // can be corrected.
+                  item.purchasedDate = legacyFallbackDate.toISOString();
+                  monthlySpentPrev += item.cost;
                 }
               });
             }
@@ -2216,7 +2230,7 @@ function loadData() {
             const baseBudgetM = typeof data.groceryBudgetMonthly === 'number' ? data.groceryBudgetMonthly : 0;
             const oldBudgetCarryM = typeof data.groceryBudgetMonthlyCarry === 'number' ? data.groceryBudgetMonthlyCarry : 0;
             const dynamicPrevBudgetM = baseBudgetM + oldBudgetCarryM;
-            data.groceryBudgetMonthlyCarry = oldBudgetCarryM + (dynamicPrevBudgetM - monthlySpentPrev);
+            data.groceryBudgetMonthlyCarry = dynamicPrevBudgetM - monthlySpentPrev;
             // Now handle biannual resets at month boundary too if half year changed
             // Determine start date and current half boundaries
             const nowDate = new Date();
@@ -2239,14 +2253,20 @@ function loadData() {
               // Compute total spent on biannual items in the previous half-year
               let biSpentPrevTotal = 0;
               if (Array.isArray(data.groceries)) {
+                const legacyFallbackDate = new Date(prevHalfEnd.getTime() - 1);
                 data.groceries.forEach(item => {
-                  if (item.frequency === 'biannual' && item.archived && item.purchasedDate) {
+                  if (!item || item.frequency !== 'biannual' || !item.archived) return;
+                  if (typeof item.cost !== 'number') return;
+                  if (item.purchasedDate) {
                     const pd = new Date(item.purchasedDate);
                     if (pd >= prevHalfStart && pd < prevHalfEnd) {
-                      if (typeof item.cost === 'number') {
-                        biSpentPrevTotal += item.cost;
-                      }
+                      biSpentPrevTotal += item.cost;
                     }
+                  } else {
+                    // Apply the same fallback for legacy biannual purchases so
+                    // they reduce the carry exactly once.
+                    item.purchasedDate = legacyFallbackDate.toISOString();
+                    biSpentPrevTotal += item.cost;
                   }
                 });
               }
@@ -2254,7 +2274,7 @@ function loadData() {
               const baseBudgetBi = typeof data.groceryBudgetBiYearly === 'number' ? data.groceryBudgetBiYearly : 0;
               const oldBudgetCarryBi = typeof data.groceryBudgetBiYearlyCarry === 'number' ? data.groceryBudgetBiYearlyCarry : 0;
               const dynamicPrevBudgetBi = baseBudgetBi + oldBudgetCarryBi;
-              data.groceryBudgetBiYearlyCarry = oldBudgetCarryBi + (dynamicPrevBudgetBi - biSpentPrevTotal);
+              data.groceryBudgetBiYearlyCarry = dynamicPrevBudgetBi - biSpentPrevTotal;
               // Persist half-year reset
               localStorage.setItem('groceryBiResetPro', halfKey);
             }


### PR DESCRIPTION
## Summary
- ensure weekly, monthly, and biannual budget carry-overs subtract the amount spent from the prior period instead of double-counting the previous carry
- clarify the weekly carry-over comment to describe the new behaviour
- treat legacy grocery purchases missing a purchase date as occurring in the last completed period so they are counted once when computing carry-over

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d132efe03c832da49dead4976b1ac6