### PR TITLE
Add custom workout intensity entry option

### DIFF
--- a/index.html
+++ b/index.html
@@ -204,11 +204,20 @@
               <option value="intense">Intense</option>
               <option value="medium" selected>Medium</option>
               <option value="light">Light</option>
+              <option value="custom">Custom</option>
             </select>
+            <input
+              id="todoCustomIntensity"
+              type="number"
+              min="0"
+              step="0.1"
+              placeholder="Points"
+              style="width:7rem; padding:0.5rem; border:1px solid #cbd5e1; border-radius:0.375rem; display:none;"
+            />
             <input id="todoWhen" type="datetime-local" style="width:13rem; padding:0.5rem; border:1px solid #cbd5e1; border-radius:0.375rem;" />
             <button type="submit" class="btn primary">Log</button>
           </form>
-          <p style="margin:0.75rem 0 0; font-size:0.85rem; color:#475569;">New combinations of workout name and intensity are saved as presets for quick access.</p>
+          <p style="margin:0.75rem 0 0; font-size:0.85rem; color:#475569;">New combinations of workout name and intensity are saved as presets for quick access. Choose <strong>Custom</strong> to log workouts with your own point value.</p>
         </div>
         <div class="card" id="workoutPresetsCard" style="margin-bottom:1rem;">
           <h3 style="margin:0 0 0.5rem 0; font-size:1.1rem; font-weight:600;">Presets</h3>
@@ -447,10 +456,40 @@
           const dt = new Date(str + 'T00:00:00');
           return isNaN(dt.getTime()) ? null : dt;
         }
