### PR TITLE
Recalculate grocery carryovers idempotently

### DIFF
--- a/index.html
+++ b/index.html
@@ -642,6 +642,9 @@ function loadData() {
       groceryBudgetWeeklyCarry: 0,
       groceryBudgetMonthlyCarry: 0,
       groceryBudgetBiYearlyCarry: 0,
+      groceryBudgetWeeklyCarryBaseline: 0,
+      groceryBudgetMonthlyCarryBaseline: 0,
+      groceryBudgetBiYearlyCarryBaseline: 0,
       groceryBudgetStartDate: null,
       backupDirName: null,
       lastBackupAt: null,
@@ -664,10 +667,28 @@ function loadData() {
         // Migrate legacy properties to new structure. Each item should have a name and frequency.
         if (!g.name) g.name = '';
         if (!g.frequency) g.frequency = 'weekly';
+        if (typeof g.frequency === 'string') {
+          const freq = g.frequency.toLowerCase();
+          if (freq === 'weekly' || freq === 'monthly' || freq === 'biannual') {
+            g.frequency = freq;
+          } else {
+            g.frequency = 'weekly';
+          }
+        } else {
+          g.frequency = 'weekly';
+        }
         // In the new structure, we track whether an item has been archived and when it was purchased. Default false/null.
         if (g.archived === undefined) g.archived = false;
         if (g.purchasedDate === undefined) g.purchasedDate = null;
         if (!g.category) g.category = 'standard';
+        if (typeof g.cost === 'string') {
+          const parsedCost = parseFloat(g.cost);
+          if (!isNaN(parsedCost)) g.cost = parsedCost;
+        }
+        if (typeof g.originalCost === 'string') {
+          const parsedOriginal = parseFloat(g.originalCost);
+          if (!isNaN(parsedOriginal)) g.originalCost = parsedOriginal;
+        }
         if (g.originalCost === undefined && typeof g.cost === 'number') g.originalCost = g.cost;
         if (g.appliedCredits === undefined) g.appliedCredits = 0;
         if (g.boostApplied === undefined) g.boostApplied = false;
@@ -685,6 +706,15 @@ function loadData() {
       groceryBudgetWeeklyCarry: typeof parsed.groceryBudgetWeeklyCarry === 'number' ? parsed.groceryBudgetWeeklyCarry : 0,
       groceryBudgetMonthlyCarry: typeof parsed.groceryBudgetMonthlyCarry === 'number' ? parsed.groceryBudgetMonthlyCarry : 0,
       groceryBudgetBiYearlyCarry: typeof parsed.groceryBudgetBiYearlyCarry === 'number' ? parsed.groceryBudgetBiYearlyCarry : 0,
+      groceryBudgetWeeklyCarryBaseline: typeof parsed.groceryBudgetWeeklyCarryBaseline === 'number'
+        ? parsed.groceryBudgetWeeklyCarryBaseline
+        : (typeof parsed.groceryBudgetWeeklyCarry === 'number' ? parsed.groceryBudgetWeeklyCarry : 0),
+      groceryBudgetMonthlyCarryBaseline: typeof parsed.groceryBudgetMonthlyCarryBaseline === 'number'
+        ? parsed.groceryBudgetMonthlyCarryBaseline
+        : (typeof parsed.groceryBudgetMonthlyCarry === 'number' ? parsed.groceryBudgetMonthlyCarry : 0),
+      groceryBudgetBiYearlyCarryBaseline: typeof parsed.groceryBudgetBiYearlyCarryBaseline === 'number'
+        ? parsed.groceryBudgetBiYearlyCarryBaseline
+        : (typeof parsed.groceryBudgetBiYearlyCarry === 'number' ? parsed.groceryBudgetBiYearlyCarry : 0),
       // Start date for budgeting periods (YYYY-MM-DD); defaults to null to use current date on first run
       groceryBudgetStartDate: parsed.groceryBudgetStartDate || null,
       // Preserve additional persisted properties like backupDirName if present in saved data
@@ -704,6 +734,9 @@ function loadData() {
       groceryBudgetWeeklyCarry: 0,
       groceryBudgetMonthlyCarry: 0,
       groceryBudgetBiYearlyCarry: 0,
+      groceryBudgetWeeklyCarryBaseline: 0,
+      groceryBudgetMonthlyCarryBaseline: 0,
+      groceryBudgetBiYearlyCarryBaseline: 0,
       groceryBudgetStartDate: null,
       backupDirName: null,
       lastBackupAt: null,
@@ -1697,8 +1730,7 @@ function loadData() {
         // navigation between sections.
         updateTodoSection();
 
-        // Perform grocery resets and render groceries list on load
-        resetGroceriesIfNeeded();
+        // Render groceries list on load (reset is triggered within the renderer)
         updateGrocerySection();
 
         // -------------------------------------------------------------------------
@@ -1715,6 +1747,7 @@ function loadData() {
         //  to zero).
 
         function updateGrocerySection() {
+          resetGroceriesIfNeeded();
           const weeklyListEl = document.getElementById('weeklyGroceryList');
           const monthlyListEl = document.getElementById('monthlyGroceryList');
           const biannualListEl = document.getElementById('biannualGroceryList');
@@ -1726,6 +1759,7 @@ function loadData() {
           biannualListEl.innerHTML = '';
           summaryContainer.innerHTML = '';
           const groceries = Array.isArray(data.groceries) ? data.groceries : [];
+          let normalizedAny = false;
           // Determine period boundaries for weekly, monthly and biannual budgets
           const now = new Date();
           // Weekly boundaries (Monday to next Monday) for spending
@@ -1767,17 +1801,24 @@ function loadData() {
           let monthlySpent = 0;
           let biannualSpent = 0;
           groceries.forEach(it => {
-            if (it.archived && it.purchasedDate && typeof it.cost === 'number') {
-              const pd = new Date(it.purchasedDate);
-              if (it.frequency === 'weekly' && pd >= weekStart && pd < weekEnd) {
-                weeklySpent += it.cost;
-              }
-              if (it.frequency === 'monthly' && pd >= monthStart && pd < monthEnd) {
-                monthlySpent += it.cost;
-              }
-              if (it.frequency === 'biannual' && pd >= halfStart && pd < halfEnd) {
-                biannualSpent += it.cost;
-              }
+            if (!it || !it.archived || !it.purchasedDate) return;
+            const cost = Number(it.cost);
+            if (!Number.isFinite(cost)) return;
+            const freq = typeof it.frequency === 'string' ? it.frequency.toLowerCase() : 'weekly';
+            if (it.frequency !== freq) {
+              it.frequency = freq;
+              normalizedAny = true;
+            }
+            const pd = new Date(it.purchasedDate);
+            if (isNaN(pd)) return;
+            if (freq === 'weekly' && pd >= weekStart && pd < weekEnd) {
+              weeklySpent += cost;
+            }
+            if (freq === 'monthly' && pd >= monthStart && pd < monthEnd) {
+              monthlySpent += cost;
+            }
+            if (freq === 'biannual' && pd >= halfStart && pd < halfEnd) {
+              biannualSpent += cost;
             }
           });
 
@@ -1802,21 +1843,30 @@ function loadData() {
             // Details span: name – cost – frequency – purchase date
             const detailsSpan = document.createElement('span');
             let dateStr = '';
+            const freq = typeof archItem.frequency === 'string' ? archItem.frequency.toLowerCase() : 'weekly';
+            if (archItem.frequency !== freq) {
+              archItem.frequency = freq;
+              normalizedAny = true;
+            }
             if (archItem.purchasedDate) {
               const dt = new Date(archItem.purchasedDate);
               dateStr = dt.toLocaleDateString();
             }
-            const costString = typeof archItem.cost === 'number' ? formatCurrency(archItem.cost, -1).replace(' kr', ' SEK') : '0 SEK';
+            const costNum = Number(archItem.cost);
+            const costString = Number.isFinite(costNum) ? formatCurrency(costNum, -1).replace(' kr', ' SEK') : '0 SEK';
             const parts = [`${archItem.name}`, costString];
-            if (typeof archItem.originalCost === 'number' && archItem.originalCost !== archItem.cost) {
-              const originalString = formatCurrency(archItem.originalCost, -1).replace(' kr', ' SEK');
+            const originalCostNum = Number(archItem.originalCost);
+            if (Number.isFinite(originalCostNum) && originalCostNum !== costNum) {
+              const originalString = formatCurrency(originalCostNum, -1).replace(' kr', ' SEK');
               let creditNote = `original ${originalString}`;
-              if (typeof archItem.appliedCredits === 'number' && archItem.appliedCredits > 0) {
-                creditNote += `, credits −${formatCurrency(archItem.appliedCredits, -1).replace(' kr', ' SEK')}`;
+              const appliedCreditsNum = Number(archItem.appliedCredits);
+              if (Number.isFinite(appliedCreditsNum) && appliedCreditsNum > 0) {
+                creditNote += `, credits −${formatCurrency(appliedCreditsNum, -1).replace(' kr', ' SEK')}`;
               }
               parts.push(creditNote);
             }
-            parts.push(archItem.frequency);
+            const freqLabel = freq.charAt(0).toUpperCase() + freq.slice(1);
+            parts.push(freqLabel);
             if (dateStr) parts.push(dateStr);
             detailsSpan.textContent = parts.join(' – ');
             rowArch.appendChild(detailsSpan);
@@ -1999,6 +2049,11 @@ function loadData() {
           const boostPercentDisplay = Math.round((fitness.weekendBoostPercent || 0) * 100);
           groceries.forEach((item, index) => {
             if (item.archived) return;
+            const freq = typeof item.frequency === 'string' ? item.frequency.toLowerCase() : 'weekly';
+            if (item.frequency !== freq) {
+              item.frequency = freq;
+              normalizedAny = true;
+            }
             const li = document.createElement('li');
             li.style.display = 'flex';
             li.style.flexDirection = 'column';
@@ -2046,7 +2101,8 @@ function loadData() {
               let creditsUsed = 0;
               let boostCreditsUsed = 0;
               let boostPercentApplied = 0;
-              if (item.frequency === 'weekly') {
+              const itemFrequency = typeof item.frequency === 'string' ? item.frequency.toLowerCase() : 'weekly';
+              if (itemFrequency === 'weekly') {
                 const availableCredits = fitnessData.wellnessCredits || 0;
                 let remainingCredits = availableCredits;
                 if (fitnessData.weekendBoostEnabled && item.category === 'treat' && isWeekendBoostActive()) {
@@ -2092,8 +2148,11 @@ function loadData() {
                 item.name = newName.trim();
               }
               const newFreq = prompt('Frequency (weekly/monthly/biannual)', item.frequency);
-              if (newFreq !== null && (newFreq === 'weekly' || newFreq === 'monthly' || newFreq === 'biannual')) {
-                item.frequency = newFreq;
+              if (newFreq !== null) {
+                const cleanedFreq = newFreq.trim().toLowerCase();
+                if (cleanedFreq === 'weekly' || cleanedFreq === 'monthly' || cleanedFreq === 'biannual') {
+                  item.frequency = cleanedFreq;
+                }
               }
               const newCategory = prompt('Category (standard/treat/essential)', item.category || 'standard');
               if (newCategory) {
@@ -2134,132 +2193,169 @@ function loadData() {
               li.appendChild(note);
             }
             // Append to appropriate list
-            if (item.frequency === 'monthly') {
+            if (freq === 'monthly') {
               monthlyListEl.appendChild(li);
-            } else if (item.frequency === 'biannual') {
+            } else if (freq === 'biannual') {
               biannualListEl.appendChild(li);
             } else {
               weeklyListEl.appendChild(li);
             }
           });
           updateFitnessCards();
+          if (normalizedAny) {
+            saveData();
+          }
         }
 
-        // Reset grocery counts each Monday for weekly items and on the first day of the month for monthly items.
-        // Carry over undershoots and overshoots into the next period via the carryOver property.
+        // Reset grocery budgets for weekly, monthly, and biannual periods. Carry-overs are recalculated
+        // whenever we cross a boundary or when archived purchases are edited retroactively.
         function resetGroceriesIfNeeded() {
           const now = new Date();
+          let dataChanged = false;
           // Determine the start of this week (Monday at 00:00)
           const dow = now.getDay();
           const diffToMonday = (dow + 6) % 7;
           const thisMonday = new Date(now.getFullYear(), now.getMonth(), now.getDate() - diffToMonday);
           thisMonday.setHours(0, 0, 0, 0);
           const mondayStr = thisMonday.toDateString();
-          // If weekly reset hasn't been done for this Monday, calculate carryover based on last week's purchases
-          const lastWeekReset = localStorage.getItem('groceryWeeklyResetPro');
-          if (lastWeekReset !== mondayStr) {
-            // Determine the boundaries of last week [prevMonday, thisMonday)
           const prevMonday = new Date(thisMonday.getTime() - 7 * 24 * 60 * 60 * 1000);
-            // Compute the total spent on weekly items in the previous week
-            let weeklySpentPrev = 0;
-            if (Array.isArray(data.groceries)) {
-              data.groceries.forEach(item => {
-                if (item.archived && item.purchasedDate) {
-                  const pd = new Date(item.purchasedDate);
-                  // Accumulate spend on weekly items purchased last week
-                  if (item.frequency === 'weekly' && pd >= prevMonday && pd < thisMonday) {
-                    if (typeof item.cost === 'number') {
-                      weeklySpentPrev += item.cost;
-                    }
-                  }
+          const lastWeekReset = localStorage.getItem('groceryWeeklyResetPro');
+          let weeklySpentPrev = 0;
+          if (Array.isArray(data.groceries)) {
+            const legacyFallbackDate = new Date(thisMonday.getTime() - 1);
+            data.groceries.forEach(item => {
+              if (!item || !item.archived) return;
+              const freq = typeof item.frequency === 'string' ? item.frequency.toLowerCase() : 'weekly';
+              if (item.frequency !== freq) item.frequency = freq;
+              if (freq !== 'weekly') return;
+              const cost = Number(item.cost);
+              if (!Number.isFinite(cost)) return;
+              if (item.purchasedDate) {
+                const pd = new Date(item.purchasedDate);
+                if (pd >= prevMonday && pd < thisMonday) {
+                  weeklySpentPrev += cost;
                 }
-              });
-            }
-            // Update budget carry-over: newCarryBudget = oldCarryBudget + (dynamicBudgetPrev - spentPrev)
-            const baseBudget = typeof data.groceryBudgetWeekly === 'number' ? data.groceryBudgetWeekly : 0;
-            const oldBudgetCarry = typeof data.groceryBudgetWeeklyCarry === 'number' ? data.groceryBudgetWeeklyCarry : 0;
-            const dynamicPrevBudget = baseBudget + oldBudgetCarry;
-            data.groceryBudgetWeeklyCarry = oldBudgetCarry + (dynamicPrevBudget - weeklySpentPrev);
-            // Persist the reset date
-            localStorage.setItem('groceryWeeklyResetPro', mondayStr);
-            saveData();
+              } else {
+                // Legacy purchases without a recorded purchase date should still be counted once.
+                item.purchasedDate = legacyFallbackDate.toISOString();
+                weeklySpentPrev += cost;
+                dataChanged = true;
+              }
+            });
           }
-          // Monthly reset: if first day of the month hasn't been reset yet
+          const baseBudget = typeof data.groceryBudgetWeekly === 'number' ? data.groceryBudgetWeekly : 0;
+          const storedCarry = typeof data.groceryBudgetWeeklyCarry === 'number' ? data.groceryBudgetWeeklyCarry : 0;
+          const baselineCarry = lastWeekReset === mondayStr && typeof data.groceryBudgetWeeklyCarryBaseline === 'number'
+            ? data.groceryBudgetWeeklyCarryBaseline
+            : storedCarry;
+          const dynamicPrevBudget = baseBudget + baselineCarry;
+          const newWeeklyCarry = dynamicPrevBudget - weeklySpentPrev;
+          if (lastWeekReset !== mondayStr ||
+              data.groceryBudgetWeeklyCarry !== newWeeklyCarry ||
+              data.groceryBudgetWeeklyCarryBaseline !== baselineCarry) {
+            data.groceryBudgetWeeklyCarry = newWeeklyCarry;
+            data.groceryBudgetWeeklyCarryBaseline = baselineCarry;
+            localStorage.setItem('groceryWeeklyResetPro', mondayStr);
+            dataChanged = true;
+          }
+          // Monthly carry-over recalculation
           const year = now.getFullYear();
           const month = now.getMonth();
           const thisMonthStart = new Date(year, month, 1);
           thisMonthStart.setHours(0, 0, 0, 0);
           const monthKey = year + '-' + month;
           const lastMonthReset = localStorage.getItem('groceryMonthlyResetPro');
-          if (lastMonthReset !== monthKey) {
-            // Determine previous month boundaries [prevMonthStart, thisMonthStart)
-            const prevMonthStart = new Date(year, month - 1, 1);
-            const prevMonthEnd = new Date(year, month, 1);
-            // Compute total spent on monthly items in the previous month
-            let monthlySpentPrev = 0;
-            // We no longer track purchase counts for item quotas
-            let biSpentPrev = 0;
-            if (Array.isArray(data.groceries)) {
-              data.groceries.forEach(item => {
-                if (item.archived && item.purchasedDate) {
-                  const pd = new Date(item.purchasedDate);
-                  // Monthly
-                  if (item.frequency === 'monthly' && pd >= prevMonthStart && pd < prevMonthEnd) {
-                    if (typeof item.cost === 'number') {
-                      monthlySpentPrev += item.cost;
-                    }
-                  }
+          const prevMonthStart = new Date(year, month - 1, 1);
+          const prevMonthEnd = new Date(year, month, 1);
+          let monthlySpentPrev = 0;
+          if (Array.isArray(data.groceries)) {
+            const legacyFallbackDate = new Date(thisMonthStart.getTime() - 1);
+            data.groceries.forEach(item => {
+              if (!item || !item.archived) return;
+              const freq = typeof item.frequency === 'string' ? item.frequency.toLowerCase() : 'weekly';
+              if (item.frequency !== freq) item.frequency = freq;
+              if (freq !== 'monthly') return;
+              const cost = Number(item.cost);
+              if (!Number.isFinite(cost)) return;
+              if (item.purchasedDate) {
+                const pd = new Date(item.purchasedDate);
+                if (pd >= prevMonthStart && pd < prevMonthEnd) {
+                  monthlySpentPrev += cost;
                 }
-              });
-            }
-            // Update monthly budget carry-over
-            const baseBudgetM = typeof data.groceryBudgetMonthly === 'number' ? data.groceryBudgetMonthly : 0;
-            const oldBudgetCarryM = typeof data.groceryBudgetMonthlyCarry === 'number' ? data.groceryBudgetMonthlyCarry : 0;
-            const dynamicPrevBudgetM = baseBudgetM + oldBudgetCarryM;
-            data.groceryBudgetMonthlyCarry = oldBudgetCarryM + (dynamicPrevBudgetM - monthlySpentPrev);
-            // Now handle biannual resets at month boundary too if half year changed
-            // Determine start date and current half boundaries
-            const nowDate = new Date();
-            let startDate;
-            if (data.groceryBudgetStartDate) {
-              startDate = new Date(data.groceryBudgetStartDate);
-            } else {
-              startDate = new Date(nowDate.getFullYear(), nowDate.getMonth(), 1);
-            }
-            startDate.setHours(0, 0, 0, 0);
-            const monthsDiff = (nowDate.getFullYear() - startDate.getFullYear()) * 12 + (nowDate.getMonth() - startDate.getMonth());
-            const currentHalfIndex = Math.floor(monthsDiff / 6);
-            // Determine if we have moved to a new half-year since last reset
-            const lastHalfReset = localStorage.getItem('groceryBiResetPro');
-            const halfKey = String(currentHalfIndex);
-            if (lastHalfReset !== halfKey) {
-              // Determine previous half boundaries
-              const prevHalfStart = new Date(startDate.getFullYear(), startDate.getMonth() + (currentHalfIndex - 1) * 6, startDate.getDate());
-              const prevHalfEnd = new Date(startDate.getFullYear(), startDate.getMonth() + currentHalfIndex * 6, startDate.getDate());
-              // Compute total spent on biannual items in the previous half-year
-              let biSpentPrevTotal = 0;
-              if (Array.isArray(data.groceries)) {
-                data.groceries.forEach(item => {
-                  if (item.frequency === 'biannual' && item.archived && item.purchasedDate) {
-                    const pd = new Date(item.purchasedDate);
-                    if (pd >= prevHalfStart && pd < prevHalfEnd) {
-                      if (typeof item.cost === 'number') {
-                        biSpentPrevTotal += item.cost;
-                      }
-                    }
-                  }
-                });
+              } else {
+                item.purchasedDate = legacyFallbackDate.toISOString();
+                monthlySpentPrev += cost;
+                dataChanged = true;
               }
-              // Update biannual budget carry-over
-              const baseBudgetBi = typeof data.groceryBudgetBiYearly === 'number' ? data.groceryBudgetBiYearly : 0;
-              const oldBudgetCarryBi = typeof data.groceryBudgetBiYearlyCarry === 'number' ? data.groceryBudgetBiYearlyCarry : 0;
-              const dynamicPrevBudgetBi = baseBudgetBi + oldBudgetCarryBi;
-              data.groceryBudgetBiYearlyCarry = oldBudgetCarryBi + (dynamicPrevBudgetBi - biSpentPrevTotal);
-              // Persist half-year reset
-              localStorage.setItem('groceryBiResetPro', halfKey);
-            }
-            // Persist monthly reset
+            });
+          }
+          const baseBudgetM = typeof data.groceryBudgetMonthly === 'number' ? data.groceryBudgetMonthly : 0;
+          const storedCarryM = typeof data.groceryBudgetMonthlyCarry === 'number' ? data.groceryBudgetMonthlyCarry : 0;
+          const baselineCarryM = lastMonthReset === monthKey && typeof data.groceryBudgetMonthlyCarryBaseline === 'number'
+            ? data.groceryBudgetMonthlyCarryBaseline
+            : storedCarryM;
+          const dynamicPrevBudgetM = baseBudgetM + baselineCarryM;
+          const newMonthlyCarry = dynamicPrevBudgetM - monthlySpentPrev;
+          if (lastMonthReset !== monthKey ||
+              data.groceryBudgetMonthlyCarry !== newMonthlyCarry ||
+              data.groceryBudgetMonthlyCarryBaseline !== baselineCarryM) {
+            data.groceryBudgetMonthlyCarry = newMonthlyCarry;
+            data.groceryBudgetMonthlyCarryBaseline = baselineCarryM;
             localStorage.setItem('groceryMonthlyResetPro', monthKey);
+            dataChanged = true;
+          }
+          // Biannual carry-over recalculation
+          let startDate;
+          if (data.groceryBudgetStartDate) {
+            startDate = new Date(data.groceryBudgetStartDate);
+          } else {
+            startDate = new Date(now.getFullYear(), now.getMonth(), 1);
+          }
+          startDate.setHours(0, 0, 0, 0);
+          const monthsDiff = (now.getFullYear() - startDate.getFullYear()) * 12 + (now.getMonth() - startDate.getMonth());
+          const currentHalfIndex = Math.floor(monthsDiff / 6);
+          const lastHalfReset = localStorage.getItem('groceryBiResetPro');
+          const halfKey = String(currentHalfIndex);
+          const prevHalfStart = new Date(startDate.getFullYear(), startDate.getMonth() + (currentHalfIndex - 1) * 6, startDate.getDate());
+          const prevHalfEnd = new Date(startDate.getFullYear(), startDate.getMonth() + currentHalfIndex * 6, startDate.getDate());
+          let biSpentPrevTotal = 0;
+          if (Array.isArray(data.groceries)) {
+            const legacyFallbackDate = new Date(prevHalfEnd.getTime() - 1);
+            data.groceries.forEach(item => {
+              if (!item || !item.archived) return;
+              const freq = typeof item.frequency === 'string' ? item.frequency.toLowerCase() : 'weekly';
+              if (item.frequency !== freq) item.frequency = freq;
+              if (freq !== 'biannual') return;
+              const cost = Number(item.cost);
+              if (!Number.isFinite(cost)) return;
+              if (item.purchasedDate) {
+                const pd = new Date(item.purchasedDate);
+                if (pd >= prevHalfStart && pd < prevHalfEnd) {
+                  biSpentPrevTotal += cost;
+                }
+              } else {
+                item.purchasedDate = legacyFallbackDate.toISOString();
+                biSpentPrevTotal += cost;
+                dataChanged = true;
+              }
+            });
+          }
+          const baseBudgetBi = typeof data.groceryBudgetBiYearly === 'number' ? data.groceryBudgetBiYearly : 0;
+          const storedCarryBi = typeof data.groceryBudgetBiYearlyCarry === 'number' ? data.groceryBudgetBiYearlyCarry : 0;
+          const baselineCarryBi = lastHalfReset === halfKey && typeof data.groceryBudgetBiYearlyCarryBaseline === 'number'
+            ? data.groceryBudgetBiYearlyCarryBaseline
+            : storedCarryBi;
+          const dynamicPrevBudgetBi = baseBudgetBi + baselineCarryBi;
+          const newBiCarry = dynamicPrevBudgetBi - biSpentPrevTotal;
+          if (lastHalfReset !== halfKey ||
+              data.groceryBudgetBiYearlyCarry !== newBiCarry ||
+              data.groceryBudgetBiYearlyCarryBaseline !== baselineCarryBi) {
+            data.groceryBudgetBiYearlyCarry = newBiCarry;
+            data.groceryBudgetBiYearlyCarryBaseline = baselineCarryBi;
+            localStorage.setItem('groceryBiResetPro', halfKey);
+            dataChanged = true;
+          }
+          if (dataChanged) {
             saveData();
           }
         }


### PR DESCRIPTION
## Summary
- add baseline carry fields to persisted grocery budget data so resets can recover the prior period balance
- recompute weekly, monthly, and biannual grocery carry-overs idempotently using the stored baselines and normalize missing purchase dates
- trigger grocery resets from the renderer so carry-over values stay in sync after edits

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d132efe03c832da49dead4976b1ac6