### PR TITLE
Ensure workout rollover updates before computing weekly plan

### DIFF
--- a/index.html
+++ b/index.html
@@ -612,6 +612,10 @@
           };
         }
         function computeWorkoutWeekPlan(options = {}) {
+          // Ensure any outstanding weekly rollovers are applied before computing the plan.
+          // This keeps the carryover/required points up-to-date even if the page has been
+          // open across a week boundary without a reload.
+          processWorkoutWeekIfNeeded();
           const now = options.now instanceof Date ? options.now : new Date();
           const weekStart = options.weekStart instanceof Date ? new Date(options.weekStart) : getWeekStart(now);
           const weekEnd = options.weekEnd instanceof Date ? new Date(options.weekEnd) : (() => {


### PR DESCRIPTION
## Summary
- trigger rollover processing whenever the weekly workout plan is computed
- keep carryover points accurate even if the page stayed open across a week boundary

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e53677cffc832dbe19a4b3bd579a05