### PR TITLE
Add mobile Company Operator missions

### DIFF
--- a/index.html
+++ b/index.html
@@ -525,6 +525,6 @@
       </section>
     </div>
     <div id="mobileNowBar" class="mobile-now-bar hidden" aria-live="polite"></div>
-    <script type="module" src="src/main.mjs?v=15"></script>
+    <script type="module" src="src/main.mjs?v=16"></script>
   </body>
 </html>

--- a/service-worker.js
+++ b/service-worker.js
@@ -3,12 +3,12 @@
 const sw = /** @type {ServiceWorkerGlobalScope} */ (
   /** @type {unknown} */ (self)
 );
-const CACHE_NAME = 'timekeeper-app-v17';
+const CACHE_NAME = 'timekeeper-app-v18';
 const APP_SHELL = [
   './',
   './index.html',
   './style.css',
-  './src/main.mjs?v=15',
+  './src/main.mjs?v=16',
   './src/shared/runtime-helpers.mjs',
   './src/shared/id.mjs',
   './src/shared/ui.mjs',
@@ -66,8 +66,8 @@ sw.addEventListener('activate', (event) => {
         if (!refreshExistingClients) return;
         clients.forEach((client) => {
           const url = new URL(client.url);
-          if (url.searchParams.get('timekeeper-update') === '15') return;
-          url.searchParams.set('timekeeper-update', '15');
+          if (url.searchParams.get('timekeeper-update') === '16') return;
+          url.searchParams.set('timekeeper-update', '16');
           client.navigate(url.href).catch(() => undefined);
         });
       })

--- a/src/features/company-operator/core.mjs
+++ b/src/features/company-operator/core.mjs
@@ -466,6 +466,10 @@ function normalizeReceipt(value) {
       source.execution_branch || source.executionBranch,
       180
     ),
+    executionBranchPendingCommitCount: toCount(
+      source.execution_branch_pending_commit_count ??
+        source.executionBranchPendingCommitCount
+    ),
     isolatedExecution:
       source.isolated_execution === true || source.isolatedExecution === true,
     sessionId: cleanText(source.session_id || source.sessionId, 140)
@@ -532,6 +536,10 @@ function normalizeDispatch(value) {
     executionBranch: cleanText(
       source.execution_branch || source.executionBranch,
       180
+    ),
+    executionBranchPendingCommitCount: toCount(
+      source.execution_branch_pending_commit_count ??
+        source.executionBranchPendingCommitCount
     ),
     isolatedExecution:
       source.isolated_execution === true || source.isolatedExecution === true,

--- a/src/features/company-operator/core.mjs
+++ b/src/features/company-operator/core.mjs
@@ -74,6 +74,7 @@ export function normalizeCompanyOperatorSnapshot(value = {}) {
   const decisions = asRecord(source.decisions);
   const handled = asRecord(source.handled);
   const dispatches = asRecord(source.dispatches);
+  const missions = asRecord(source.missions);
   const sources = asRecord(source.sources);
   return {
     schemaVersion: COMPANY_OPERATOR_SCHEMA_VERSION,
@@ -82,6 +83,23 @@ export function normalizeCompanyOperatorSnapshot(value = {}) {
     stateVersion: cleanText(source.state_version || source.stateVersion, 128),
     today: normalizeToday(source.today),
     priorities,
+    missions: {
+      status: cleanText(missions.status, 80),
+      activeCount: toCount(missions.active_count ?? missions.activeCount),
+      waitingCount: toCount(missions.waiting_count ?? missions.waitingCount),
+      completedTodayCount: toCount(
+        missions.completed_today_count ?? missions.completedTodayCount
+      ),
+      primary: normalizeMission(missions.primary),
+      active: normalizeArray(missions.active, normalizeMission, 6),
+      completedToday: normalizeArray(
+        missions.completed_today || missions.completedToday,
+        normalizeMission,
+        6
+      ),
+      budget: normalizeMissionBudget(missions.budget),
+      scorecard: normalizeMissionScorecard(missions.scorecard)
+    },
     workProducts: {
       status: cleanText(workProducts.status, 80),
       title: cleanText(workProducts.title, 180),
@@ -250,7 +268,8 @@ export function buildCompanyOperatorCommand({
     state_version: cleanText(snapshot?.stateVersion, 128),
     target: {
       issue_id: cleanText(targetSource.issueId, 160),
-      evidence_fingerprint: cleanText(targetSource.evidenceFingerprint, 128)
+      evidence_fingerprint: cleanText(targetSource.evidenceFingerprint, 128),
+      mission_id: cleanText(targetSource.missionId, 100)
     },
     params: {}
   };
@@ -371,6 +390,112 @@ function normalizePriority(value) {
       500
     ),
     steered: source.steered === true
+  };
+}
+
+function normalizeMission(value) {
+  const source = asRecord(value);
+  const missionId = cleanText(source.mission_id || source.missionId, 100);
+  if (!missionId) return null;
+  const currentStep = asRecord(source.current_step || source.currentStep);
+  const userRequest = asRecord(source.user_request || source.userRequest);
+  return {
+    missionId,
+    issueId: cleanText(source.issue_id || source.issueId, 160),
+    evidenceFingerprint: cleanText(
+      source.evidence_fingerprint || source.evidenceFingerprint,
+      128
+    ),
+    project: cleanText(source.project, 100) || 'Company',
+    objective: cleanLegacyResponsibilityCopy(source.objective, 500),
+    doneWhen: cleanLegacyResponsibilityCopy(
+      source.done_when || source.doneWhen,
+      500
+    ),
+    outputType: cleanText(source.output_type || source.outputType, 40),
+    status: cleanText(source.status, 40) || 'queued',
+    priorityScore: toCount(source.priority_score ?? source.priorityScore),
+    userPinned: source.user_pinned === true || source.userPinned === true,
+    isPrimary: source.is_primary === true || source.isPrimary === true,
+    revision: Math.max(1, toCount(source.revision)),
+    currentStep: {
+      title: cleanLegacyResponsibilityCopy(currentStep.title, 180),
+      status: cleanText(currentStep.status, 40),
+      startedAt: cleanText(
+        currentStep.started_at || currentStep.startedAt,
+        80
+      )
+    },
+    latestUpdate: cleanLegacyResponsibilityCopy(
+      source.latest_update || source.latestUpdate,
+      320
+    ),
+    stepCount: toCount(source.step_count ?? source.stepCount),
+    updatedAt: cleanText(source.updated_at || source.updatedAt, 80),
+    completedAt: cleanText(source.completed_at || source.completedAt, 80),
+    destinations: normalizeArray(
+      source.destinations,
+      normalizeResultDestination,
+      4
+    ),
+    userRequest: {
+      dispatchId: cleanText(
+        userRequest.dispatch_id || userRequest.dispatchId,
+        180
+      ),
+      instruction: cleanLegacyResponsibilityCopy(
+        userRequest.instruction,
+        240
+      ),
+      reason: cleanLegacyResponsibilityCopy(userRequest.reason, 180),
+      choices: Array.isArray(userRequest.choices)
+        ? userRequest.choices
+            .map(normalizeUserRequestChoice)
+            .filter(Boolean)
+            .slice(0, 3)
+        : []
+    }
+  };
+}
+
+function normalizeMissionBudget(value) {
+  const source = asRecord(value);
+  return {
+    date: cleanText(source.date, 20),
+    automaticStepsToday: toCount(
+      source.automatic_steps_today ?? source.automaticStepsToday
+    ),
+    automaticMinutesToday: toCount(
+      source.automatic_minutes_today ?? source.automaticMinutesToday
+    ),
+    stepsRemaining: toCount(source.steps_remaining ?? source.stepsRemaining),
+    minutesRemaining: toCount(
+      source.minutes_remaining ?? source.minutesRemaining
+    )
+  };
+}
+
+function normalizeMissionScorecard(value) {
+  const source = asRecord(value);
+  return {
+    date: cleanText(source.date, 20),
+    missionsCompletedToday: toCount(
+      source.missions_completed_today ?? source.missionsCompletedToday
+    ),
+    verifiedStepsToday: toCount(
+      source.verified_steps_today ?? source.verifiedStepsToday
+    ),
+    failedStepsToday: toCount(
+      source.failed_steps_today ?? source.failedStepsToday
+    ),
+    verifiedOutputsToday: toCount(
+      source.verified_outputs_today ?? source.verifiedOutputsToday
+    ),
+    estimatedMinutesSavedToday: toCount(
+      source.estimated_minutes_saved_today ??
+        source.estimatedMinutesSavedToday
+    ),
+    openDecisions: toCount(source.open_decisions ?? source.openDecisions)
   };
 }
 

--- a/src/features/company-operator/runtime.mjs
+++ b/src/features/company-operator/runtime.mjs
@@ -826,6 +826,11 @@ export function createCompanyOperatorController({
       [dispatch.model, dispatch.reasoningEffort].filter(Boolean).join(' / '),
       dispatch.executionRepo,
       dispatch.executionBranch ? `Branch ${dispatch.executionBranch}` : '',
+      dispatch.executionBranchPendingCommitCount
+        ? `${dispatch.executionBranchPendingCommitCount} pending Company Operator ${
+            dispatch.executionBranchPendingCommitCount === 1 ? 'commit' : 'commits'
+          }`
+        : '',
       formatDispatchDuration(dispatch.durationSeconds),
       dispatch.timeTrackingStatus === 'session_persisted'
         ? 'IFLAI time recorded'

--- a/src/features/company-operator/runtime.mjs
+++ b/src/features/company-operator/runtime.mjs
@@ -142,7 +142,8 @@ export function createCompanyOperatorController({
         snapshot,
         target: {
           issueId: priority.issueId,
-          evidenceFingerprint: priority.evidenceFingerprint
+          evidenceFingerprint: priority.evidenceFingerprint,
+          missionId: priority.missionId
         },
         params
       });
@@ -159,6 +160,7 @@ export function createCompanyOperatorController({
           label: priority.project || priority.title || 'Company priority',
           issueId: priority.issueId,
           evidenceFingerprint: priority.evidenceFingerprint,
+          missionId: priority.missionId || '',
           dispatchId: String(params.dispatchId || ''),
           project: priority.project || 'Company',
           title: priority.title || '',
@@ -489,8 +491,13 @@ export function createCompanyOperatorController({
     const freshness = companySnapshotFreshness(snapshot);
     root.appendChild(statusBanner(freshness));
     const dispatches = compactDispatchSections();
-    if (dispatches.inProgress) root.appendChild(dispatches.inProgress);
-    if (dispatches.done) root.appendChild(dispatches.done);
+    const missions = missionSections();
+    if (missions.working) root.appendChild(missions.working);
+    else if (dispatches.inProgress) root.appendChild(dispatches.inProgress);
+    if (missions.completed) root.appendChild(missions.completed);
+    else if (dispatches.done) root.appendChild(dispatches.done);
+    if (missions.needsYou) root.appendChild(missions.needsYou);
+    else if (dispatches.needsYou) root.appendChild(dispatches.needsYou);
     const priorities = visiblePriorities();
     const primary = priorities[0];
     if (primary) root.appendChild(primaryCard(primary));
@@ -502,10 +509,15 @@ export function createCompanyOperatorController({
         )
       );
     }
-    if (dispatches.needsYou) root.appendChild(dispatches.needsYou);
     if (snapshot.decisions.pending.length) {
       root.appendChild(decisionSection(snapshot.decisions.pending));
-    } else if (!primary && !dispatches.needsYou && !dispatches.inProgress) {
+    } else if (
+      !primary &&
+      !missions.working &&
+      !missions.needsYou &&
+      !dispatches.needsYou &&
+      !dispatches.inProgress
+    ) {
       root.appendChild(
         card(
           'Nothing needs you',
@@ -567,6 +579,233 @@ export function createCompanyOperatorController({
     const hours = Math.round(minutes / 60);
     if (hours < 48) return `${hours}h old`;
     return `${Math.round(hours / 24)}d old`;
+  }
+
+  function missionSections() {
+    const source = snapshot.missions;
+    const active = Array.isArray(source.active) ? source.active : [];
+    const completedToday = Array.isArray(source.completedToday)
+      ? source.completedToday
+      : [];
+    const workingRows = active.filter((mission) =>
+      ['active', 'queued', 'waiting_for_source'].includes(mission.status)
+    );
+    const waitingRows = active.filter(
+      (mission) => mission.status === 'waiting_for_decision'
+    );
+    const sections = { working: null, completed: null, needsYou: null };
+
+    if (workingRows.length) {
+      const section = sectionBlock('Working now');
+      const primaryId = source.primary?.missionId;
+      const ordered = [...workingRows].sort((left, right) => {
+        if (left.missionId === primaryId) return -1;
+        if (right.missionId === primaryId) return 1;
+        return right.priorityScore - left.priorityScore;
+      });
+      section.appendChild(missionCard(ordered[0], 'working'));
+      if (ordered.length > 1) {
+        const more = element('details', 'company-result-backlog');
+        more.appendChild(
+          element(
+            'summary',
+            '',
+            `${ordered.length - 1} other active mission${ordered.length === 2 ? '' : 's'}`
+          )
+        );
+        ordered.slice(1).forEach((mission) =>
+          more.appendChild(missionCard(mission, 'working compact'))
+        );
+        section.appendChild(more);
+      }
+      sections.working = section;
+    }
+
+    if (completedToday.length) {
+      const section = sectionBlock('Completed for you');
+      const scorecard = source.scorecard;
+      if (scorecard.missionsCompletedToday || scorecard.estimatedMinutesSavedToday) {
+        section.appendChild(
+          element(
+            'p',
+            'company-handled-summary',
+            [
+              scorecard.missionsCompletedToday
+                ? `${scorecard.missionsCompletedToday} finished today`
+                : '',
+              scorecard.estimatedMinutesSavedToday
+                ? `about ${scorecard.estimatedMinutesSavedToday} minutes saved`
+                : ''
+            ]
+              .filter(Boolean)
+              .join(' · ')
+          )
+        );
+      }
+      section.appendChild(missionCard(completedToday.at(-1), 'completed'));
+      if (completedToday.length > 1) {
+        const more = element('details', 'company-result-backlog');
+        more.appendChild(
+          element(
+            'summary',
+            '',
+            `${completedToday.length - 1} earlier completion${completedToday.length === 2 ? '' : 's'}`
+          )
+        );
+        completedToday
+          .slice(0, -1)
+          .reverse()
+          .forEach((mission) =>
+            more.appendChild(missionCard(mission, 'completed compact'))
+          );
+        section.appendChild(more);
+      }
+      sections.completed = section;
+    }
+
+    if (waitingRows.length) {
+      const section = sectionBlock('Needs you');
+      section.appendChild(missionCard(waitingRows[0], 'needs-you'));
+      if (waitingRows.length > 1) {
+        const more = element('details', 'company-question-backlog');
+        more.appendChild(
+          element(
+            'summary',
+            '',
+            `${waitingRows.length - 1} more question${waitingRows.length === 2 ? '' : 's'}`
+          )
+        );
+        waitingRows.slice(1).forEach((mission) =>
+          more.appendChild(missionCard(mission, 'needs-you compact'))
+        );
+        section.appendChild(more);
+      }
+      sections.needsYou = section;
+    }
+    return sections;
+  }
+
+  function missionCard(mission, tone) {
+    const row = element('article', `company-dispatch-card mission ${tone}`);
+    row.appendChild(element('p', 'company-eyebrow', mission.project));
+    row.appendChild(
+      element('strong', '', mission.objective || 'Company mission')
+    );
+    if (tone.includes('needs-you')) {
+      const request = mission.userRequest || {};
+      row.appendChild(
+        element(
+          'p',
+          'company-dispatch-next',
+          request.instruction || 'One answer is needed to continue.'
+        )
+      );
+      const actions = element('div', 'company-action-grid');
+      (request.choices || []).forEach((choice) => {
+        actions.appendChild(
+          button(choice.label, 'primary', () =>
+            answerMission(mission, choice)
+          )
+        );
+      });
+      actions.appendChild(
+        button('Add context', 'secondary', () => answerMission(mission))
+      );
+      row.appendChild(actions);
+    } else if (tone.includes('completed')) {
+      if (mission.latestUpdate) {
+        row.appendChild(element('span', '', mission.latestUpdate));
+      }
+      (mission.destinations || []).forEach((destination) =>
+        row.appendChild(compactResultDestination(destination))
+      );
+    } else {
+      row.appendChild(
+        element('span', '', missionProgressLabel(mission))
+      );
+      if (mission.latestUpdate) {
+        row.appendChild(element('small', '', mission.latestUpdate));
+      }
+      if (!missionCommandPending(mission)) {
+        const actions = element('div', 'company-action-grid');
+        actions.appendChild(
+          button(
+            mission.status === 'queued' ? 'Work now' : 'Continue now',
+            'primary',
+            () => queuePriorityAction('work_next', mission)
+          )
+        );
+        actions.appendChild(
+          button('Add direction', 'secondary', () => addDirection(mission))
+        );
+        row.appendChild(actions);
+        const more = element('details', 'company-more-actions');
+        more.appendChild(element('summary', '', 'More actions'));
+        const secondary = element('div', 'company-action-grid');
+        secondary.appendChild(
+          button('Pause', 'secondary', () => snooze(mission))
+        );
+        secondary.appendChild(
+          button('Already handled', 'secondary', () => markHandled(mission))
+        );
+        more.appendChild(secondary);
+        row.appendChild(more);
+      }
+    }
+    const details = element('details', 'company-run-details');
+    details.appendChild(element('summary', '', 'Finish line and progress'));
+    if (mission.doneWhen) details.appendChild(element('p', '', mission.doneWhen));
+    details.appendChild(
+      element(
+        'small',
+        '',
+        `${mission.stepCount} verified step${mission.stepCount === 1 ? '' : 's'} recorded`
+      )
+    );
+    row.appendChild(details);
+    return row;
+  }
+
+  function missionProgressLabel(mission) {
+    if (missionCommandPending(mission)) {
+      return 'The next Codex step is queued or running.';
+    }
+    if (mission.status === 'waiting_for_source') {
+      return 'Waiting for the next information refresh; no input needed from you.';
+    }
+    if (mission.currentStep?.status === 'running') {
+      return mission.currentStep.title || 'Codex is working on this now.';
+    }
+    if (mission.status === 'queued') {
+      return 'Ready for the next Codex step.';
+    }
+    return 'Codex will continue this mission within today\'s work budget.';
+  }
+
+  function missionCommandPending(mission) {
+    return loadPending().some(
+      (item) =>
+        CODEX_ACTIONS.has(item.action) &&
+        item.issueId === mission.issueId &&
+        (!item.evidenceFingerprint ||
+          item.evidenceFingerprint === mission.evidenceFingerprint)
+    );
+  }
+
+  async function answerMission(mission, choice = null) {
+    await answerDispatch(
+      {
+        dispatchId: mission.userRequest?.dispatchId || '',
+        issueId: mission.issueId,
+        evidenceFingerprint: mission.evidenceFingerprint,
+        project: mission.project,
+        result: {
+          headline: mission.objective,
+          userRequest: mission.userRequest
+        }
+      },
+      choice
+    );
   }
 
   function primaryCard(priority) {

--- a/src/styles/features.css
+++ b/src/styles/features.css
@@ -1185,6 +1185,20 @@ tr:nth-child(even) td {
   background: #eff6ff;
 }
 
+.company-dispatch-card.mission.working {
+  border-color: #93c5fd;
+  background: linear-gradient(145deg, #eff6ff, #ffffff 85%);
+}
+
+.company-dispatch-card.mission.completed {
+  border-color: #86efac;
+  background: #f0fdf4;
+}
+
+.company-dispatch-card.mission.compact {
+  background: #ffffff;
+}
+
 .company-dispatch-card.verified {
   border-color: #86efac;
   background: #f0fdf4;

--- a/tests/smoke/timekeeper.spec.js
+++ b/tests/smoke/timekeeper.spec.js
@@ -1744,6 +1744,8 @@ test('mobile Company tab loads private priorities and queues safe steering', asy
           reasoning_effort: 'medium',
           model_routing_tier: 'standard',
           execution_repo: 'Aventix',
+          execution_branch: 'codex/company-operator',
+          execution_branch_pending_commit_count: 1,
           duration_seconds: 96,
           time_tracking_status: 'session_persisted',
           result: {
@@ -1922,6 +1924,9 @@ test('mobile Company tab loads private priorities and queues safe steering', asy
   );
   await expect(page.locator('#companyPageContent')).toContainText(
     'IFLAI time recorded'
+  );
+  await expect(page.locator('#companyPageContent')).toContainText(
+    '1 pending Company Operator commit'
   );
   await expect(page.locator('#companyPageContent')).toContainText(
     'Aventix local commit'

--- a/tests/smoke/timekeeper.spec.js
+++ b/tests/smoke/timekeeper.spec.js
@@ -1560,7 +1560,7 @@ test('service worker never caches private cross-origin API responses', async () 
   expect(serviceWorker).toContain(
     'if (requestUrl.origin !== sw.location.origin) return;'
   );
-  expect(serviceWorker).toContain("const CACHE_NAME = 'timekeeper-app-v17';");
+  expect(serviceWorker).toContain("const CACHE_NAME = 'timekeeper-app-v18';");
 });
 
 test('mobile Company tab loads private priorities and queues safe steering', async ({
@@ -1851,7 +1851,7 @@ test('mobile Company tab loads private priorities and queues safe steering', asy
       .find((heading) => heading.textContent === 'Needs you')
       ?.getBoundingClientRect().top
   }));
-  expect(sectionOrder.priority).toBeLessThan(sectionOrder.question);
+  expect(sectionOrder.question).toBeLessThan(sectionOrder.priority);
   await expect(page.locator('#companyPageContent')).not.toContainText(
     'Commercial workbook'
   );
@@ -2052,6 +2052,238 @@ test('mobile Company tab loads private priorities and queues safe steering', asy
     'decision-evidence-1'
   );
   expect(decisionCommand.params.decision).toBe('approve');
+});
+
+test('mobile Company tab presents missions before the next priority', async ({
+  page
+}) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await freezeTime(page, '2026-08-03T12:00:00.000Z');
+  await seedLocalStorage(page, { projects: [], entries: [] });
+  await page.addInitScript(() => {
+    localStorage.setItem(
+      'timekeeperCompanyOperatorSettings',
+      JSON.stringify({
+        repository: 'Henrik-KM/timekeeper-private-context',
+        branch: 'main',
+        statePath: 'company-operator/state.json',
+        commandsPath: 'company-operator/commands',
+        receiptsPath: 'company-operator/receipts'
+      })
+    );
+    localStorage.setItem(
+      'timekeeperCompanyOperatorToken',
+      'github_pat_private_company_mission_test'
+    );
+  });
+  const snapshot = {
+    schema_version: 1,
+    generated_at: '2026-08-03T11:59:00.000Z',
+    status: 'ready',
+    state_version: 'state-missions-1',
+    today: {},
+    priorities: [
+      {
+        issue_id: 'priority:vwr-avantor',
+        evidence_fingerprint: 'evidence-vwr-1',
+        project: 'VWR/Avantor',
+        title: 'Camera pilot follow-through',
+        priority_score: 84,
+        next_action: 'Prepare the next customer-ready pilot deliverable.',
+        done_when: 'The deliverable is tested and ready at a named location.'
+      }
+    ],
+    missions: {
+      status: 'ready',
+      active_count: 1,
+      waiting_count: 1,
+      completed_today_count: 1,
+      budget: {
+        automatic_steps_today: 2,
+        automatic_minutes_today: 18,
+        steps_remaining: 4,
+        minutes_remaining: 72
+      },
+      primary: {
+        mission_id: 'mission:avantor',
+        issue_id: 'priority:avantor-delivery',
+        evidence_fingerprint: 'evidence-avantor-delivery-1',
+        project: 'Avantor',
+        objective: 'Finish the tested camera configuration for the customer.',
+        done_when: 'The tested configuration is available in a verified local commit.',
+        status: 'active',
+        step_count: 1,
+        latest_update: 'Implemented the supported device configuration.',
+        current_step: { title: '', status: '' },
+        is_primary: true
+      },
+      active: [
+        {
+          mission_id: 'mission:avantor',
+          issue_id: 'priority:avantor-delivery',
+          evidence_fingerprint: 'evidence-avantor-delivery-1',
+          project: 'Avantor',
+          objective: 'Finish the tested camera configuration for the customer.',
+          done_when: 'The tested configuration is available in a verified local commit.',
+          status: 'active',
+          step_count: 1,
+          latest_update: 'Implemented the supported device configuration.',
+          is_primary: true
+        },
+        {
+          mission_id: 'mission:albany',
+          issue_id: 'priority:albany-route',
+          evidence_fingerprint: 'evidence-albany-route-1',
+          project: 'Albany',
+          objective: 'Prepare the agreed customer delivery route.',
+          done_when: 'The selected route is implemented and ready for review.',
+          status: 'waiting_for_decision',
+          user_request: {
+            dispatch_id: 'dispatch:albany-route',
+            instruction: 'Choose direct delivery or partner delivery.',
+            reason: 'Both are supported; the commercial choice is protected.',
+            choices: [
+              {
+                id: 'direct',
+                label: 'Direct delivery',
+                kind: 'decision',
+                fields: []
+              },
+              {
+                id: 'partner',
+                label: 'Partner delivery',
+                kind: 'decision',
+                fields: []
+              }
+            ]
+          }
+        }
+      ],
+      completed_today: [
+        {
+          mission_id: 'mission:aventix',
+          issue_id: 'priority:aventix-export',
+          evidence_fingerprint: 'evidence-aventix-export-1',
+          project: 'Aventix',
+          objective: 'Repair the customer data export.',
+          status: 'completed',
+          latest_update: 'The export fix passed its regression test.',
+          destinations: [
+            {
+              type: 'local_commit',
+              mode: 'none',
+              label: 'Aventix local commit',
+              location: 'Aventix',
+              reference: '1234567890abcdef',
+              status_text: 'Committed locally and not pushed.',
+              verified: true
+            }
+          ]
+        }
+      ]
+    },
+    work_products: { status: 'ready', assets: [] },
+    decisions: { pending_count: 0, deferred_count: 0, pending: [] },
+    handled: { today_verified_actions: 1, receipts: [] },
+    dispatches: { in_progress_count: 0, in_progress: [], recent: [] },
+    sources: {
+      status: 'ready',
+      attention_count: 0,
+      items: [{ name: 'outlook', status: 'ready', status_text: 'Up to date' }]
+    }
+  };
+  const encodedSnapshot = Buffer.from(JSON.stringify(snapshot)).toString(
+    'base64'
+  );
+  await page.route('https://api.github.com/**', async (route) => {
+    const request = route.request();
+    if (
+      request.method() === 'GET' &&
+      request.url().includes('/contents/company-operator/state.json')
+    ) {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ content: encodedSnapshot, sha: 'state-sha' })
+      });
+      return;
+    }
+    if (
+      request.method() === 'GET' &&
+      request.url().includes('/contents/company-operator/receipts/')
+    ) {
+      await route.fulfill({ status: 404, body: '{}' });
+      return;
+    }
+    if (
+      request.method() === 'PUT' &&
+      request.url().includes('/contents/company-operator/commands/')
+    ) {
+      await route.fulfill({
+        status: 201,
+        contentType: 'application/json',
+        body: JSON.stringify({ content: { path: 'company-operator/commands' } })
+      });
+      return;
+    }
+    await route.fulfill({ status: 404, body: '{}' });
+  });
+
+  await page.goto('/#company');
+  const content = page.locator('#companyPageContent');
+  await expect(content).toContainText('Working now');
+  await expect(content).toContainText('Completed for you');
+  await expect(content).toContainText('Needs you');
+  await expect(content).toContainText('Up next');
+  await expect(content).toContainText(
+    'Finish the tested camera configuration for the customer.'
+  );
+  await expect(content).toContainText('Aventix local commit');
+  await expect(content).toContainText(
+    'Choose direct delivery or partner delivery.'
+  );
+  await expect(content).toContainText('VWR/Avantor');
+  const order = await page.evaluate(() => {
+    const headings = [...document.querySelectorAll('#companyPageContent h3')];
+    return Object.fromEntries(
+      ['Working now', 'Completed for you', 'Needs you'].map((label) => [
+        label,
+        headings.find((heading) => heading.textContent === label)?.getBoundingClientRect().top
+      ])
+    );
+  });
+  const upNext = await page
+    .locator('#companyPageContent .company-primary-card')
+    .evaluate((node) => node.getBoundingClientRect().top);
+  expect(order['Working now']).toBeLessThan(order['Completed for you']);
+  expect(order['Completed for you']).toBeLessThan(order['Needs you']);
+  expect(order['Needs you']).toBeLessThan(upNext);
+
+  const commandRequest = page.waitForRequest(
+    (request) =>
+      request.method() === 'PUT' &&
+      request.url().includes('/contents/company-operator/commands/')
+  );
+  await page.getByRole('button', { name: 'Continue now' }).click();
+  const commandPayload = (await commandRequest).postDataJSON();
+  const command = JSON.parse(
+    Buffer.from(commandPayload.content, 'base64').toString('utf8')
+  );
+  expect(command.action).toBe('work_next');
+  expect(command.target.issue_id).toBe('priority:avantor-delivery');
+  expect(command.target.mission_id).toBe('mission:avantor');
+
+  const layout = await page.evaluate(() => ({
+    viewportWidth: window.innerWidth,
+    scrollWidth: document.documentElement.scrollWidth,
+    minimumActionHeight: Math.min(
+      ...[...document.querySelectorAll('#companyPageContent .company-action-grid .btn')].map(
+        (button) => button.getBoundingClientRect().height
+      ).filter((height) => height > 0)
+    )
+  }));
+  expect(layout.scrollWidth).toBeLessThanOrEqual(layout.viewportWidth + 2);
+  expect(layout.minimumActionHeight).toBeGreaterThanOrEqual(44);
 });
 
 test('mobile shell exposes Now bar More menu sync status charts and richer quick timers', async ({

--- a/tests/unit/company-operator.test.mjs
+++ b/tests/unit/company-operator.test.mjs
@@ -139,6 +139,8 @@ test('normalizes a bounded mobile Company snapshot', () => {
           reasoning_effort: 'max',
           model_routing_tier: 'frontier',
           execution_repo: 'email-helper',
+          execution_branch: 'codex/company-operator',
+          execution_branch_pending_commit_count: 2,
           duration_seconds: 125,
           result: {
             status: 'needs_decision',
@@ -190,6 +192,14 @@ test('normalizes a bounded mobile Company snapshot', () => {
   });
 
   assert.equal(snapshot.today.project, 'Avantor');
+  assert.equal(
+    snapshot.dispatches.recent[0].executionBranch,
+    'codex/company-operator'
+  );
+  assert.equal(
+    snapshot.dispatches.recent[0].executionBranchPendingCommitCount,
+    2
+  );
   assert.equal(snapshot.priorities[0].issueId, 'priority:avantor');
   assert.equal(
     snapshot.workProducts.assets[0].format,

--- a/tests/unit/company-operator.test.mjs
+++ b/tests/unit/company-operator.test.mjs
@@ -252,6 +252,103 @@ test('normalizes a bounded mobile Company snapshot', () => {
   assert.equal(snapshot.priorities[0].title, '<img src=x onerror=alert(1)>');
 });
 
+test('normalizes persistent missions, questions, progress, and verified outputs', () => {
+  const snapshot = normalizeCompanyOperatorSnapshot({
+    schema_version: 1,
+    missions: {
+      status: 'ready',
+      active_count: 2,
+      waiting_count: 1,
+      completed_today_count: 1,
+      budget: {
+        automatic_steps_today: 3,
+        automatic_minutes_today: 24,
+        steps_remaining: 3,
+        minutes_remaining: 66
+      },
+      primary: {
+        mission_id: 'mission:avantor',
+        issue_id: 'priority:avantor',
+        evidence_fingerprint: 'evidence-1',
+        project: 'Avantor',
+        objective: 'Finish the camera delivery package.',
+        done_when: 'The tested package is available in a local commit.',
+        status: 'active',
+        step_count: 2,
+        latest_update: 'Implemented the validated configuration.',
+        current_step: {
+          title: 'Run the final validation',
+          status: 'running'
+        }
+      },
+      active: [
+        {
+          mission_id: 'mission:avantor',
+          issue_id: 'priority:avantor',
+          evidence_fingerprint: 'evidence-1',
+          project: 'Avantor',
+          objective: 'Finish the camera delivery package.',
+          status: 'active'
+        },
+        {
+          mission_id: 'mission:albany',
+          issue_id: 'priority:albany',
+          evidence_fingerprint: 'evidence-2',
+          project: 'Albany',
+          objective: 'Confirm the delivery route.',
+          status: 'waiting_for_decision',
+          user_request: {
+            dispatch_id: 'dispatch:albany',
+            instruction: 'Choose direct delivery or partner delivery.',
+            choices: [
+              {
+                id: 'direct',
+                label: 'Direct',
+                kind: 'decision',
+                fields: []
+              }
+            ]
+          }
+        }
+      ],
+      completed_today: [
+        {
+          mission_id: 'mission:done',
+          issue_id: 'priority:done',
+          evidence_fingerprint: 'evidence-3',
+          project: 'Aventix',
+          objective: 'Repair the data export.',
+          status: 'completed',
+          destinations: [
+            {
+              type: 'local_commit',
+              mode: 'none',
+              label: 'Aventix local commit',
+              reference: 'abc123',
+              location: 'Aventix',
+              verified: true
+            }
+          ]
+        }
+      ]
+    }
+  });
+
+  assert.equal(snapshot.missions.activeCount, 2);
+  assert.equal(snapshot.missions.primary.currentStep.status, 'running');
+  assert.equal(snapshot.missions.primary.stepCount, 2);
+  assert.equal(
+    snapshot.missions.active[1].userRequest.dispatchId,
+    'dispatch:albany'
+  );
+  assert.equal(
+    snapshot.missions.active[1].userRequest.choices[0].label,
+    'Direct'
+  );
+  assert.equal(snapshot.missions.completedToday[0].destinations[0].type, 'local_commit');
+  assert.equal(snapshot.missions.budget.stepsRemaining, 3);
+});
+
 test('normalizes concise action-first company results', () => {
   const snapshot = normalizeCompanyOperatorSnapshot({
     schema_version: 1,
@@ -452,7 +549,8 @@ test('builds an expiring allowlisted command without source content', () => {
     snapshot: { stateVersion: 'state-1' },
     target: {
       issueId: 'priority:avantor',
-      evidenceFingerprint: 'evidence-1'
+      evidenceFingerprint: 'evidence-1',
+      missionId: 'mission:avantor'
     },
     params: { note: 'Focus on the pricing assumptions.' },
     now: new Date('2026-08-03T12:00:00.000Z')
@@ -461,6 +559,7 @@ test('builds an expiring allowlisted command without source content', () => {
   assert.equal(command.source, 'timekeeper_mobile');
   assert.equal(command.action, 'work_next');
   assert.equal(command.target.issue_id, 'priority:avantor');
+  assert.equal(command.target.mission_id, 'mission:avantor');
   assert.equal(command.params.note, 'Focus on the pricing assumptions.');
   assert.equal(command.expires_at, '2026-08-05T12:00:00.000Z');
   assert.doesNotMatch(JSON.stringify(command), /email.body|slack.message/i);


### PR DESCRIPTION
## What changed

- Added persistent Company Operator mission normalization and steering to the mobile TimeKeeper app.
- Presents `Working now`, `Completed for you`, `Needs you`, and `Up next` in action-first order.
- Added Continue, Add direction, Pause, and Already handled controls with duplicate-command prevention.
- Shows verified output destinations and a concise daily time-saved scorecard while keeping technical details collapsed.
- Updated the service-worker cache version and mobile browser coverage.

## Why

The previous Company tab exposed one-shot operator notes that were hard to interpret and did not make ongoing work or its destination clear. The new flow shows what Codex is actually doing, what it completed, and the one decision Henrik must make when work genuinely cannot continue.

## Verification

- ESLint
- TypeScript check
- 64 unit tests
- 58 Playwright smoke tests
- Dedicated 390x844 mobile Company mission flow