### PR TITLE
Persist workout pause state across sessions

### DIFF
--- a/index.html
+++ b/index.html
@@ -486,10 +486,15 @@
         function setWeekPaused(weekKey, paused) {
           const fitness = ensureFitnessDefaults();
           if (!fitness.pausedWeeks) fitness.pausedWeeks = {};
+          const wasPaused = !!fitness.pausedWeeks[weekKey];
           if (paused) {
-            fitness.pausedWeeks[weekKey] = true;
-          } else {
+            if (!wasPaused) {
+              fitness.pausedWeeks[weekKey] = true;
+              saveData();
+            }
+          } else if (wasPaused) {
             delete fitness.pausedWeeks[weekKey];
+            saveData();
           }
         }
         function finalizeFitnessWeek(weeklyStats, lastMonday, thisMonday) {


### PR DESCRIPTION
## Summary
- ensure toggling the workout pause flag immediately saves the updated fitness state
- avoid unintentionally applying penalties to weeks that were paused

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68da401a37c8832da7a38831ff340314