+        function sanitizeCustomPoints(value) {
+          const num = typeof value === 'number' ? value : parseFloat(value);
+          if (!Number.isFinite(num) || num <= 0) return null;
+          return Math.round(num * 100) / 100;
+        }
+        function formatCustomIntensityValue(value) {
+          if (!Number.isFinite(value)) return '';
+          const fixed = value.toFixed(2);
+          return fixed.replace(/\.00$/, '').replace(/(\.\d*?)0+$/, '$1');
+        }
+        function makeCustomIntensity(points) {
+          const sanitized = sanitizeCustomPoints(points);
+          if (sanitized === null) return 'medium';
+          return `custom:${formatCustomIntensityValue(sanitized)}`;
+        }
+        function parseCustomIntensity(intensity) {
+          if (typeof intensity !== 'string') return null;
+          const trimmed = intensity.trim();
+          const match = trimmed.match(/^custom:\s*([-+]?\d+(?:\.\d+)?)$/i);
+          if (!match) return null;
+          const parsed = sanitizeCustomPoints(parseFloat(match[1]));
+          return parsed === null ? null : parsed;
+        }
+        function isCustomIntensity(intensity) {
+          if (typeof intensity !== 'string') return false;
+          return parseCustomIntensity(intensity) !== null;
+        }
         function getIntensityPoints(intensity) {
+          const normalized = normalizeIntensity(intensity);
+          const customPoints = parseCustomIntensity(normalized);
+          if (customPoints !== null) return customPoints;
           const fitness = ensureFitnessDefaults();
           const settings = fitness.pointSettings || {};
-          const key = typeof intensity === 'string' ? intensity.toLowerCase() : 'medium';
+          const key = normalized;
           const intensePoints = Number(settings.intense);
           const mediumPoints = Number(settings.medium);
           const lightPoints = Number(settings.light);
@@ -463,7 +502,12 @@
           return Object.prototype.hasOwnProperty.call(map, key) ? map[key] : map.medium;
         }
         function getIntensityLabel(intensity) {
-          switch ((intensity || 'medium').toLowerCase()) {
+          if (typeof intensity === 'string' && intensity.trim().toLowerCase() === 'custom') {
+            return 'Custom';
+          }
+          const normalized = normalizeIntensity(intensity);
+          if (isCustomIntensity(normalized)) return 'Custom';
+          switch (normalized) {
             case 'intense':
               return 'Intense';
             case 'light':
@@ -471,6 +515,23 @@
             default:
               return 'Medium';
           }
+        }
+        function getIntensitySummary(intensity) {
+          const normalized = normalizeIntensity(intensity);
+          const points = getIntensityPoints(normalized);
+          const customPoints = parseCustomIntensity(normalized);
+          const formattedPoints = customPoints !== null
+            ? formatCustomIntensityValue(customPoints)
+            : formatPoints(points);
+          return `${getIntensityLabel(normalized)} (${formattedPoints} pts)`;
+        }
+        function getIntensityPromptDefault(intensity) {
+          const normalized = normalizeIntensity(intensity);
+          const customPoints = parseCustomIntensity(normalized);
+          if (customPoints !== null) {
+            return formatCustomIntensityValue(customPoints);
+          }
+          return normalized;
         }
         function collectWorkoutPoints(options = {}) {
           const workouts = ensureWorkoutData();
@@ -487,28 +548,21 @@
           const endMs = end ? end.getTime() : Number.POSITIVE_INFINITY;
           const includeEntries = !!options.includeEntries;
           const collected = includeEntries ? [] : undefined;
-          const counts = { intense: 0, medium: 0, light: 0 };
-          const pointsByIntensity = { intense: 0, medium: 0, light: 0 };
-          const fitness = ensureFitnessDefaults();
-          const settings = fitness.pointSettings || {};
-          const intensePoints = Number(settings.intense);
-          const mediumPoints = Number(settings.medium);
-          const lightPoints = Number(settings.light);
-          const pointMap = {
-            intense: Number.isFinite(intensePoints) ? intensePoints : 0,
-            medium: Number.isFinite(mediumPoints) ? mediumPoints : 0,
-            light: Number.isFinite(lightPoints) ? lightPoints : 0
-          };
+          const counts = { intense: 0, medium: 0, light: 0, custom: 0 };
+          const pointsByIntensity = { intense: 0, medium: 0, light: 0, custom: 0 };
           let totalPoints = 0;
           workouts.entries.forEach(entry => {
             if (!entry || !entry.timestamp) return;
             const ts = Date.parse(entry.timestamp);
             if (!Number.isFinite(ts) || ts < startMs || ts >= endMs) return;
-            const key = normalizeIntensity(entry.intensity);
-            const points = Object.prototype.hasOwnProperty.call(pointMap, key) ? pointMap[key] : pointMap.medium;
+            const normalizedIntensity = normalizeIntensity(entry.intensity);
+            const points = getIntensityPoints(normalizedIntensity);
+            const bucket = parseCustomIntensity(normalizedIntensity) !== null ? 'custom' : normalizedIntensity;
             totalPoints += points;
-            counts[key] = (counts[key] || 0) + 1;
-            pointsByIntensity[key] = (pointsByIntensity[key] || 0) + points;
+            if (!counts.hasOwnProperty(bucket)) counts[bucket] = 0;
+            if (!pointsByIntensity.hasOwnProperty(bucket)) pointsByIntensity[bucket] = 0;
+            counts[bucket] += 1;
+            pointsByIntensity[bucket] += points;
             if (includeEntries) {
               collected.push(Object.assign({}, entry, { timestamp: new Date(ts).toISOString() }));
             }
@@ -621,8 +675,26 @@
         }
 
         function normalizeIntensity(value) {
-          const key = typeof value === 'string' ? value.toLowerCase().trim() : '';
-          if (key === 'intense' || key === 'medium' || key === 'light') return key;
+          if (typeof value === 'string') {
+            const trimmed = value.trim();
+            const lower = trimmed.toLowerCase();
+            if (lower === 'intense' || lower === 'medium' || lower === 'light') return lower;
+            const customFromTag = parseCustomIntensity(trimmed);
+            if (customFromTag !== null) return makeCustomIntensity(customFromTag);
+            const numeric = sanitizeCustomPoints(trimmed);
+            if (numeric !== null) return makeCustomIntensity(numeric);
+          } else if (typeof value === 'number') {
+            const numeric = sanitizeCustomPoints(value);
+            if (numeric !== null) return makeCustomIntensity(numeric);
+          } else if (value && typeof value === 'object') {
+            if (Number.isFinite(value.points)) {
+              const numeric = sanitizeCustomPoints(value.points);
+              if (numeric !== null) return makeCustomIntensity(numeric);
+            }
+            if (value.intensity !== undefined) {
+              return normalizeIntensity(value.intensity);
+            }
+          }
           return 'medium';
         }
         function ensureWorkoutPreset(name, intensity) {
@@ -1182,13 +1254,26 @@ function loadData() {
         processWorkoutWeekIfNeeded();
         const todoForm = document.getElementById('todoForm');
         if (todoForm) {
+          const intensityInput = document.getElementById('todoIntensity');
+          const customIntensityInput = document.getElementById('todoCustomIntensity');
+          const updateCustomIntensityVisibility = () => {
+            if (!intensityInput || !customIntensityInput) return;
+            if (intensityInput.value === 'custom') {
+              customIntensityInput.style.display = '';
+            } else {
+              customIntensityInput.style.display = 'none';
+              customIntensityInput.value = '';
+            }
+          };
+          if (intensityInput && customIntensityInput) {
+            intensityInput.addEventListener('change', updateCustomIntensityVisibility);
+            updateCustomIntensityVisibility();
+          }
           todoForm.addEventListener('submit', e => {
             e.preventDefault();
             const nameInput = document.getElementById('todoName');
-            const intensityInput = document.getElementById('todoIntensity');
             const whenInput = document.getElementById('todoWhen');
             const name = nameInput ? nameInput.value : '';
-            const intensity = intensityInput ? intensityInput.value : 'medium';
             const whenValue = whenInput && whenInput.value ? whenInput.value : '';
             const whenDate = whenValue ? new Date(whenValue) : new Date();
             if (!name.trim()) {
@@ -1199,10 +1284,27 @@ function loadData() {
               alert('Please provide a valid date and time.');
               return;
             }
-            logWorkoutEntry({ name, intensity, timestamp: whenDate });
+            let intensityValue = intensityInput ? intensityInput.value : 'medium';
+            let intensityToSave = intensityValue;
+            if (intensityValue === 'custom') {
+              const raw = customIntensityInput ? customIntensityInput.value : '';
+              const customPoints = sanitizeCustomPoints(raw);
+              if (customPoints === null) {
+                alert('Please enter a valid custom intensity (positive number of points).');
+                return;
+              }
+              intensityToSave = makeCustomIntensity(customPoints);
+            }
+            logWorkoutEntry({ name, intensity: intensityToSave, timestamp: whenDate });
             if (nameInput) nameInput.value = '';
             if (whenInput) whenInput.value = '';
-            if (intensityInput) intensityInput.value = 'medium';
+            if (intensityInput) {
+              intensityInput.value = 'medium';
+            }
+            if (customIntensityInput) {
+              customIntensityInput.value = '';
+            }
+            updateCustomIntensityVisibility();
           });
         }
         // Ensure every project has a color and that colors are unique when possible.
@@ -1456,11 +1558,17 @@ function loadData() {
             const pointsSub = pointsSubParts.join(' • ');
             createRow('Points this week', pointsValue, pointsSub);
             const intensityParts = [];
-            ['intense', 'medium', 'light'].forEach(key => {
+            ['intense', 'medium', 'light', 'custom'].forEach(key => {
               const count = pointsInfo.counts[key] || 0;
               if (count > 0) {
                 const pts = pointsInfo.pointsByIntensity[key] || 0;
-                intensityParts.push(`${getIntensityLabel(key)}: ${count} (${formatPoints(pts)} pts)`);
+                let formattedPts;
+                if (key === 'custom') {
+                  formattedPts = formatCustomIntensityValue(pts) || formatPoints(pts, 2);
+                } else {
+                  formattedPts = formatPoints(pts);
+                }
+                intensityParts.push(`${getIntensityLabel(key)}: ${count} (${formattedPts} pts)`);
               }
             });
             createRow('Intensity mix', intensityParts.length ? intensityParts.join(' • ') : 'No workouts logged yet', null);
@@ -1702,7 +1810,7 @@ function loadData() {
                 row.style.padding = '0.4rem 0';
                 row.style.borderBottom = '1px solid #e2e8f0';
                 const info = document.createElement('div');
-                info.innerHTML = `<strong>${preset.name}</strong> • ${getIntensityLabel(preset.intensity)} (${getIntensityPoints(preset.intensity)} pts)`;
+                info.innerHTML = `<strong>${preset.name}</strong> • ${getIntensitySummary(preset.intensity)}`;
                 row.appendChild(info);
                 const actions = document.createElement('div');
                 actions.style.display = 'flex';
@@ -1727,7 +1835,7 @@ function loadData() {
                     alert('Preset name cannot be empty.');
                     return;
                   }
-                  const newIntensity = prompt('Intensity (intense / medium / light)', preset.intensity || 'medium');
+                  const newIntensity = prompt('Intensity (intense / medium / light / custom points)', getIntensityPromptDefault(preset.intensity));
                   if (newIntensity === null) return;
                   const normalized = normalizeIntensity(newIntensity);
                   const existing = workouts.presets.find(p => p.id !== preset.id && p.name === trimmed && normalizeIntensity(p.intensity) === normalized);
@@ -1814,7 +1922,7 @@ function loadData() {
                 row.style.borderBottom = '1px solid #e2e8f0';
                 row.style.padding = '0.5rem 0';
                 const info = document.createElement('div');
-                info.innerHTML = `<strong>${entry.name}</strong> • ${getIntensityLabel(entry.intensity)} (${getIntensityPoints(entry.intensity)} pts) • ${formatWorkoutTimestamp(entry.timestamp)}`;
+                info.innerHTML = `<strong>${entry.name}</strong> • ${getIntensitySummary(entry.intensity)} • ${formatWorkoutTimestamp(entry.timestamp)}`;
                 row.appendChild(info);
                 const actions = document.createElement('div');
                 actions.style.display = 'flex';
@@ -1831,7 +1939,7 @@ function loadData() {
                     alert('Workout name cannot be empty.');
                     return;
                   }
-                  const newIntensity = prompt('Intensity (intense / medium / light)', entry.intensity || 'medium');
+                  const newIntensity = prompt('Intensity (intense / medium / light / custom points)', getIntensityPromptDefault(entry.intensity));
                   if (newIntensity === null) return;
                   const timeDefault = formatTimestampForInput(entry.timestamp).replace('T', ' ');
                   const newTimeRaw = prompt('When? (YYYY-MM-DD HH:MM, leave blank to keep current)', timeDefault);


### PR DESCRIPTION
## Summary
- allow logging workouts with custom decimal intensity values alongside existing presets
- normalize and aggregate custom intensities when calculating weekly workout points
- surface custom intensity details across presets, entries, and summaries

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0eee6ec00832d877ced7eacebce47