### PR TITLE
Improve workout summary layout and rendering performance

### DIFF
--- a/index.html
+++ b/index.html
@@ -2324,9 +2324,9 @@ function loadData() {
               weeklyFragment.appendChild(li);
             }
           });
-          weeklyListEl.replaceChildren(weeklyFragment);
-          monthlyListEl.replaceChildren(monthlyFragment);
-          biannualListEl.replaceChildren(biannualFragment);
+          weeklyListEl.replaceChildren(...weeklyFragment.childNodes);
+          monthlyListEl.replaceChildren(...monthlyFragment.childNodes);
+          biannualListEl.replaceChildren(...biannualFragment.childNodes);
           updateFitnessCards();
           if (normalizedAny) {
             saveData();


### PR DESCRIPTION
## Summary
- move the fitness & budget summary card beneath the weekly workout list so it appears just before the settings panel
- reorder the dashboard cards so Workout Progress follows the monthly stats instead of sitting between weekly and monthly progress
- batch the workout and budget summary renders with requestAnimationFrame and replaceChildren to reduce the slow loading behaviour

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da99e16ab0832dba356b22a9635ec2