### PR TITLE
Fix workout point spillover consumption

### DIFF
--- a/index.html
+++ b/index.html
@@ -892,12 +892,19 @@
           let spilloverAfter = spilloverBefore;
           if (wasPaused) {
             metTarget = true;
-          } else if (requiredPoints <= 0) {
-            metTarget = true;
-            spilloverAfter = spilloverBefore + actualPoints;
           } else {
-            metTarget = actualPoints >= requiredPoints;
-            spilloverAfter = spilloverBefore + (actualPoints - requiredPoints);
+            const netSpilloverChange = actualPoints - baseTarget;
+            spilloverAfter = spilloverBefore + (Number.isFinite(netSpilloverChange) ? netSpilloverChange : 0);
+            if (!Number.isFinite(spilloverAfter)) {
+              spilloverAfter = 0;
+            } else if (Math.abs(spilloverAfter) < 1e-9) {
+              spilloverAfter = 0;
+            }
+            if (requiredPoints <= 0) {
+              metTarget = true;
+            } else {
+              metTarget = actualPoints >= requiredPoints;
+            }
           }
           const previousStreak = Number.isFinite(fitness.streakCount) ? fitness.streakCount : 0;
           const streakCount = metTarget ? previousStreak + 1 : 0;


### PR DESCRIPTION
## Summary
- adjust weekly rollover logic so surplus workout points are actually consumed when computing the next week's carry-over
- add guards to prevent invalid spillover values when finalizing workout weeks

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e51efd60ac832d9db104b86265523a