### PR TITLE
Handle legacy budget start date strings

### DIFF
--- a/index.html
+++ b/index.html
@@ -2891,12 +2891,10 @@ function loadData() {
             const year = Number(match[1]);
             const month = Number(match[2]);
             const day = Number(match[3]);
-            if (Number.isFinite(year) && Number.isFinite(month) && Number.isFinite(day)) {
-              const date = new Date(year, month - 1, day);
-              if (date.getFullYear() === year && date.getMonth() === month - 1 && date.getDate() === day) {
-                date.setHours(0, 0, 0, 0);
-                return date;
-              }
+            const date = new Date(year, month - 1, day);
+            if (date.getFullYear() === year && date.getMonth() === month - 1 && date.getDate() === day) {
+              date.setHours(0, 0, 0, 0);
+              return date;
             }
           }
           // Fall back to Date parsing for any other legacy formats, normalizing


### PR DESCRIPTION
## Summary
- extend the budget start date parser to accept ISO timestamp strings saved by older builds
- fall back to native Date parsing so legacy values do not reset to the current month

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d18ee0e324832da30756d96c3ca0e4