### PR TITLE
Make workout scoring modality-aware

### DIFF
--- a/assets/strava.json
+++ b/assets/strava.json
@@ -1,10 +1,50 @@
 {
-  "updated_utc": "2026-08-10T08:03:49.821043+00:00",
+  "updated_utc": "2026-08-10T11:44:53.136389+00:00",
+  "score_model_version": 2,
   "activities": [
+    {
+      "id": 19677954071,
+      "name": "Morning Weight Training",
+      "type": "WeightTraining",
+      "sport_type": "WeightTraining",
+      "start_date": "2026-08-10T07:33:12Z",
+      "distance_km": 0.0,
+      "moving_time_min": 68.9,
+      "elapsed_time_min": 68.9,
+      "total_elevation_gain_m": 0,
+      "avg_hr": 125.7,
+      "max_hr": 179.0,
+      "reported_exertion": null,
+      "avg_speed_kmh": null,
+      "url": "https://www.strava.com/activities/19677954071",
+      "score_model_version": 2,
+      "score_features": {
+        "version": 2,
+        "source": "summary",
+        "active_minutes": 68.93,
+        "effective_active_minutes": 68.93,
+        "strength_minutes": 68.93,
+        "strength_block_minutes": 68.93,
+        "cardio_zone_minutes": [
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0
+        ],
+        "cardio_block_minutes": 0.0,
+        "strength_density": 0.0,
+        "strength_factor": 1.0,
+        "work_recovery_cycles": 0,
+        "hr_max_reference": 190.0,
+        "stream_status": "deferred"
+      }
+    },
     {
       "id": 19565243772,
       "name": "Morning Weight Training",
       "type": "WeightTraining",
+      "sport_type": "WeightTraining",
       "start_date": "2026-08-02T06:32:07Z",
       "distance_km": 0.0,
       "moving_time_min": 70.5,
@@ -15,14 +55,34 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/19565243772",
-      "estimated_exertion": 3.06,
-      "exertion": null,
-      "faulty": false
+      "score_model_version": 2,
+      "score_features": {
+        "version": 2,
+        "source": "summary",
+        "active_minutes": 70.55,
+        "effective_active_minutes": 70.55,
+        "strength_minutes": 70.55,
+        "strength_block_minutes": 70.55,
+        "cardio_zone_minutes": [
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0
+        ],
+        "cardio_block_minutes": 0.0,
+        "strength_density": 0.0,
+        "strength_factor": 1.0,
+        "work_recovery_cycles": 0,
+        "hr_max_reference": 190.0,
+        "stream_status": "deferred"
+      }
     },
     {
       "id": 19543427455,
       "name": "Afternoon Weight Training",
       "type": "WeightTraining",
+      "sport_type": "WeightTraining",
       "start_date": "2026-07-31T12:58:47Z",
       "distance_km": 0.0,
       "moving_time_min": 101.2,
@@ -33,14 +93,34 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/19543427455",
-      "estimated_exertion": 3.96,
-      "exertion": null,
-      "faulty": false
+      "score_model_version": 2,
+      "score_features": {
+        "version": 2,
+        "source": "summary",
+        "active_minutes": 101.18,
+        "effective_active_minutes": 101.18,
+        "strength_minutes": 101.18,
+        "strength_block_minutes": 101.18,
+        "cardio_zone_minutes": [
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0
+        ],
+        "cardio_block_minutes": 0.0,
+        "strength_density": 0.0,
+        "strength_factor": 1.0,
+        "work_recovery_cycles": 0,
+        "hr_max_reference": 190.0,
+        "stream_status": "deferred"
+      }
     },
     {
       "id": 19496641814,
       "name": "Morning Weight Training",
       "type": "WeightTraining",
+      "sport_type": "WeightTraining",
       "start_date": "2026-07-28T07:42:57Z",
       "distance_km": 0.0,
       "moving_time_min": 83.4,
@@ -51,14 +131,34 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/19496641814",
-      "estimated_exertion": 3.32,
-      "exertion": null,
-      "faulty": false
+      "score_model_version": 2,
+      "score_features": {
+        "version": 2,
+        "source": "summary",
+        "active_minutes": 83.43,
+        "effective_active_minutes": 83.43,
+        "strength_minutes": 83.43,
+        "strength_block_minutes": 83.43,
+        "cardio_zone_minutes": [
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0
+        ],
+        "cardio_block_minutes": 0.0,
+        "strength_density": 0.0,
+        "strength_factor": 1.0,
+        "work_recovery_cycles": 0,
+        "hr_max_reference": 190.0,
+        "stream_status": "deferred"
+      }
     },
     {
       "id": 19468811618,
       "name": "Morning Weight Training",
       "type": "WeightTraining",
+      "sport_type": "WeightTraining",
       "start_date": "2026-07-26T07:09:49Z",
       "distance_km": 0.0,
       "moving_time_min": 90.4,
@@ -69,14 +169,34 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/19468811618",
-      "estimated_exertion": 4.11,
-      "exertion": null,
-      "faulty": false
+      "score_model_version": 2,
+      "score_features": {
+        "version": 2,
+        "source": "summary",
+        "active_minutes": 90.4,
+        "effective_active_minutes": 90.4,
+        "strength_minutes": 90.4,
+        "strength_block_minutes": 90.4,
+        "cardio_zone_minutes": [
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0
+        ],
+        "cardio_block_minutes": 0.0,
+        "strength_density": 0.0,
+        "strength_factor": 1.0,
+        "work_recovery_cycles": 0,
+        "hr_max_reference": 190.0,
+        "stream_status": "deferred"
+      }
     },
     {
       "id": 19428791555,
       "name": "Morning Weight Training",
       "type": "WeightTraining",
+      "sport_type": "WeightTraining",
       "start_date": "2026-07-23T08:03:24Z",
       "distance_km": 0.0,
       "moving_time_min": 67.0,
@@ -87,14 +207,34 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/19428791555",
-      "estimated_exertion": 3.3,
-      "exertion": null,
-      "faulty": false
+      "score_model_version": 2,
+      "score_features": {
+        "version": 2,
+        "source": "summary",
+        "active_minutes": 66.95,
+        "effective_active_minutes": 66.95,
+        "strength_minutes": 66.95,
+        "strength_block_minutes": 66.95,
+        "cardio_zone_minutes": [
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0
+        ],
+        "cardio_block_minutes": 0.0,
+        "strength_density": 0.0,
+        "strength_factor": 1.0,
+        "work_recovery_cycles": 0,
+        "hr_max_reference": 190.0,
+        "stream_status": "deferred"
+      }
     },
     {
       "id": 19394164627,
       "name": "Evening Weight Training",
       "type": "WeightTraining",
+      "sport_type": "WeightTraining",
       "start_date": "2026-07-20T17:25:50Z",
       "distance_km": 0.0,
       "moving_time_min": 195.9,
@@ -105,14 +245,34 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/19394164627",
-      "estimated_exertion": 8.64,
-      "exertion": null,
-      "faulty": false
+      "score_model_version": 2,
+      "score_features": {
+        "version": 2,
+        "source": "summary",
+        "active_minutes": 195.88,
+        "effective_active_minutes": 195.88,
+        "strength_minutes": 195.88,
+        "strength_block_minutes": 195.88,
+        "cardio_zone_minutes": [
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0
+        ],
+        "cardio_block_minutes": 0.0,
+        "strength_density": 0.0,
+        "strength_factor": 1.0,
+        "work_recovery_cycles": 0,
+        "hr_max_reference": 190.0,
+        "stream_status": "deferred"
+      }
     },
     {
       "id": 19373044429,
       "name": "Lunch Weight Training",
       "type": "WeightTraining",
+      "sport_type": "WeightTraining",
       "start_date": "2026-07-19T09:15:45Z",
       "distance_km": 0.0,
       "moving_time_min": 2.4,
@@ -123,14 +283,34 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/19373044429",
-      "estimated_exertion": 0.13,
-      "exertion": null,
-      "faulty": false
+      "score_model_version": 2,
+      "score_features": {
+        "version": 2,
+        "source": "summary",
+        "active_minutes": 2.37,
+        "effective_active_minutes": 2.37,
+        "strength_minutes": 2.37,
+        "strength_block_minutes": 2.37,
+        "cardio_zone_minutes": [
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0
+        ],
+        "cardio_block_minutes": 0.0,
+        "strength_density": 0.0,
+        "strength_factor": 1.0,
+        "work_recovery_cycles": 0,
+        "hr_max_reference": 190.0,
+        "stream_status": "deferred"
+      }
     },
     {
       "id": 19309261580,
       "name": "Afternoon Weight Training",
       "type": "WeightTraining",
+      "sport_type": "WeightTraining",
       "start_date": "2026-07-14T11:57:15Z",
       "distance_km": 0.0,
       "moving_time_min": 84.9,
@@ -141,14 +321,34 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/19309261580",
-      "estimated_exertion": 3.84,
-      "exertion": null,
-      "faulty": false
+      "score_model_version": 2,
+      "score_features": {
+        "version": 2,
+        "source": "summary",
+        "active_minutes": 84.87,
+        "effective_active_minutes": 84.87,
+        "strength_minutes": 84.87,
+        "strength_block_minutes": 84.87,
+        "cardio_zone_minutes": [
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0
+        ],
+        "cardio_block_minutes": 0.0,
+        "strength_density": 0.0,
+        "strength_factor": 1.0,
+        "work_recovery_cycles": 0,
+        "hr_max_reference": 190.0,
+        "stream_status": "deferred"
+      }
     },
     {
       "id": 19254361613,
       "name": "Lunch Weight Training",
       "type": "WeightTraining",
+      "sport_type": "WeightTraining",
       "start_date": "2026-07-10T09:55:50Z",
       "distance_km": 0.0,
       "moving_time_min": 70.1,
@@ -159,14 +359,34 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/19254361613",
-      "estimated_exertion": 3.24,
-      "exertion": null,
-      "faulty": false
+      "score_model_version": 2,
+      "score_features": {
+        "version": 2,
+        "source": "summary",
+        "active_minutes": 70.08,
+        "effective_active_minutes": 70.08,
+        "strength_minutes": 70.08,
+        "strength_block_minutes": 70.08,
+        "cardio_zone_minutes": [
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0
+        ],
+        "cardio_block_minutes": 0.0,
+        "strength_density": 0.0,
+        "strength_factor": 1.0,
+        "work_recovery_cycles": 0,
+        "hr_max_reference": 190.0,
+        "stream_status": "deferred"
+      }
     },
     {
       "id": 19212827958,
       "name": "Lunch Weight Training",
       "type": "WeightTraining",
+      "sport_type": "WeightTraining",
       "start_date": "2026-07-07T10:01:39Z",
       "distance_km": 0.0,
       "moving_time_min": 67.5,
@@ -177,14 +397,34 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/19212827958",
-      "estimated_exertion": 3.19,
-      "exertion": null,
-      "faulty": false
+      "score_model_version": 2,
+      "score_features": {
+        "version": 2,
+        "source": "summary",
+        "active_minutes": 67.53,
+        "effective_active_minutes": 67.53,
+        "strength_minutes": 67.53,
+        "strength_block_minutes": 67.53,
+        "cardio_zone_minutes": [
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0
+        ],
+        "cardio_block_minutes": 0.0,
+        "strength_density": 0.0,
+        "strength_factor": 1.0,
+        "work_recovery_cycles": 0,
+        "hr_max_reference": 190.0,
+        "stream_status": "deferred"
+      }
     },
     {
       "id": 19174735579,
       "name": "Lunch Weight Training",
       "type": "WeightTraining",
+      "sport_type": "WeightTraining",
       "start_date": "2026-07-04T09:59:26Z",
       "distance_km": 0.0,
       "moving_time_min": 80.6,
@@ -195,14 +435,34 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/19174735579",
-      "estimated_exertion": 3.61,
-      "exertion": null,
-      "faulty": false
+      "score_model_version": 2,
+      "score_features": {
+        "version": 2,
+        "source": "summary",
+        "active_minutes": 80.57,
+        "effective_active_minutes": 80.57,
+        "strength_minutes": 80.57,
+        "strength_block_minutes": 80.57,
+        "cardio_zone_minutes": [
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0
+        ],
+        "cardio_block_minutes": 0.0,
+        "strength_density": 0.0,
+        "strength_factor": 1.0,
+        "work_recovery_cycles": 0,
+        "hr_max_reference": 190.0,
+        "stream_status": "deferred"
+      }
     },
     {
       "id": 19164481049,
       "name": "Afternoon Workout",
       "type": "Workout",
+      "sport_type": "Workout",
       "start_date": "2026-07-03T14:06:10Z",
       "distance_km": 0.0,
       "moving_time_min": 61.4,
@@ -213,14 +473,34 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/19164481049",
-      "estimated_exertion": 2.85,
-      "exertion": null,
-      "faulty": false
+      "score_model_version": 2,
+      "score_features": {
+        "version": 2,
+        "source": "summary",
+        "active_minutes": 61.35,
+        "effective_active_minutes": 61.35,
+        "strength_minutes": 46.01,
+        "strength_block_minutes": 46.01,
+        "cardio_zone_minutes": [
+          15.34,
+          0.0,
+          0.0,
+          0.0,
+          0.0
+        ],
+        "cardio_block_minutes": 15.34,
+        "strength_density": 0.25,
+        "strength_factor": 1.0,
+        "work_recovery_cycles": 0,
+        "hr_max_reference": 190.0,
+        "stream_status": "deferred"
+      }
     },
     {
       "id": 19135647103,
       "name": "Lunch Weight Training",
       "type": "WeightTraining",
+      "sport_type": "WeightTraining",
       "start_date": "2026-07-01T09:49:39Z",
       "distance_km": 0.0,
       "moving_time_min": 76.0,
@@ -231,14 +511,34 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/19135647103",
-      "estimated_exertion": 3.5,
-      "exertion": null,
-      "faulty": false
+      "score_model_version": 2,
+      "score_features": {
+        "version": 2,
+        "source": "summary",
+        "active_minutes": 75.97,
+        "effective_active_minutes": 75.97,
+        "strength_minutes": 75.97,
+        "strength_block_minutes": 75.97,
+        "cardio_zone_minutes": [
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0
+        ],
+        "cardio_block_minutes": 0.0,
+        "strength_density": 0.0,
+        "strength_factor": 1.0,
+        "work_recovery_cycles": 0,
+        "hr_max_reference": 190.0,
+        "stream_status": "deferred"
+      }
     },
     {
       "id": 19108635699,
       "name": "Lunch Weight Training",
       "type": "WeightTraining",
+      "sport_type": "WeightTraining",
       "start_date": "2026-06-29T09:36:18Z",
       "distance_km": 0.0,
       "moving_time_min": 83.1,
@@ -249,14 +549,34 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/19108635699",
-      "estimated_exertion": 3.7,
-      "exertion": null,
-      "faulty": false
+      "score_model_version": 2,
+      "score_features": {
+        "version": 2,
+        "source": "summary",
+        "active_minutes": 83.12,
+        "effective_active_minutes": 83.12,
+        "strength_minutes": 83.12,
+        "strength_block_minutes": 83.12,
+        "cardio_zone_minutes": [
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0
+        ],
+        "cardio_block_minutes": 0.0,
+        "strength_density": 0.0,
+        "strength_factor": 1.0,
+        "work_recovery_cycles": 0,
+        "hr_max_reference": 190.0,
+        "stream_status": "deferred"
+      }
     },
     {
       "id": 19087019169,
       "name": "Afternoon Ride",
       "type": "Ride",
+      "sport_type": "Ride",
       "start_date": "2026-06-27T12:28:39Z",
       "distance_km": 4.09,
       "moving_time_min": 37.2,
@@ -267,14 +587,34 @@
       "reported_exertion": null,
       "avg_speed_kmh": 6.58,
       "url": "https://www.strava.com/activities/19087019169",
-      "estimated_exertion": 6.76,
-      "exertion": null,
-      "faulty": false
+      "score_model_version": 2,
+      "score_features": {
+        "version": 2,
+        "source": "summary",
+        "active_minutes": 37.25,
+        "effective_active_minutes": 37.25,
+        "strength_minutes": 0.0,
+        "strength_block_minutes": 0.0,
+        "cardio_zone_minutes": [
+          37.25,
+          0.0,
+          0.0,
+          0.0,
+          0.0
+        ],
+        "cardio_block_minutes": 37.25,
+        "strength_density": 0.0,
+        "strength_factor": 1.0,
+        "work_recovery_cycles": 0,
+        "hr_max_reference": 190.0,
+        "stream_status": "deferred"
+      }
     },
     {
       "id": 19083850819,
       "name": "Lunch Weight Training",
       "type": "WeightTraining",
+      "sport_type": "WeightTraining",
       "start_date": "2026-06-27T09:17:53Z",
       "distance_km": 0.0,
       "moving_time_min": 71.1,
@@ -285,14 +625,34 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/19083850819",
-      "estimated_exertion": 3.22,
-      "exertion": null,
-      "faulty": false
+      "score_model_version": 2,
+      "score_features": {
+        "version": 2,
+        "source": "summary",
+        "active_minutes": 71.08,
+        "effective_active_minutes": 71.08,
+        "strength_minutes": 71.08,
+        "strength_block_minutes": 71.08,
+        "cardio_zone_minutes": [
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0
+        ],
+        "cardio_block_minutes": 0.0,
+        "strength_density": 0.0,
+        "strength_factor": 1.0,
+        "work_recovery_cycles": 0,
+        "hr_max_reference": 190.0,
+        "stream_status": "deferred"
+      }
     },
     {
       "id": 19073380863,
       "name": "Afternoon Ride",
       "type": "Ride",
+      "sport_type": "Ride",
       "start_date": "2026-06-26T11:29:51Z",
       "distance_km": 0.05,
       "moving_time_min": 0.5,
@@ -303,14 +663,34 @@
       "reported_exertion": null,
       "avg_speed_kmh": 5.76,
       "url": "https://www.strava.com/activities/19073380863",
-      "estimated_exertion": 2.83,
-      "exertion": null,
-      "faulty": false
+      "score_model_version": 2,
+      "score_features": {
+        "version": 2,
+        "source": "summary",
+        "active_minutes": 0.5,
+        "effective_active_minutes": 0.5,
+        "strength_minutes": 0.0,
+        "strength_block_minutes": 0.0,
+        "cardio_zone_minutes": [
+          0.5,
+          0.0,
+          0.0,
+          0.0,
+          0.0
+        ],
+        "cardio_block_minutes": 0.5,
+        "strength_density": 0.0,
+        "strength_factor": 1.0,
+        "work_recovery_cycles": 0,
+        "hr_max_reference": 190.0,
+        "stream_status": "deferred"
+      }
     },
     {
       "id": 19047309417,
       "name": "Lunch Weight Training",
       "type": "WeightTraining",
+      "sport_type": "WeightTraining",
       "start_date": "2026-06-24T10:10:43Z",
       "distance_km": 0.0,
       "moving_time_min": 29.1,
@@ -321,14 +701,34 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/19047309417",
-      "estimated_exertion": 1.44,
-      "exertion": null,
-      "faulty": false
+      "score_model_version": 2,
+      "score_features": {
+        "version": 2,
+        "source": "summary",
+        "active_minutes": 29.15,
+        "effective_active_minutes": 29.15,
+        "strength_minutes": 29.15,
+        "strength_block_minutes": 29.15,
+        "cardio_zone_minutes": [
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0
+        ],
+        "cardio_block_minutes": 0.0,
+        "strength_density": 0.0,
+        "strength_factor": 1.0,
+        "work_recovery_cycles": 0,
+        "hr_max_reference": 190.0,
+        "stream_status": "deferred"
+      }
     },
     {
       "id": 19021090341,
       "name": "Lunch Weight Training",
       "type": "WeightTraining",
+      "sport_type": "WeightTraining",
       "start_date": "2026-06-22T10:45:00Z",
       "distance_km": 0.0,
       "moving_time_min": 68.8,
@@ -339,14 +739,34 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/19021090341",
-      "estimated_exertion": 3.18,
-      "exertion": null,
-      "faulty": false
+      "score_model_version": 2,
+      "score_features": {
+        "version": 2,
+        "source": "summary",
+        "active_minutes": 68.77,
+        "effective_active_minutes": 68.77,
+        "strength_minutes": 68.77,
+        "strength_block_minutes": 68.77,
+        "cardio_zone_minutes": [
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0
+        ],
+        "cardio_block_minutes": 0.0,
+        "strength_density": 0.0,
+        "strength_factor": 1.0,
+        "work_recovery_cycles": 0,
+        "hr_max_reference": 190.0,
+        "stream_status": "deferred"
+      }
     },
     {
       "id": 18969077347,
       "name": "Morning Weight Training",
       "type": "WeightTraining",
+      "sport_type": "WeightTraining",
       "start_date": "2026-06-18T08:58:26Z",
       "distance_km": 0.0,
       "moving_time_min": 62.9,
@@ -357,14 +777,34 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/18969077347",
-      "estimated_exertion": 2.92,
-      "exertion": null,
-      "faulty": false
+      "score_model_version": 2,
+      "score_features": {
+        "version": 2,
+        "source": "summary",
+        "active_minutes": 62.87,
+        "effective_active_minutes": 62.87,
+        "strength_minutes": 62.87,
+        "strength_block_minutes": 62.87,
+        "cardio_zone_minutes": [
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0
+        ],
+        "cardio_block_minutes": 0.0,
+        "strength_density": 0.0,
+        "strength_factor": 1.0,
+        "work_recovery_cycles": 0,
+        "hr_max_reference": 190.0,
+        "stream_status": "deferred"
+      }
     },
     {
       "id": 18928485523,
       "name": "Afternoon Weight Training",
       "type": "WeightTraining",
+      "sport_type": "WeightTraining",
       "start_date": "2026-06-15T11:05:47Z",
       "distance_km": 0.0,
       "moving_time_min": 82.0,
@@ -375,14 +815,34 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/18928485523",
-      "estimated_exertion": 3.6,
-      "exertion": null,
-      "faulty": false
+      "score_model_version": 2,
+      "score_features": {
+        "version": 2,
+        "source": "summary",
+        "active_minutes": 82.0,
+        "effective_active_minutes": 82.0,
+        "strength_minutes": 82.0,
+        "strength_block_minutes": 82.0,
+        "cardio_zone_minutes": [
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0
+        ],
+        "cardio_block_minutes": 0.0,
+        "strength_density": 0.0,
+        "strength_factor": 1.0,
+        "work_recovery_cycles": 0,
+        "hr_max_reference": 190.0,
+        "stream_status": "deferred"
+      }
     },
     {
       "id": 18901369698,
       "name": "Lunch Ride",
       "type": "Ride",
+      "sport_type": "Ride",
       "start_date": "2026-06-13T09:46:36Z",
       "distance_km": 0.0,
       "moving_time_min": 53.0,
@@ -393,14 +853,34 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/18901369698",
-      "estimated_exertion": 2.6,
-      "exertion": null,
-      "faulty": false
+      "score_model_version": 2,
+      "score_features": {
+        "version": 2,
+        "source": "summary",
+        "active_minutes": 53.02,
+        "effective_active_minutes": 53.02,
+        "strength_minutes": 0.0,
+        "strength_block_minutes": 0.0,
+        "cardio_zone_minutes": [
+          53.02,
+          0.0,
+          0.0,
+          0.0,
+          0.0
+        ],
+        "cardio_block_minutes": 53.02,
+        "strength_density": 0.0,
+        "strength_factor": 1.0,
+        "work_recovery_cycles": 0,
+        "hr_max_reference": 190.0,
+        "stream_status": "deferred"
+      }
     },
     {
       "id": 18890831520,
       "name": "Afternoon Weight Training",
       "type": "WeightTraining",
+      "sport_type": "WeightTraining",
       "start_date": "2026-06-12T12:27:51Z",
       "distance_km": 0.0,
       "moving_time_min": 76.0,
@@ -411,14 +891,34 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/18890831520",
-      "estimated_exertion": 3.66,
-      "exertion": null,
-      "faulty": false
+      "score_model_version": 2,
+      "score_features": {
+        "version": 2,
+        "source": "summary",
+        "active_minutes": 75.98,
+        "effective_active_minutes": 75.98,
+        "strength_minutes": 75.98,
+        "strength_block_minutes": 75.98,
+        "cardio_zone_minutes": [
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0
+        ],
+        "cardio_block_minutes": 0.0,
+        "strength_density": 0.0,
+        "strength_factor": 1.0,
+        "work_recovery_cycles": 0,
+        "hr_max_reference": 190.0,
+        "stream_status": "deferred"
+      }
     },
     {
       "id": 18862132250,
       "name": "Morning Weight Training",
       "type": "WeightTraining",
+      "sport_type": "WeightTraining",
       "start_date": "2026-06-10T08:41:26Z",
       "distance_km": 0.0,
       "moving_time_min": 68.9,
@@ -429,14 +929,34 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/18862132250",
-      "estimated_exertion": 3.05,
-      "exertion": null,
-      "faulty": false
+      "score_model_version": 2,
+      "score_features": {
+        "version": 2,
+        "source": "summary",
+        "active_minutes": 68.93,
+        "effective_active_minutes": 68.93,
+        "strength_minutes": 68.93,
+        "strength_block_minutes": 68.93,
+        "cardio_zone_minutes": [
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0
+        ],
+        "cardio_block_minutes": 0.0,
+        "strength_density": 0.0,
+        "strength_factor": 1.0,
+        "work_recovery_cycles": 0,
+        "hr_max_reference": 190.0,
+        "stream_status": "deferred"
+      }
     },
     {
       "id": 18836320528,
       "name": "Afternoon Weight Training",
       "type": "WeightTraining",
+      "sport_type": "WeightTraining",
       "start_date": "2026-06-08T11:46:45Z",
       "distance_km": 0.0,
       "moving_time_min": 72.8,
@@ -447,14 +967,34 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/18836320528",
-      "estimated_exertion": 3.31,
-      "exertion": null,
-      "faulty": false
+      "score_model_version": 2,
+      "score_features": {
+        "version": 2,
+        "source": "streams",
+        "active_minutes": 72.23,
+        "effective_active_minutes": 72.23,
+        "strength_minutes": 72.23,
+        "strength_block_minutes": 72.23,
+        "cardio_zone_minutes": [
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0
+        ],
+        "cardio_block_minutes": 0.0,
+        "strength_density": 0.811,
+        "strength_factor": 1.0,
+        "work_recovery_cycles": 1,
+        "hr_max_reference": 190.0,
+        "stream_status": "complete"
+      }
     },
     {
       "id": 18822884521,
       "name": "Lunch Weight Training",
       "type": "WeightTraining",
+      "sport_type": "WeightTraining",
       "start_date": "2026-06-07T10:24:11Z",
       "distance_km": 0.0,
       "moving_time_min": 88.6,
@@ -465,14 +1005,34 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/18822884521",
-      "estimated_exertion": 3.9,
-      "exertion": null,
-      "faulty": false
+      "score_model_version": 2,
+      "score_features": {
+        "version": 2,
+        "source": "streams",
+        "active_minutes": 80.72,
+        "effective_active_minutes": 80.72,
+        "strength_minutes": 80.72,
+        "strength_block_minutes": 80.72,
+        "cardio_zone_minutes": [
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0
+        ],
+        "cardio_block_minutes": 0.0,
+        "strength_density": 0.883,
+        "strength_factor": 1.0,
+        "work_recovery_cycles": 3,
+        "hr_max_reference": 190.0,
+        "stream_status": "complete"
+      }
     },
     {
       "id": 18739736076,
       "name": "Lunch Weight Training",
       "type": "WeightTraining",
+      "sport_type": "WeightTraining",
       "start_date": "2026-06-01T09:12:25Z",
       "distance_km": 0.0,
       "moving_time_min": 60.3,
@@ -483,14 +1043,34 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/18739736076",
-      "estimated_exertion": 2.79,
-      "exertion": null,
-      "faulty": false
+      "score_model_version": 2,
+      "score_features": {
+        "version": 2,
+        "source": "streams",
+        "active_minutes": 54.22,
+        "effective_active_minutes": 54.22,
+        "strength_minutes": 54.22,
+        "strength_block_minutes": 54.22,
+        "cardio_zone_minutes": [
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0
+        ],
+        "cardio_block_minutes": 0.0,
+        "strength_density": 0.93,
+        "strength_factor": 1.0,
+        "work_recovery_cycles": 1,
+        "hr_max_reference": 190.0,
+        "stream_status": "complete"
+      }
     },
     {
       "id": 18699501208,
       "name": "Morning Weight Training",
       "type": "WeightTraining",
+      "sport_type": "WeightTraining",
       "start_date": "2026-05-29T07:43:21Z",
       "distance_km": 0.0,
       "moving_time_min": 70.2,
@@ -501,14 +1081,34 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/18699501208",
-      "estimated_exertion": 3.19,
-      "exertion": null,
-      "faulty": false
+      "score_model_version": 2,
+      "score_features": {
+        "version": 2,
+        "source": "streams",
+        "active_minutes": 59.95,
+        "effective_active_minutes": 59.95,
+        "strength_minutes": 59.95,
+        "strength_block_minutes": 59.95,
+        "cardio_zone_minutes": [
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0
+        ],
+        "cardio_block_minutes": 0.0,
+        "strength_density": 0.883,
+        "strength_factor": 1.0,
+        "work_recovery_cycles": 5,
+        "hr_max_reference": 190.0,
+        "stream_status": "complete"
+      }
     },
     {
       "id": 18688966943,
       "name": "Afternoon Ride",
       "type": "Ride",
+      "sport_type": "Ride",
       "start_date": "2026-05-28T12:29:56Z",
       "distance_km": 0.0,
       "moving_time_min": 45.9,
@@ -519,14 +1119,34 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/18688966943",
-      "estimated_exertion": 2.0,
-      "exertion": null,
-      "faulty": false
+      "score_model_version": 2,
+      "score_features": {
+        "version": 2,
+        "source": "streams",
+        "active_minutes": 45.65,
+        "effective_active_minutes": 45.65,
+        "strength_minutes": 45.65,
+        "strength_block_minutes": 45.65,
+        "cardio_zone_minutes": [
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0
+        ],
+        "cardio_block_minutes": 0.0,
+        "strength_density": 0.743,
+        "strength_factor": 1.0,
+        "work_recovery_cycles": 1,
+        "hr_max_reference": 190.0,
+        "stream_status": "complete"
+      }
     },
     {
       "id": 18672250731,
       "name": "Morning Weight Training",
       "type": "WeightTraining",
+      "sport_type": "WeightTraining",
       "start_date": "2026-05-27T08:10:59Z",
       "distance_km": 0.0,
       "moving_time_min": 59.5,
@@ -537,14 +1157,34 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/18672250731",
-      "estimated_exertion": 2.78,
-      "exertion": null,
-      "faulty": false
+      "score_model_version": 2,
+      "score_features": {
+        "version": 2,
+        "source": "streams",
+        "active_minutes": 52.17,
+        "effective_active_minutes": 52.17,
+        "strength_minutes": 52.17,
+        "strength_block_minutes": 52.17,
+        "cardio_zone_minutes": [
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0
+        ],
+        "cardio_block_minutes": 0.0,
+        "strength_density": 0.923,
+        "strength_factor": 1.0,
+        "work_recovery_cycles": 1,
+        "hr_max_reference": 190.0,
+        "stream_status": "complete"
+      }
     },
     {
       "id": 18646098611,
       "name": "Lunch Weight Training",
       "type": "WeightTraining",
+      "sport_type": "WeightTraining",
       "start_date": "2026-05-25T09:19:44Z",
       "distance_km": 0.0,
       "moving_time_min": 108.5,
@@ -555,14 +1195,34 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/18646098611",
-      "estimated_exertion": 4.93,
-      "exertion": null,
-      "faulty": false
+      "score_model_version": 2,
+      "score_features": {
+        "version": 2,
+        "source": "streams",
+        "active_minutes": 100.97,
+        "effective_active_minutes": 100.97,
+        "strength_minutes": 100.97,
+        "strength_block_minutes": 100.97,
+        "cardio_zone_minutes": [
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0
+        ],
+        "cardio_block_minutes": 0.0,
+        "strength_density": 0.944,
+        "strength_factor": 1.0,
+        "work_recovery_cycles": 2,
+        "hr_max_reference": 190.0,
+        "stream_status": "complete"
+      }
     },
     {
       "id": 18634538171,
       "name": "Lunch Weight Training",
       "type": "WeightTraining",
+      "sport_type": "WeightTraining",
       "start_date": "2026-05-24T10:23:36Z",
       "distance_km": 0.0,
       "moving_time_min": 79.9,
@@ -573,14 +1233,34 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/18634538171",
-      "estimated_exertion": 3.53,
-      "exertion": null,
-      "faulty": false
+      "score_model_version": 2,
+      "score_features": {
+        "version": 2,
+        "source": "streams",
+        "active_minutes": 72.53,
+        "effective_active_minutes": 72.53,
+        "strength_minutes": 72.53,
+        "strength_block_minutes": 72.53,
+        "cardio_zone_minutes": [
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0
+        ],
+        "cardio_block_minutes": 0.0,
+        "strength_density": 0.861,
+        "strength_factor": 1.0,
+        "work_recovery_cycles": 3,
+        "hr_max_reference": 190.0,
+        "stream_status": "complete"
+      }
     },
     {
       "id": 18579781509,
       "name": "Lunch Weight Training",
       "type": "WeightTraining",
+      "sport_type": "WeightTraining",
       "start_date": "2026-05-20T09:37:05Z",
       "distance_km": 0.0,
       "moving_time_min": 68.6,
@@ -591,14 +1271,34 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/18579781509",
-      "estimated_exertion": 3.13,
-      "exertion": null,
-      "faulty": false
+      "score_model_version": 2,
+      "score_features": {
+        "version": 2,
+        "source": "streams",
+        "active_minutes": 60.87,
+        "effective_active_minutes": 60.87,
+        "strength_minutes": 60.87,
+        "strength_block_minutes": 60.87,
+        "cardio_zone_minutes": [
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0
+        ],
+        "cardio_block_minutes": 0.0,
+        "strength_density": 0.79,
+        "strength_factor": 1.0,
+        "work_recovery_cycles": 5,
+        "hr_max_reference": 190.0,
+        "stream_status": "complete"
+      }
     },
     {
       "id": 18552772778,
       "name": "Lunch Weight Training",
       "type": "WeightTraining",
+      "sport_type": "WeightTraining",
       "start_date": "2026-05-18T09:26:48Z",
       "distance_km": 0.0,
       "moving_time_min": 67.7,
@@ -609,14 +1309,34 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/18552772778",
-      "estimated_exertion": 3.0,
-      "exertion": null,
-      "faulty": false
+      "score_model_version": 2,
+      "score_features": {
+        "version": 2,
+        "source": "streams",
+        "active_minutes": 61.97,
+        "effective_active_minutes": 61.97,
+        "strength_minutes": 61.97,
+        "strength_block_minutes": 61.97,
+        "cardio_zone_minutes": [
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0
+        ],
+        "cardio_block_minutes": 0.0,
+        "strength_density": 0.683,
+        "strength_factor": 1.0,
+        "work_recovery_cycles": 4,
+        "hr_max_reference": 190.0,
+        "stream_status": "complete"
+      }
     },
     {
       "id": 18542816835,
       "name": "Lunch Weight Training",
       "type": "WeightTraining",
+      "sport_type": "WeightTraining",
       "start_date": "2026-05-17T10:59:54Z",
       "distance_km": 0.0,
       "moving_time_min": 122.6,
@@ -627,14 +1347,34 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/18542816835",
-      "estimated_exertion": 5.1,
-      "exertion": null,
-      "faulty": false
+      "score_model_version": 2,
+      "score_features": {
+        "version": 2,
+        "source": "streams",
+        "active_minutes": 100.27,
+        "effective_active_minutes": 100.27,
+        "strength_minutes": 100.27,
+        "strength_block_minutes": 100.27,
+        "cardio_zone_minutes": [
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0
+        ],
+        "cardio_block_minutes": 0.0,
+        "strength_density": 0.662,
+        "strength_factor": 1.0,
+        "work_recovery_cycles": 4,
+        "hr_max_reference": 190.0,
+        "stream_status": "complete"
+      }
     },
     {
       "id": 18503210740,
       "name": "Lunch Ride",
       "type": "Ride",
+      "sport_type": "Ride",
       "start_date": "2026-05-14T10:59:40Z",
       "distance_km": 0.0,
       "moving_time_min": 66.3,
@@ -645,14 +1385,34 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/18503210740",
-      "estimated_exertion": 3.11,
-      "exertion": null,
-      "faulty": false
+      "score_model_version": 2,
+      "score_features": {
+        "version": 2,
+        "source": "streams",
+        "active_minutes": 66.32,
+        "effective_active_minutes": 66.32,
+        "strength_minutes": 66.32,
+        "strength_block_minutes": 66.32,
+        "cardio_zone_minutes": [
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0
+        ],
+        "cardio_block_minutes": 0.0,
+        "strength_density": 0.949,
+        "strength_factor": 1.0,
+        "work_recovery_cycles": 2,
+        "hr_max_reference": 190.0,
+        "stream_status": "complete"
+      }
     },
     {
       "id": 18487121625,
       "name": "Morning Ride",
       "type": "Ride",
+      "sport_type": "Ride",
       "start_date": "2026-05-13T06:15:52Z",
       "distance_km": 0.0,
       "moving_time_min": 48.7,
@@ -663,14 +1423,34 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/18487121625",
-      "estimated_exertion": 2.22,
-      "exertion": null,
-      "faulty": false
+      "score_model_version": 2,
+      "score_features": {
+        "version": 2,
+        "source": "streams",
+        "active_minutes": 48.47,
+        "effective_active_minutes": 48.47,
+        "strength_minutes": 48.47,
+        "strength_block_minutes": 48.47,
+        "cardio_zone_minutes": [
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0
+        ],
+        "cardio_block_minutes": 0.0,
+        "strength_density": 0.858,
+        "strength_factor": 1.0,
+        "work_recovery_cycles": 3,
+        "hr_max_reference": 190.0,
+        "stream_status": "complete"
+      }
     },
     {
       "id": 18461570151,
       "name": "Morning Weight Training",
       "type": "WeightTraining",
+      "sport_type": "WeightTraining",
       "start_date": "2026-05-11T08:44:12Z",
       "distance_km": 0.0,
       "moving_time_min": 82.5,
@@ -681,14 +1461,34 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/18461570151",
-      "estimated_exertion": 3.71,
-      "exertion": null,
-      "faulty": false
+      "score_model_version": 2,
+      "score_features": {
+        "version": 2,
+        "source": "streams",
+        "active_minutes": 72.55,
+        "effective_active_minutes": 72.55,
+        "strength_minutes": 72.55,
+        "strength_block_minutes": 72.55,
+        "cardio_zone_minutes": [
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0
+        ],
+        "cardio_block_minutes": 0.0,
+        "strength_density": 0.651,
+        "strength_factor": 1.0,
+        "work_recovery_cycles": 9,
+        "hr_max_reference": 190.0,
+        "stream_status": "complete"
+      }
     },
     {
       "id": 18450503927,
       "name": "Lunch Weight Training",
       "type": "WeightTraining",
+      "sport_type": "WeightTraining",
       "start_date": "2026-05-10T09:52:36Z",
       "distance_km": 0.0,
       "moving_time_min": 71.2,
@@ -699,14 +1499,34 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/18450503927",
-      "estimated_exertion": 3.08,
-      "exertion": null,
-      "faulty": false
+      "score_model_version": 2,
+      "score_features": {
+        "version": 2,
+        "source": "streams",
+        "active_minutes": 63.37,
+        "effective_active_minutes": 63.37,
+        "strength_minutes": 63.37,
+        "strength_block_minutes": 63.37,
+        "cardio_zone_minutes": [
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0
+        ],
+        "cardio_block_minutes": 0.0,
+        "strength_density": 0.825,
+        "strength_factor": 1.0,
+        "work_recovery_cycles": 4,
+        "hr_max_reference": 190.0,
+        "stream_status": "complete"
+      }
     },
     {
       "id": 18440178049,
       "name": "Afternoon Ride",
       "type": "Ride",
+      "sport_type": "Ride",
       "start_date": "2026-05-09T13:10:37Z",
       "distance_km": 8.54,
       "moving_time_min": 48.2,
@@ -717,14 +1537,34 @@
       "reported_exertion": null,
       "avg_speed_kmh": 10.62,
       "url": "https://www.strava.com/activities/18440178049",
-      "estimated_exertion": 4.72,
-      "exertion": null,
-      "faulty": false
+      "score_model_version": 2,
+      "score_features": {
+        "version": 2,
+        "source": "streams",
+        "active_minutes": 44.98,
+        "effective_active_minutes": 44.98,
+        "strength_minutes": 0.0,
+        "strength_block_minutes": 0.0,
+        "cardio_zone_minutes": [
+          22.28,
+          19.13,
+          3.57,
+          0.0,
+          0.0
+        ],
+        "cardio_block_minutes": 44.98,
+        "strength_density": 0.0,
+        "strength_factor": 1.0,
+        "work_recovery_cycles": 0,
+        "hr_max_reference": 190.0,
+        "stream_status": "complete"
+      }
     },
     {
       "id": 18425867200,
       "name": "Afternoon Weight Training",
       "type": "WeightTraining",
+      "sport_type": "WeightTraining",
       "start_date": "2026-05-08T12:52:51Z",
       "distance_km": 0.0,
       "moving_time_min": 79.5,
@@ -735,14 +1575,34 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/18425867200",
-      "estimated_exertion": 3.17,
-      "exertion": null,
-      "faulty": false
+      "score_model_version": 2,
+      "score_features": {
+        "version": 2,
+        "source": "streams",
+        "active_minutes": 59.3,
+        "effective_active_minutes": 59.3,
+        "strength_minutes": 59.3,
+        "strength_block_minutes": 59.3,
+        "cardio_zone_minutes": [
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0
+        ],
+        "cardio_block_minutes": 0.0,
+        "strength_density": 0.166,
+        "strength_factor": 1.0,
+        "work_recovery_cycles": 2,
+        "hr_max_reference": 190.0,
+        "stream_status": "complete"
+      }
     },
     {
       "id": 18368921048,
       "name": "Morning Ride",
       "type": "Ride",
+      "sport_type": "Ride",
       "start_date": "2026-05-04T08:19:13Z",
       "distance_km": 0.0,
       "moving_time_min": 38.3,
@@ -753,14 +1613,34 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/18368921048",
-      "estimated_exertion": 1.85,
-      "exertion": null,
-      "faulty": false
+      "score_model_version": 2,
+      "score_features": {
+        "version": 2,
+        "source": "streams",
+        "active_minutes": 38.28,
+        "effective_active_minutes": 38.28,
+        "strength_minutes": 38.28,
+        "strength_block_minutes": 38.28,
+        "cardio_zone_minutes": [
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0
+        ],
+        "cardio_block_minutes": 0.0,
+        "strength_density": 0.925,
+        "strength_factor": 1.0,
+        "work_recovery_cycles": 2,
+        "hr_max_reference": 190.0,
+        "stream_status": "complete"
+      }
     },
     {
       "id": 18330853338,
       "name": "Lunch Weight Training",
       "type": "WeightTraining",
+      "sport_type": "WeightTraining",
       "start_date": "2026-05-01T09:45:57Z",
       "distance_km": 0.0,
       "moving_time_min": 82.9,
@@ -771,14 +1651,34 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/18330853338",
-      "estimated_exertion": 3.64,
-      "exertion": null,
-      "faulty": false
+      "score_model_version": 2,
+      "score_features": {
+        "version": 2,
+        "source": "streams",
+        "active_minutes": 71.35,
+        "effective_active_minutes": 71.35,
+        "strength_minutes": 71.35,
+        "strength_block_minutes": 71.35,
+        "cardio_zone_minutes": [
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0
+        ],
+        "cardio_block_minutes": 0.0,
+        "strength_density": 0.892,
+        "strength_factor": 1.0,
+        "work_recovery_cycles": 4,
+        "hr_max_reference": 190.0,
+        "stream_status": "complete"
+      }
     },
     {
       "id": 18316904403,
       "name": "Lunch Ride",
       "type": "Ride",
+      "sport_type": "Ride",
       "start_date": "2026-04-30T09:12:00Z",
       "distance_km": 0.0,
       "moving_time_min": 56.3,
@@ -789,14 +1689,34 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/18316904403",
-      "estimated_exertion": 2.44,
-      "exertion": null,
-      "faulty": false
+      "score_model_version": 2,
+      "score_features": {
+        "version": 2,
+        "source": "streams",
+        "active_minutes": 56.02,
+        "effective_active_minutes": 56.02,
+        "strength_minutes": 56.02,
+        "strength_block_minutes": 56.02,
+        "cardio_zone_minutes": [
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0
+        ],
+        "cardio_block_minutes": 0.0,
+        "strength_density": 0.648,
+        "strength_factor": 1.0,
+        "work_recovery_cycles": 8,
+        "hr_max_reference": 190.0,
+        "stream_status": "complete"
+      }
     },
     {
       "id": 18303519220,
       "name": "Morning Weight Training",
       "type": "WeightTraining",
+      "sport_type": "WeightTraining",
       "start_date": "2026-04-29T08:44:51Z",
       "distance_km": 0.0,
       "moving_time_min": 73.5,
@@ -807,14 +1727,34 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/18303519220",
-      "estimated_exertion": 3.35,
-      "exertion": null,
-      "faulty": false
+      "score_model_version": 2,
+      "score_features": {
+        "version": 2,
+        "source": "streams",
+        "active_minutes": 72.77,
+        "effective_active_minutes": 72.77,
+        "strength_minutes": 72.77,
+        "strength_block_minutes": 72.77,
+        "cardio_zone_minutes": [
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0
+        ],
+        "cardio_block_minutes": 0.0,
+        "strength_density": 0.652,
+        "strength_factor": 1.0,
+        "work_recovery_cycles": 8,
+        "hr_max_reference": 190.0,
+        "stream_status": "complete"
+      }
     },
     {
       "id": 18275602792,
       "name": "Morning Weight Training",
       "type": "WeightTraining",
+      "sport_type": "WeightTraining",
       "start_date": "2026-04-27T07:46:50Z",
       "distance_km": 0.0,
       "moving_time_min": 75.0,
@@ -825,14 +1765,34 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/18275602792",
-      "estimated_exertion": 3.28,
-      "exertion": null,
-      "faulty": false
+      "score_model_version": 2,
+      "score_features": {
+        "version": 2,
+        "source": "streams",
+        "active_minutes": 66.07,
+        "effective_active_minutes": 66.07,
+        "strength_minutes": 66.07,
+        "strength_block_minutes": 66.07,
+        "cardio_zone_minutes": [
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0
+        ],
+        "cardio_block_minutes": 0.0,
+        "strength_density": 0.782,
+        "strength_factor": 1.0,
+        "work_recovery_cycles": 5,
+        "hr_max_reference": 190.0,
+        "stream_status": "complete"
+      }
     },
     {
       "id": 18265789375,
       "name": "Afternoon Ride",
       "type": "Ride",
+      "sport_type": "Ride",
       "start_date": "2026-04-26T11:32:34Z",
       "distance_km": 0.0,
       "moving_time_min": 80.2,
@@ -843,14 +1803,34 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/18265789375",
-      "estimated_exertion": 3.81,
-      "exertion": null,
-      "faulty": false
+      "score_model_version": 2,
+      "score_features": {
+        "version": 2,
+        "source": "streams",
+        "active_minutes": 74.52,
+        "effective_active_minutes": 74.52,
+        "strength_minutes": 74.52,
+        "strength_block_minutes": 74.52,
+        "cardio_zone_minutes": [
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0
+        ],
+        "cardio_block_minutes": 0.0,
+        "strength_density": 0.766,
+        "strength_factor": 1.0,
+        "work_recovery_cycles": 5,
+        "hr_max_reference": 190.0,
+        "stream_status": "complete"
+      }
     },
     {
       "id": 18251157808,
       "name": "Lunch Weight Training",
       "type": "WeightTraining",
+      "sport_type": "WeightTraining",
       "start_date": "2026-04-25T10:59:39Z",
       "distance_km": 0.0,
       "moving_time_min": 71.7,
@@ -861,14 +1841,34 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/18251157808",
-      "estimated_exertion": 3.11,
-      "exertion": null,
-      "faulty": false
+      "score_model_version": 2,
+      "score_features": {
+        "version": 2,
+        "source": "streams",
+        "active_minutes": 67.73,
+        "effective_active_minutes": 67.73,
+        "strength_minutes": 67.73,
+        "strength_block_minutes": 67.73,
+        "cardio_zone_minutes": [
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0
+        ],
+        "cardio_block_minutes": 0.0,
+        "strength_density": 0.813,
+        "strength_factor": 1.0,
+        "work_recovery_cycles": 3,
+        "hr_max_reference": 190.0,
+        "stream_status": "complete"
+      }
     },
     {
       "id": 18237676512,
       "name": "Lunch Ride",
       "type": "Ride",
+      "sport_type": "Ride",
       "start_date": "2026-04-24T10:31:00Z",
       "distance_km": 0.91,
       "moving_time_min": 8.6,
@@ -879,14 +1879,34 @@
       "reported_exertion": null,
       "avg_speed_kmh": 6.38,
       "url": "https://www.strava.com/activities/18237676512",
-      "estimated_exertion": 2.84,
-      "exertion": null,
-      "faulty": false
+      "score_model_version": 2,
+      "score_features": {
+        "version": 2,
+        "source": "streams",
+        "active_minutes": 59.28,
+        "effective_active_minutes": 59.28,
+        "strength_minutes": 52.12,
+        "strength_block_minutes": 52.12,
+        "cardio_zone_minutes": [
+          0.3,
+          5.67,
+          1.2,
+          0.0,
+          0.0
+        ],
+        "cardio_block_minutes": 7.17,
+        "strength_density": 0.937,
+        "strength_factor": 1.0,
+        "work_recovery_cycles": 2,
+        "hr_max_reference": 190.0,
+        "stream_status": "complete"
+      }
     },
     {
       "id": 18209650193,
       "name": "Lunch Ride",
       "type": "Ride",
+      "sport_type": "Ride",
       "start_date": "2026-04-22T09:44:45Z",
       "distance_km": 0.0,
       "moving_time_min": 49.0,
@@ -897,14 +1917,34 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/18209650193",
-      "estimated_exertion": 2.19,
-      "exertion": null,
-      "faulty": false
+      "score_model_version": 2,
+      "score_features": {
+        "version": 2,
+        "source": "summary",
+        "active_minutes": 48.98,
+        "effective_active_minutes": 48.98,
+        "strength_minutes": 0.0,
+        "strength_block_minutes": 0.0,
+        "cardio_zone_minutes": [
+          0.0,
+          48.98,
+          0.0,
+          0.0,
+          0.0
+        ],
+        "cardio_block_minutes": 48.98,
+        "strength_density": 0.0,
+        "strength_factor": 1.0,
+        "work_recovery_cycles": 0,
+        "hr_max_reference": 190.0,
+        "stream_status": "unavailable"
+      }
     },
     {
       "id": 18198596442,
       "name": "Lunch Weight Training",
       "type": "WeightTraining",
+      "sport_type": "WeightTraining",
       "start_date": "2026-04-21T09:16:23Z",
       "distance_km": 0.0,
       "moving_time_min": 63.2,
@@ -915,14 +1955,34 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/18198596442",
-      "estimated_exertion": 2.82,
-      "exertion": null,
-      "faulty": false
+      "score_model_version": 2,
+      "score_features": {
+        "version": 2,
+        "source": "streams",
+        "active_minutes": 53.4,
+        "effective_active_minutes": 53.4,
+        "strength_minutes": 53.4,
+        "strength_block_minutes": 53.4,
+        "cardio_zone_minutes": [
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0
+        ],
+        "cardio_block_minutes": 0.0,
+        "strength_density": 0.914,
+        "strength_factor": 1.0,
+        "work_recovery_cycles": 2,
+        "hr_max_reference": 190.0,
+        "stream_status": "complete"
+      }
     },
     {
       "id": 18192272548,
       "name": "Lunch Ride",
       "type": "Ride",
+      "sport_type": "Ride",
       "start_date": "2026-04-20T10:18:04Z",
       "distance_km": 0.37,
       "moving_time_min": 3.7,
@@ -933,14 +1993,34 @@
       "reported_exertion": null,
       "avg_speed_kmh": 6.0,
       "url": "https://www.strava.com/activities/18192272548",
-      "estimated_exertion": 2.29,
-      "exertion": null,
-      "faulty": false
+      "score_model_version": 2,
+      "score_features": {
+        "version": 2,
+        "source": "streams",
+        "active_minutes": 46.8,
+        "effective_active_minutes": 46.8,
+        "strength_minutes": 43.5,
+        "strength_block_minutes": 43.5,
+        "cardio_zone_minutes": [
+          0.0,
+          1.3,
+          2.0,
+          0.0,
+          0.0
+        ],
+        "cardio_block_minutes": 3.3,
+        "strength_density": 0.964,
+        "strength_factor": 1.0,
+        "work_recovery_cycles": 1,
+        "hr_max_reference": 190.0,
+        "stream_status": "complete"
+      }
     },
     {
       "id": 18102107131,
       "name": "Lunch Ride",
       "type": "Ride",
+      "sport_type": "Ride",
       "start_date": "2026-04-14T09:14:34Z",
       "distance_km": 0.0,
       "moving_time_min": 56.8,
@@ -951,14 +2031,34 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/18102107131",
-      "estimated_exertion": 2.68,
-      "exertion": null,
-      "faulty": false
+      "score_model_version": 2,
+      "score_features": {
+        "version": 2,
+        "source": "streams",
+        "active_minutes": 56.3,
+        "effective_active_minutes": 56.3,
+        "strength_minutes": 56.3,
+        "strength_block_minutes": 56.3,
+        "cardio_zone_minutes": [
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0
+        ],
+        "cardio_block_minutes": 0.0,
+        "strength_density": 0.981,
+        "strength_factor": 1.0,
+        "work_recovery_cycles": 1,
+        "hr_max_reference": 190.0,
+        "stream_status": "complete"
+      }
     },
     {
       "id": 18089180150,
       "name": "Lunch Weight Training",
       "type": "WeightTraining",
+      "sport_type": "WeightTraining",
       "start_date": "2026-04-13T09:06:39Z",
       "distance_km": 0.0,
       "moving_time_min": 71.2,
@@ -969,9 +2069,28 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/18089180150",
-      "estimated_exertion": 3.09,
-      "exertion": null,
-      "faulty": false
+      "score_model_version": 2,
+      "score_features": {
+        "version": 2,
+        "source": "streams",
+        "active_minutes": 55.95,
+        "effective_active_minutes": 55.95,
+        "strength_minutes": 55.95,
+        "strength_block_minutes": 55.95,
+        "cardio_zone_minutes": [
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0
+        ],
+        "cardio_block_minutes": 0.0,
+        "strength_density": 0.772,
+        "strength_factor": 1.0,
+        "work_recovery_cycles": 3,
+        "hr_max_reference": 190.0,
+        "stream_status": "complete"
+      }
     },
     {
       "id": 18063170965,

--- a/assets/strava.json
+++ b/assets/strava.json
@@ -1,51 +1,10 @@
 {
-  "updated_utc": "2026-08-10T11:56:46.294661+00:00",
-  "score_model_version": 2,
+  "updated_utc": "2026-08-10T08:03:49.821043+00:00",
   "activities": [
-    {
-      "id": 19677954071,
-      "name": "Morning Weight Training",
-      "type": "WeightTraining",
-      "sport_type": "WeightTraining",
-      "start_date": "2026-08-10T07:33:12Z",
-      "distance_km": 0.0,
-      "moving_time_min": 68.9,
-      "elapsed_time_min": 68.9,
-      "total_elevation_gain_m": 0,
-      "avg_hr": 125.7,
-      "max_hr": 179.0,
-      "reported_exertion": null,
-      "avg_speed_kmh": null,
-      "url": "https://www.strava.com/activities/19677954071",
-      "score_model_version": 2,
-      "score_features": {
-        "version": 2,
-        "feature_version": 2,
-        "source": "summary",
-        "active_minutes": 68.93,
-        "effective_active_minutes": 68.93,
-        "strength_minutes": 68.93,
-        "strength_block_minutes": 68.93,
-        "cardio_zone_minutes": [
-          0.0,
-          0.0,
-          0.0,
-          0.0,
-          0.0
-        ],
-        "cardio_block_minutes": 0.0,
-        "strength_density": 0.0,
-        "strength_factor": 1.0,
-        "work_recovery_cycles": 0,
-        "hr_max_reference": 190.0,
-        "stream_status": "deferred"
-      }
-    },
     {
       "id": 19565243772,
       "name": "Morning Weight Training",
       "type": "WeightTraining",
-      "sport_type": "WeightTraining",
       "start_date": "2026-08-02T06:32:07Z",
       "distance_km": 0.0,
       "moving_time_min": 70.5,
@@ -56,35 +15,14 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/19565243772",
-      "score_model_version": 2,
-      "score_features": {
-        "version": 2,
-        "feature_version": 2,
-        "source": "summary",
-        "active_minutes": 70.55,
-        "effective_active_minutes": 70.55,
-        "strength_minutes": 70.55,
-        "strength_block_minutes": 70.55,
-        "cardio_zone_minutes": [
-          0.0,
-          0.0,
-          0.0,
-          0.0,
-          0.0
-        ],
-        "cardio_block_minutes": 0.0,
-        "strength_density": 0.0,
-        "strength_factor": 1.0,
-        "work_recovery_cycles": 0,
-        "hr_max_reference": 190.0,
-        "stream_status": "deferred"
-      }
+      "estimated_exertion": 3.06,
+      "exertion": null,
+      "faulty": false
     },
     {
       "id": 19543427455,
       "name": "Afternoon Weight Training",
       "type": "WeightTraining",
-      "sport_type": "WeightTraining",
       "start_date": "2026-07-31T12:58:47Z",
       "distance_km": 0.0,
       "moving_time_min": 101.2,
@@ -95,35 +33,14 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/19543427455",
-      "score_model_version": 2,
-      "score_features": {
-        "version": 2,
-        "feature_version": 2,
-        "source": "summary",
-        "active_minutes": 101.18,
-        "effective_active_minutes": 101.18,
-        "strength_minutes": 101.18,
-        "strength_block_minutes": 101.18,
-        "cardio_zone_minutes": [
-          0.0,
-          0.0,
-          0.0,
-          0.0,
-          0.0
-        ],
-        "cardio_block_minutes": 0.0,
-        "strength_density": 0.0,
-        "strength_factor": 1.0,
-        "work_recovery_cycles": 0,
-        "hr_max_reference": 190.0,
-        "stream_status": "deferred"
-      }
+      "estimated_exertion": 3.96,
+      "exertion": null,
+      "faulty": false
     },
     {
       "id": 19496641814,
       "name": "Morning Weight Training",
       "type": "WeightTraining",
-      "sport_type": "WeightTraining",
       "start_date": "2026-07-28T07:42:57Z",
       "distance_km": 0.0,
       "moving_time_min": 83.4,
@@ -134,35 +51,14 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/19496641814",
-      "score_model_version": 2,
-      "score_features": {
-        "version": 2,
-        "feature_version": 2,
-        "source": "summary",
-        "active_minutes": 83.43,
-        "effective_active_minutes": 83.43,
-        "strength_minutes": 83.43,
-        "strength_block_minutes": 83.43,
-        "cardio_zone_minutes": [
-          0.0,
-          0.0,
-          0.0,
-          0.0,
-          0.0
-        ],
-        "cardio_block_minutes": 0.0,
-        "strength_density": 0.0,
-        "strength_factor": 1.0,
-        "work_recovery_cycles": 0,
-        "hr_max_reference": 190.0,
-        "stream_status": "deferred"
-      }
+      "estimated_exertion": 3.32,
+      "exertion": null,
+      "faulty": false
     },
     {
       "id": 19468811618,
       "name": "Morning Weight Training",
       "type": "WeightTraining",
-      "sport_type": "WeightTraining",
       "start_date": "2026-07-26T07:09:49Z",
       "distance_km": 0.0,
       "moving_time_min": 90.4,
@@ -173,35 +69,14 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/19468811618",
-      "score_model_version": 2,
-      "score_features": {
-        "version": 2,
-        "feature_version": 2,
-        "source": "summary",
-        "active_minutes": 90.4,
-        "effective_active_minutes": 90.4,
-        "strength_minutes": 90.4,
-        "strength_block_minutes": 90.4,
-        "cardio_zone_minutes": [
-          0.0,
-          0.0,
-          0.0,
-          0.0,
-          0.0
-        ],
-        "cardio_block_minutes": 0.0,
-        "strength_density": 0.0,
-        "strength_factor": 1.0,
-        "work_recovery_cycles": 0,
-        "hr_max_reference": 190.0,
-        "stream_status": "deferred"
-      }
+      "estimated_exertion": 4.11,
+      "exertion": null,
+      "faulty": false
     },
     {
       "id": 19428791555,
       "name": "Morning Weight Training",
       "type": "WeightTraining",
-      "sport_type": "WeightTraining",
       "start_date": "2026-07-23T08:03:24Z",
       "distance_km": 0.0,
       "moving_time_min": 67.0,
@@ -212,35 +87,14 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/19428791555",
-      "score_model_version": 2,
-      "score_features": {
-        "version": 2,
-        "feature_version": 2,
-        "source": "summary",
-        "active_minutes": 66.95,
-        "effective_active_minutes": 66.95,
-        "strength_minutes": 66.95,
-        "strength_block_minutes": 66.95,
-        "cardio_zone_minutes": [
-          0.0,
-          0.0,
-          0.0,
-          0.0,
-          0.0
-        ],
-        "cardio_block_minutes": 0.0,
-        "strength_density": 0.0,
-        "strength_factor": 1.0,
-        "work_recovery_cycles": 0,
-        "hr_max_reference": 190.0,
-        "stream_status": "deferred"
-      }
+      "estimated_exertion": 3.3,
+      "exertion": null,
+      "faulty": false
     },
     {
       "id": 19394164627,
       "name": "Evening Weight Training",
       "type": "WeightTraining",
-      "sport_type": "WeightTraining",
       "start_date": "2026-07-20T17:25:50Z",
       "distance_km": 0.0,
       "moving_time_min": 195.9,
@@ -251,35 +105,14 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/19394164627",
-      "score_model_version": 2,
-      "score_features": {
-        "version": 2,
-        "feature_version": 2,
-        "source": "summary",
-        "active_minutes": 195.88,
-        "effective_active_minutes": 195.88,
-        "strength_minutes": 195.88,
-        "strength_block_minutes": 195.88,
-        "cardio_zone_minutes": [
-          0.0,
-          0.0,
-          0.0,
-          0.0,
-          0.0
-        ],
-        "cardio_block_minutes": 0.0,
-        "strength_density": 0.0,
-        "strength_factor": 1.0,
-        "work_recovery_cycles": 0,
-        "hr_max_reference": 190.0,
-        "stream_status": "deferred"
-      }
+      "estimated_exertion": 8.64,
+      "exertion": null,
+      "faulty": false
     },
     {
       "id": 19373044429,
       "name": "Lunch Weight Training",
       "type": "WeightTraining",
-      "sport_type": "WeightTraining",
       "start_date": "2026-07-19T09:15:45Z",
       "distance_km": 0.0,
       "moving_time_min": 2.4,
@@ -290,35 +123,14 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/19373044429",
-      "score_model_version": 2,
-      "score_features": {
-        "version": 2,
-        "feature_version": 2,
-        "source": "summary",
-        "active_minutes": 2.37,
-        "effective_active_minutes": 2.37,
-        "strength_minutes": 2.37,
-        "strength_block_minutes": 2.37,
-        "cardio_zone_minutes": [
-          0.0,
-          0.0,
-          0.0,
-          0.0,
-          0.0
-        ],
-        "cardio_block_minutes": 0.0,
-        "strength_density": 0.0,
-        "strength_factor": 1.0,
-        "work_recovery_cycles": 0,
-        "hr_max_reference": 190.0,
-        "stream_status": "deferred"
-      }
+      "estimated_exertion": 0.13,
+      "exertion": null,
+      "faulty": false
     },
     {
       "id": 19309261580,
       "name": "Afternoon Weight Training",
       "type": "WeightTraining",
-      "sport_type": "WeightTraining",
       "start_date": "2026-07-14T11:57:15Z",
       "distance_km": 0.0,
       "moving_time_min": 84.9,
@@ -329,35 +141,14 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/19309261580",
-      "score_model_version": 2,
-      "score_features": {
-        "version": 2,
-        "feature_version": 2,
-        "source": "summary",
-        "active_minutes": 84.87,
-        "effective_active_minutes": 84.87,
-        "strength_minutes": 84.87,
-        "strength_block_minutes": 84.87,
-        "cardio_zone_minutes": [
-          0.0,
-          0.0,
-          0.0,
-          0.0,
-          0.0
-        ],
-        "cardio_block_minutes": 0.0,
-        "strength_density": 0.0,
-        "strength_factor": 1.0,
-        "work_recovery_cycles": 0,
-        "hr_max_reference": 190.0,
-        "stream_status": "deferred"
-      }
+      "estimated_exertion": 3.84,
+      "exertion": null,
+      "faulty": false
     },
     {
       "id": 19254361613,
       "name": "Lunch Weight Training",
       "type": "WeightTraining",
-      "sport_type": "WeightTraining",
       "start_date": "2026-07-10T09:55:50Z",
       "distance_km": 0.0,
       "moving_time_min": 70.1,
@@ -368,35 +159,14 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/19254361613",
-      "score_model_version": 2,
-      "score_features": {
-        "version": 2,
-        "feature_version": 2,
-        "source": "summary",
-        "active_minutes": 70.08,
-        "effective_active_minutes": 70.08,
-        "strength_minutes": 70.08,
-        "strength_block_minutes": 70.08,
-        "cardio_zone_minutes": [
-          0.0,
-          0.0,
-          0.0,
-          0.0,
-          0.0
-        ],
-        "cardio_block_minutes": 0.0,
-        "strength_density": 0.0,
-        "strength_factor": 1.0,
-        "work_recovery_cycles": 0,
-        "hr_max_reference": 190.0,
-        "stream_status": "deferred"
-      }
+      "estimated_exertion": 3.24,
+      "exertion": null,
+      "faulty": false
     },
     {
       "id": 19212827958,
       "name": "Lunch Weight Training",
       "type": "WeightTraining",
-      "sport_type": "WeightTraining",
       "start_date": "2026-07-07T10:01:39Z",
       "distance_km": 0.0,
       "moving_time_min": 67.5,
@@ -407,35 +177,14 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/19212827958",
-      "score_model_version": 2,
-      "score_features": {
-        "version": 2,
-        "feature_version": 2,
-        "source": "summary",
-        "active_minutes": 67.53,
-        "effective_active_minutes": 67.53,
-        "strength_minutes": 67.53,
-        "strength_block_minutes": 67.53,
-        "cardio_zone_minutes": [
-          0.0,
-          0.0,
-          0.0,
-          0.0,
-          0.0
-        ],
-        "cardio_block_minutes": 0.0,
-        "strength_density": 0.0,
-        "strength_factor": 1.0,
-        "work_recovery_cycles": 0,
-        "hr_max_reference": 190.0,
-        "stream_status": "deferred"
-      }
+      "estimated_exertion": 3.19,
+      "exertion": null,
+      "faulty": false
     },
     {
       "id": 19174735579,
       "name": "Lunch Weight Training",
       "type": "WeightTraining",
-      "sport_type": "WeightTraining",
       "start_date": "2026-07-04T09:59:26Z",
       "distance_km": 0.0,
       "moving_time_min": 80.6,
@@ -446,35 +195,14 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/19174735579",
-      "score_model_version": 2,
-      "score_features": {
-        "version": 2,
-        "feature_version": 2,
-        "source": "summary",
-        "active_minutes": 80.57,
-        "effective_active_minutes": 80.57,
-        "strength_minutes": 80.57,
-        "strength_block_minutes": 80.57,
-        "cardio_zone_minutes": [
-          0.0,
-          0.0,
-          0.0,
-          0.0,
-          0.0
-        ],
-        "cardio_block_minutes": 0.0,
-        "strength_density": 0.0,
-        "strength_factor": 1.0,
-        "work_recovery_cycles": 0,
-        "hr_max_reference": 190.0,
-        "stream_status": "deferred"
-      }
+      "estimated_exertion": 3.61,
+      "exertion": null,
+      "faulty": false
     },
     {
       "id": 19164481049,
       "name": "Afternoon Workout",
       "type": "Workout",
-      "sport_type": "Workout",
       "start_date": "2026-07-03T14:06:10Z",
       "distance_km": 0.0,
       "moving_time_min": 61.4,
@@ -485,35 +213,14 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/19164481049",
-      "score_model_version": 2,
-      "score_features": {
-        "version": 2,
-        "feature_version": 2,
-        "source": "summary",
-        "active_minutes": 61.35,
-        "effective_active_minutes": 61.35,
-        "strength_minutes": 46.01,
-        "strength_block_minutes": 46.01,
-        "cardio_zone_minutes": [
-          15.34,
-          0.0,
-          0.0,
-          0.0,
-          0.0
-        ],
-        "cardio_block_minutes": 15.34,
-        "strength_density": 0.25,
-        "strength_factor": 1.0,
-        "work_recovery_cycles": 0,
-        "hr_max_reference": 190.0,
-        "stream_status": "deferred"
-      }
+      "estimated_exertion": 2.85,
+      "exertion": null,
+      "faulty": false
     },
     {
       "id": 19135647103,
       "name": "Lunch Weight Training",
       "type": "WeightTraining",
-      "sport_type": "WeightTraining",
       "start_date": "2026-07-01T09:49:39Z",
       "distance_km": 0.0,
       "moving_time_min": 76.0,
@@ -524,35 +231,14 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/19135647103",
-      "score_model_version": 2,
-      "score_features": {
-        "version": 2,
-        "feature_version": 2,
-        "source": "summary",
-        "active_minutes": 75.97,
-        "effective_active_minutes": 75.97,
-        "strength_minutes": 75.97,
-        "strength_block_minutes": 75.97,
-        "cardio_zone_minutes": [
-          0.0,
-          0.0,
-          0.0,
-          0.0,
-          0.0
-        ],
-        "cardio_block_minutes": 0.0,
-        "strength_density": 0.0,
-        "strength_factor": 1.0,
-        "work_recovery_cycles": 0,
-        "hr_max_reference": 190.0,
-        "stream_status": "deferred"
-      }
+      "estimated_exertion": 3.5,
+      "exertion": null,
+      "faulty": false
     },
     {
       "id": 19108635699,
       "name": "Lunch Weight Training",
       "type": "WeightTraining",
-      "sport_type": "WeightTraining",
       "start_date": "2026-06-29T09:36:18Z",
       "distance_km": 0.0,
       "moving_time_min": 83.1,
@@ -563,35 +249,14 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/19108635699",
-      "score_model_version": 2,
-      "score_features": {
-        "version": 2,
-        "feature_version": 2,
-        "source": "summary",
-        "active_minutes": 83.12,
-        "effective_active_minutes": 83.12,
-        "strength_minutes": 83.12,
-        "strength_block_minutes": 83.12,
-        "cardio_zone_minutes": [
-          0.0,
-          0.0,
-          0.0,
-          0.0,
-          0.0
-        ],
-        "cardio_block_minutes": 0.0,
-        "strength_density": 0.0,
-        "strength_factor": 1.0,
-        "work_recovery_cycles": 0,
-        "hr_max_reference": 190.0,
-        "stream_status": "deferred"
-      }
+      "estimated_exertion": 3.7,
+      "exertion": null,
+      "faulty": false
     },
     {
       "id": 19087019169,
       "name": "Afternoon Ride",
       "type": "Ride",
-      "sport_type": "Ride",
       "start_date": "2026-06-27T12:28:39Z",
       "distance_km": 4.09,
       "moving_time_min": 37.2,
@@ -602,35 +267,14 @@
       "reported_exertion": null,
       "avg_speed_kmh": 6.58,
       "url": "https://www.strava.com/activities/19087019169",
-      "score_model_version": 2,
-      "score_features": {
-        "version": 2,
-        "feature_version": 2,
-        "source": "summary",
-        "active_minutes": 37.25,
-        "effective_active_minutes": 37.25,
-        "strength_minutes": 0.0,
-        "strength_block_minutes": 0.0,
-        "cardio_zone_minutes": [
-          37.25,
-          0.0,
-          0.0,
-          0.0,
-          0.0
-        ],
-        "cardio_block_minutes": 37.25,
-        "strength_density": 0.0,
-        "strength_factor": 1.0,
-        "work_recovery_cycles": 0,
-        "hr_max_reference": 190.0,
-        "stream_status": "deferred"
-      }
+      "estimated_exertion": 6.76,
+      "exertion": null,
+      "faulty": false
     },
     {
       "id": 19083850819,
       "name": "Lunch Weight Training",
       "type": "WeightTraining",
-      "sport_type": "WeightTraining",
       "start_date": "2026-06-27T09:17:53Z",
       "distance_km": 0.0,
       "moving_time_min": 71.1,
@@ -641,35 +285,14 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/19083850819",
-      "score_model_version": 2,
-      "score_features": {
-        "version": 2,
-        "feature_version": 2,
-        "source": "summary",
-        "active_minutes": 71.08,
-        "effective_active_minutes": 71.08,
-        "strength_minutes": 71.08,
-        "strength_block_minutes": 71.08,
-        "cardio_zone_minutes": [
-          0.0,
-          0.0,
-          0.0,
-          0.0,
-          0.0
-        ],
-        "cardio_block_minutes": 0.0,
-        "strength_density": 0.0,
-        "strength_factor": 1.0,
-        "work_recovery_cycles": 0,
-        "hr_max_reference": 190.0,
-        "stream_status": "deferred"
-      }
+      "estimated_exertion": 3.22,
+      "exertion": null,
+      "faulty": false
     },
     {
       "id": 19073380863,
       "name": "Afternoon Ride",
       "type": "Ride",
-      "sport_type": "Ride",
       "start_date": "2026-06-26T11:29:51Z",
       "distance_km": 0.05,
       "moving_time_min": 0.5,
@@ -680,35 +303,14 @@
       "reported_exertion": null,
       "avg_speed_kmh": 5.76,
       "url": "https://www.strava.com/activities/19073380863",
-      "score_model_version": 2,
-      "score_features": {
-        "version": 2,
-        "feature_version": 2,
-        "source": "summary",
-        "active_minutes": 0.5,
-        "effective_active_minutes": 0.5,
-        "strength_minutes": 0.0,
-        "strength_block_minutes": 0.0,
-        "cardio_zone_minutes": [
-          0.5,
-          0.0,
-          0.0,
-          0.0,
-          0.0
-        ],
-        "cardio_block_minutes": 0.5,
-        "strength_density": 0.0,
-        "strength_factor": 1.0,
-        "work_recovery_cycles": 0,
-        "hr_max_reference": 190.0,
-        "stream_status": "deferred"
-      }
+      "estimated_exertion": 2.83,
+      "exertion": null,
+      "faulty": false
     },
     {
       "id": 19047309417,
       "name": "Lunch Weight Training",
       "type": "WeightTraining",
-      "sport_type": "WeightTraining",
       "start_date": "2026-06-24T10:10:43Z",
       "distance_km": 0.0,
       "moving_time_min": 29.1,
@@ -719,35 +321,14 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/19047309417",
-      "score_model_version": 2,
-      "score_features": {
-        "version": 2,
-        "feature_version": 2,
-        "source": "summary",
-        "active_minutes": 29.15,
-        "effective_active_minutes": 29.15,
-        "strength_minutes": 29.15,
-        "strength_block_minutes": 29.15,
-        "cardio_zone_minutes": [
-          0.0,
-          0.0,
-          0.0,
-          0.0,
-          0.0
-        ],
-        "cardio_block_minutes": 0.0,
-        "strength_density": 0.0,
-        "strength_factor": 1.0,
-        "work_recovery_cycles": 0,
-        "hr_max_reference": 190.0,
-        "stream_status": "deferred"
-      }
+      "estimated_exertion": 1.44,
+      "exertion": null,
+      "faulty": false
     },
     {
       "id": 19021090341,
       "name": "Lunch Weight Training",
       "type": "WeightTraining",
-      "sport_type": "WeightTraining",
       "start_date": "2026-06-22T10:45:00Z",
       "distance_km": 0.0,
       "moving_time_min": 68.8,
@@ -758,35 +339,14 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/19021090341",
-      "score_model_version": 2,
-      "score_features": {
-        "version": 2,
-        "feature_version": 2,
-        "source": "summary",
-        "active_minutes": 68.77,
-        "effective_active_minutes": 68.77,
-        "strength_minutes": 68.77,
-        "strength_block_minutes": 68.77,
-        "cardio_zone_minutes": [
-          0.0,
-          0.0,
-          0.0,
-          0.0,
-          0.0
-        ],
-        "cardio_block_minutes": 0.0,
-        "strength_density": 0.0,
-        "strength_factor": 1.0,
-        "work_recovery_cycles": 0,
-        "hr_max_reference": 190.0,
-        "stream_status": "deferred"
-      }
+      "estimated_exertion": 3.18,
+      "exertion": null,
+      "faulty": false
     },
     {
       "id": 18969077347,
       "name": "Morning Weight Training",
       "type": "WeightTraining",
-      "sport_type": "WeightTraining",
       "start_date": "2026-06-18T08:58:26Z",
       "distance_km": 0.0,
       "moving_time_min": 62.9,
@@ -797,35 +357,14 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/18969077347",
-      "score_model_version": 2,
-      "score_features": {
-        "version": 2,
-        "feature_version": 2,
-        "source": "summary",
-        "active_minutes": 62.87,
-        "effective_active_minutes": 62.87,
-        "strength_minutes": 62.87,
-        "strength_block_minutes": 62.87,
-        "cardio_zone_minutes": [
-          0.0,
-          0.0,
-          0.0,
-          0.0,
-          0.0
-        ],
-        "cardio_block_minutes": 0.0,
-        "strength_density": 0.0,
-        "strength_factor": 1.0,
-        "work_recovery_cycles": 0,
-        "hr_max_reference": 190.0,
-        "stream_status": "deferred"
-      }
+      "estimated_exertion": 2.92,
+      "exertion": null,
+      "faulty": false
     },
     {
       "id": 18928485523,
       "name": "Afternoon Weight Training",
       "type": "WeightTraining",
-      "sport_type": "WeightTraining",
       "start_date": "2026-06-15T11:05:47Z",
       "distance_km": 0.0,
       "moving_time_min": 82.0,
@@ -836,35 +375,14 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/18928485523",
-      "score_model_version": 2,
-      "score_features": {
-        "version": 2,
-        "feature_version": 2,
-        "source": "summary",
-        "active_minutes": 82.0,
-        "effective_active_minutes": 82.0,
-        "strength_minutes": 82.0,
-        "strength_block_minutes": 82.0,
-        "cardio_zone_minutes": [
-          0.0,
-          0.0,
-          0.0,
-          0.0,
-          0.0
-        ],
-        "cardio_block_minutes": 0.0,
-        "strength_density": 0.0,
-        "strength_factor": 1.0,
-        "work_recovery_cycles": 0,
-        "hr_max_reference": 190.0,
-        "stream_status": "deferred"
-      }
+      "estimated_exertion": 3.6,
+      "exertion": null,
+      "faulty": false
     },
     {
       "id": 18901369698,
       "name": "Lunch Ride",
       "type": "Ride",
-      "sport_type": "Ride",
       "start_date": "2026-06-13T09:46:36Z",
       "distance_km": 0.0,
       "moving_time_min": 53.0,
@@ -875,35 +393,14 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/18901369698",
-      "score_model_version": 2,
-      "score_features": {
-        "version": 2,
-        "feature_version": 2,
-        "source": "summary",
-        "active_minutes": 53.02,
-        "effective_active_minutes": 53.02,
-        "strength_minutes": 0.0,
-        "strength_block_minutes": 0.0,
-        "cardio_zone_minutes": [
-          53.02,
-          0.0,
-          0.0,
-          0.0,
-          0.0
-        ],
-        "cardio_block_minutes": 53.02,
-        "strength_density": 0.0,
-        "strength_factor": 1.0,
-        "work_recovery_cycles": 0,
-        "hr_max_reference": 190.0,
-        "stream_status": "deferred"
-      }
+      "estimated_exertion": 2.6,
+      "exertion": null,
+      "faulty": false
     },
     {
       "id": 18890831520,
       "name": "Afternoon Weight Training",
       "type": "WeightTraining",
-      "sport_type": "WeightTraining",
       "start_date": "2026-06-12T12:27:51Z",
       "distance_km": 0.0,
       "moving_time_min": 76.0,
@@ -914,35 +411,14 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/18890831520",
-      "score_model_version": 2,
-      "score_features": {
-        "version": 2,
-        "feature_version": 2,
-        "source": "summary",
-        "active_minutes": 75.98,
-        "effective_active_minutes": 75.98,
-        "strength_minutes": 75.98,
-        "strength_block_minutes": 75.98,
-        "cardio_zone_minutes": [
-          0.0,
-          0.0,
-          0.0,
-          0.0,
-          0.0
-        ],
-        "cardio_block_minutes": 0.0,
-        "strength_density": 0.0,
-        "strength_factor": 1.0,
-        "work_recovery_cycles": 0,
-        "hr_max_reference": 190.0,
-        "stream_status": "deferred"
-      }
+      "estimated_exertion": 3.66,
+      "exertion": null,
+      "faulty": false
     },
     {
       "id": 18862132250,
       "name": "Morning Weight Training",
       "type": "WeightTraining",
-      "sport_type": "WeightTraining",
       "start_date": "2026-06-10T08:41:26Z",
       "distance_km": 0.0,
       "moving_time_min": 68.9,
@@ -953,35 +429,14 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/18862132250",
-      "score_model_version": 2,
-      "score_features": {
-        "version": 2,
-        "feature_version": 2,
-        "source": "summary",
-        "active_minutes": 68.93,
-        "effective_active_minutes": 68.93,
-        "strength_minutes": 68.93,
-        "strength_block_minutes": 68.93,
-        "cardio_zone_minutes": [
-          0.0,
-          0.0,
-          0.0,
-          0.0,
-          0.0
-        ],
-        "cardio_block_minutes": 0.0,
-        "strength_density": 0.0,
-        "strength_factor": 1.0,
-        "work_recovery_cycles": 0,
-        "hr_max_reference": 190.0,
-        "stream_status": "deferred"
-      }
+      "estimated_exertion": 3.05,
+      "exertion": null,
+      "faulty": false
     },
     {
       "id": 18836320528,
       "name": "Afternoon Weight Training",
       "type": "WeightTraining",
-      "sport_type": "WeightTraining",
       "start_date": "2026-06-08T11:46:45Z",
       "distance_km": 0.0,
       "moving_time_min": 72.8,
@@ -992,35 +447,14 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/18836320528",
-      "score_model_version": 2,
-      "score_features": {
-        "version": 2,
-        "feature_version": 2,
-        "source": "streams",
-        "active_minutes": 72.23,
-        "effective_active_minutes": 72.23,
-        "strength_minutes": 72.23,
-        "strength_block_minutes": 72.23,
-        "cardio_zone_minutes": [
-          0.0,
-          0.0,
-          0.0,
-          0.0,
-          0.0
-        ],
-        "cardio_block_minutes": 0.0,
-        "strength_density": 0.811,
-        "strength_factor": 1.0,
-        "work_recovery_cycles": 1,
-        "hr_max_reference": 190.0,
-        "stream_status": "complete"
-      }
+      "estimated_exertion": 3.31,
+      "exertion": null,
+      "faulty": false
     },
     {
       "id": 18822884521,
       "name": "Lunch Weight Training",
       "type": "WeightTraining",
-      "sport_type": "WeightTraining",
       "start_date": "2026-06-07T10:24:11Z",
       "distance_km": 0.0,
       "moving_time_min": 88.6,
@@ -1031,35 +465,14 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/18822884521",
-      "score_model_version": 2,
-      "score_features": {
-        "version": 2,
-        "feature_version": 2,
-        "source": "streams",
-        "active_minutes": 80.72,
-        "effective_active_minutes": 80.72,
-        "strength_minutes": 80.72,
-        "strength_block_minutes": 80.72,
-        "cardio_zone_minutes": [
-          0.0,
-          0.0,
-          0.0,
-          0.0,
-          0.0
-        ],
-        "cardio_block_minutes": 0.0,
-        "strength_density": 0.883,
-        "strength_factor": 1.0,
-        "work_recovery_cycles": 3,
-        "hr_max_reference": 190.0,
-        "stream_status": "complete"
-      }
+      "estimated_exertion": 3.9,
+      "exertion": null,
+      "faulty": false
     },
     {
       "id": 18739736076,
       "name": "Lunch Weight Training",
       "type": "WeightTraining",
-      "sport_type": "WeightTraining",
       "start_date": "2026-06-01T09:12:25Z",
       "distance_km": 0.0,
       "moving_time_min": 60.3,
@@ -1070,35 +483,14 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/18739736076",
-      "score_model_version": 2,
-      "score_features": {
-        "version": 2,
-        "feature_version": 2,
-        "source": "streams",
-        "active_minutes": 54.22,
-        "effective_active_minutes": 54.22,
-        "strength_minutes": 54.22,
-        "strength_block_minutes": 54.22,
-        "cardio_zone_minutes": [
-          0.0,
-          0.0,
-          0.0,
-          0.0,
-          0.0
-        ],
-        "cardio_block_minutes": 0.0,
-        "strength_density": 0.93,
-        "strength_factor": 1.0,
-        "work_recovery_cycles": 1,
-        "hr_max_reference": 190.0,
-        "stream_status": "complete"
-      }
+      "estimated_exertion": 2.79,
+      "exertion": null,
+      "faulty": false
     },
     {
       "id": 18699501208,
       "name": "Morning Weight Training",
       "type": "WeightTraining",
-      "sport_type": "WeightTraining",
       "start_date": "2026-05-29T07:43:21Z",
       "distance_km": 0.0,
       "moving_time_min": 70.2,
@@ -1109,35 +501,14 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/18699501208",
-      "score_model_version": 2,
-      "score_features": {
-        "version": 2,
-        "feature_version": 2,
-        "source": "streams",
-        "active_minutes": 59.95,
-        "effective_active_minutes": 59.95,
-        "strength_minutes": 59.95,
-        "strength_block_minutes": 59.95,
-        "cardio_zone_minutes": [
-          0.0,
-          0.0,
-          0.0,
-          0.0,
-          0.0
-        ],
-        "cardio_block_minutes": 0.0,
-        "strength_density": 0.883,
-        "strength_factor": 1.0,
-        "work_recovery_cycles": 5,
-        "hr_max_reference": 190.0,
-        "stream_status": "complete"
-      }
+      "estimated_exertion": 3.19,
+      "exertion": null,
+      "faulty": false
     },
     {
       "id": 18688966943,
       "name": "Afternoon Ride",
       "type": "Ride",
-      "sport_type": "Ride",
       "start_date": "2026-05-28T12:29:56Z",
       "distance_km": 0.0,
       "moving_time_min": 45.9,
@@ -1148,35 +519,14 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/18688966943",
-      "score_model_version": 2,
-      "score_features": {
-        "version": 2,
-        "feature_version": 2,
-        "source": "streams",
-        "active_minutes": 45.87,
-        "effective_active_minutes": 45.87,
-        "strength_minutes": 0.0,
-        "strength_block_minutes": 0.0,
-        "cardio_zone_minutes": [
-          8.95,
-          24.75,
-          9.35,
-          2.82,
-          0.0
-        ],
-        "cardio_block_minutes": 45.87,
-        "strength_density": 0.0,
-        "strength_factor": 1.0,
-        "work_recovery_cycles": 0,
-        "hr_max_reference": 190.0,
-        "stream_status": "complete"
-      }
+      "estimated_exertion": 2.0,
+      "exertion": null,
+      "faulty": false
     },
     {
       "id": 18672250731,
       "name": "Morning Weight Training",
       "type": "WeightTraining",
-      "sport_type": "WeightTraining",
       "start_date": "2026-05-27T08:10:59Z",
       "distance_km": 0.0,
       "moving_time_min": 59.5,
@@ -1187,35 +537,14 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/18672250731",
-      "score_model_version": 2,
-      "score_features": {
-        "version": 2,
-        "feature_version": 2,
-        "source": "streams",
-        "active_minutes": 52.17,
-        "effective_active_minutes": 52.17,
-        "strength_minutes": 52.17,
-        "strength_block_minutes": 52.17,
-        "cardio_zone_minutes": [
-          0.0,
-          0.0,
-          0.0,
-          0.0,
-          0.0
-        ],
-        "cardio_block_minutes": 0.0,
-        "strength_density": 0.923,
-        "strength_factor": 1.0,
-        "work_recovery_cycles": 1,
-        "hr_max_reference": 190.0,
-        "stream_status": "complete"
-      }
+      "estimated_exertion": 2.78,
+      "exertion": null,
+      "faulty": false
     },
     {
       "id": 18646098611,
       "name": "Lunch Weight Training",
       "type": "WeightTraining",
-      "sport_type": "WeightTraining",
       "start_date": "2026-05-25T09:19:44Z",
       "distance_km": 0.0,
       "moving_time_min": 108.5,
@@ -1226,35 +555,14 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/18646098611",
-      "score_model_version": 2,
-      "score_features": {
-        "version": 2,
-        "feature_version": 2,
-        "source": "streams",
-        "active_minutes": 100.97,
-        "effective_active_minutes": 100.97,
-        "strength_minutes": 100.97,
-        "strength_block_minutes": 100.97,
-        "cardio_zone_minutes": [
-          0.0,
-          0.0,
-          0.0,
-          0.0,
-          0.0
-        ],
-        "cardio_block_minutes": 0.0,
-        "strength_density": 0.944,
-        "strength_factor": 1.0,
-        "work_recovery_cycles": 2,
-        "hr_max_reference": 190.0,
-        "stream_status": "complete"
-      }
+      "estimated_exertion": 4.93,
+      "exertion": null,
+      "faulty": false
     },
     {
       "id": 18634538171,
       "name": "Lunch Weight Training",
       "type": "WeightTraining",
-      "sport_type": "WeightTraining",
       "start_date": "2026-05-24T10:23:36Z",
       "distance_km": 0.0,
       "moving_time_min": 79.9,
@@ -1265,35 +573,14 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/18634538171",
-      "score_model_version": 2,
-      "score_features": {
-        "version": 2,
-        "feature_version": 2,
-        "source": "streams",
-        "active_minutes": 72.53,
-        "effective_active_minutes": 72.53,
-        "strength_minutes": 72.53,
-        "strength_block_minutes": 72.53,
-        "cardio_zone_minutes": [
-          0.0,
-          0.0,
-          0.0,
-          0.0,
-          0.0
-        ],
-        "cardio_block_minutes": 0.0,
-        "strength_density": 0.861,
-        "strength_factor": 1.0,
-        "work_recovery_cycles": 3,
-        "hr_max_reference": 190.0,
-        "stream_status": "complete"
-      }
+      "estimated_exertion": 3.53,
+      "exertion": null,
+      "faulty": false
     },
     {
       "id": 18579781509,
       "name": "Lunch Weight Training",
       "type": "WeightTraining",
-      "sport_type": "WeightTraining",
       "start_date": "2026-05-20T09:37:05Z",
       "distance_km": 0.0,
       "moving_time_min": 68.6,
@@ -1304,35 +591,14 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/18579781509",
-      "score_model_version": 2,
-      "score_features": {
-        "version": 2,
-        "feature_version": 2,
-        "source": "streams",
-        "active_minutes": 60.87,
-        "effective_active_minutes": 60.87,
-        "strength_minutes": 60.87,
-        "strength_block_minutes": 60.87,
-        "cardio_zone_minutes": [
-          0.0,
-          0.0,
-          0.0,
-          0.0,
-          0.0
-        ],
-        "cardio_block_minutes": 0.0,
-        "strength_density": 0.79,
-        "strength_factor": 1.0,
-        "work_recovery_cycles": 5,
-        "hr_max_reference": 190.0,
-        "stream_status": "complete"
-      }
+      "estimated_exertion": 3.13,
+      "exertion": null,
+      "faulty": false
     },
     {
       "id": 18552772778,
       "name": "Lunch Weight Training",
       "type": "WeightTraining",
-      "sport_type": "WeightTraining",
       "start_date": "2026-05-18T09:26:48Z",
       "distance_km": 0.0,
       "moving_time_min": 67.7,
@@ -1343,35 +609,14 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/18552772778",
-      "score_model_version": 2,
-      "score_features": {
-        "version": 2,
-        "feature_version": 2,
-        "source": "streams",
-        "active_minutes": 61.97,
-        "effective_active_minutes": 61.97,
-        "strength_minutes": 61.97,
-        "strength_block_minutes": 61.97,
-        "cardio_zone_minutes": [
-          0.0,
-          0.0,
-          0.0,
-          0.0,
-          0.0
-        ],
-        "cardio_block_minutes": 0.0,
-        "strength_density": 0.683,
-        "strength_factor": 1.0,
-        "work_recovery_cycles": 4,
-        "hr_max_reference": 190.0,
-        "stream_status": "complete"
-      }
+      "estimated_exertion": 3.0,
+      "exertion": null,
+      "faulty": false
     },
     {
       "id": 18542816835,
       "name": "Lunch Weight Training",
       "type": "WeightTraining",
-      "sport_type": "WeightTraining",
       "start_date": "2026-05-17T10:59:54Z",
       "distance_km": 0.0,
       "moving_time_min": 122.6,
@@ -1382,35 +627,14 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/18542816835",
-      "score_model_version": 2,
-      "score_features": {
-        "version": 2,
-        "feature_version": 2,
-        "source": "streams",
-        "active_minutes": 100.27,
-        "effective_active_minutes": 100.27,
-        "strength_minutes": 100.27,
-        "strength_block_minutes": 100.27,
-        "cardio_zone_minutes": [
-          0.0,
-          0.0,
-          0.0,
-          0.0,
-          0.0
-        ],
-        "cardio_block_minutes": 0.0,
-        "strength_density": 0.662,
-        "strength_factor": 1.0,
-        "work_recovery_cycles": 4,
-        "hr_max_reference": 190.0,
-        "stream_status": "complete"
-      }
+      "estimated_exertion": 5.1,
+      "exertion": null,
+      "faulty": false
     },
     {
       "id": 18503210740,
       "name": "Lunch Ride",
       "type": "Ride",
-      "sport_type": "Ride",
       "start_date": "2026-05-14T10:59:40Z",
       "distance_km": 0.0,
       "moving_time_min": 66.3,
@@ -1421,35 +645,14 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/18503210740",
-      "score_model_version": 2,
-      "score_features": {
-        "version": 2,
-        "feature_version": 2,
-        "source": "streams",
-        "active_minutes": 66.32,
-        "effective_active_minutes": 66.32,
-        "strength_minutes": 0.0,
-        "strength_block_minutes": 0.0,
-        "cardio_zone_minutes": [
-          3.17,
-          12.03,
-          33.57,
-          15.75,
-          1.8
-        ],
-        "cardio_block_minutes": 66.32,
-        "strength_density": 0.0,
-        "strength_factor": 1.0,
-        "work_recovery_cycles": 0,
-        "hr_max_reference": 190.0,
-        "stream_status": "complete"
-      }
+      "estimated_exertion": 3.11,
+      "exertion": null,
+      "faulty": false
     },
     {
       "id": 18487121625,
       "name": "Morning Ride",
       "type": "Ride",
-      "sport_type": "Ride",
       "start_date": "2026-05-13T06:15:52Z",
       "distance_km": 0.0,
       "moving_time_min": 48.7,
@@ -1460,35 +663,14 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/18487121625",
-      "score_model_version": 2,
-      "score_features": {
-        "version": 2,
-        "feature_version": 2,
-        "source": "streams",
-        "active_minutes": 48.73,
-        "effective_active_minutes": 48.73,
-        "strength_minutes": 0.0,
-        "strength_block_minutes": 0.0,
-        "cardio_zone_minutes": [
-          5.37,
-          12.58,
-          24.13,
-          6.23,
-          0.42
-        ],
-        "cardio_block_minutes": 48.73,
-        "strength_density": 0.0,
-        "strength_factor": 1.0,
-        "work_recovery_cycles": 0,
-        "hr_max_reference": 190.0,
-        "stream_status": "complete"
-      }
+      "estimated_exertion": 2.22,
+      "exertion": null,
+      "faulty": false
     },
     {
       "id": 18461570151,
       "name": "Morning Weight Training",
       "type": "WeightTraining",
-      "sport_type": "WeightTraining",
       "start_date": "2026-05-11T08:44:12Z",
       "distance_km": 0.0,
       "moving_time_min": 82.5,
@@ -1499,35 +681,14 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/18461570151",
-      "score_model_version": 2,
-      "score_features": {
-        "version": 2,
-        "feature_version": 2,
-        "source": "streams",
-        "active_minutes": 72.55,
-        "effective_active_minutes": 72.55,
-        "strength_minutes": 72.55,
-        "strength_block_minutes": 72.55,
-        "cardio_zone_minutes": [
-          0.0,
-          0.0,
-          0.0,
-          0.0,
-          0.0
-        ],
-        "cardio_block_minutes": 0.0,
-        "strength_density": 0.651,
-        "strength_factor": 1.0,
-        "work_recovery_cycles": 9,
-        "hr_max_reference": 190.0,
-        "stream_status": "complete"
-      }
+      "estimated_exertion": 3.71,
+      "exertion": null,
+      "faulty": false
     },
     {
       "id": 18450503927,
       "name": "Lunch Weight Training",
       "type": "WeightTraining",
-      "sport_type": "WeightTraining",
       "start_date": "2026-05-10T09:52:36Z",
       "distance_km": 0.0,
       "moving_time_min": 71.2,
@@ -1538,35 +699,14 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/18450503927",
-      "score_model_version": 2,
-      "score_features": {
-        "version": 2,
-        "feature_version": 2,
-        "source": "streams",
-        "active_minutes": 63.37,
-        "effective_active_minutes": 63.37,
-        "strength_minutes": 63.37,
-        "strength_block_minutes": 63.37,
-        "cardio_zone_minutes": [
-          0.0,
-          0.0,
-          0.0,
-          0.0,
-          0.0
-        ],
-        "cardio_block_minutes": 0.0,
-        "strength_density": 0.825,
-        "strength_factor": 1.0,
-        "work_recovery_cycles": 4,
-        "hr_max_reference": 190.0,
-        "stream_status": "complete"
-      }
+      "estimated_exertion": 3.08,
+      "exertion": null,
+      "faulty": false
     },
     {
       "id": 18440178049,
       "name": "Afternoon Ride",
       "type": "Ride",
-      "sport_type": "Ride",
       "start_date": "2026-05-09T13:10:37Z",
       "distance_km": 8.54,
       "moving_time_min": 48.2,
@@ -1577,35 +717,14 @@
       "reported_exertion": null,
       "avg_speed_kmh": 10.62,
       "url": "https://www.strava.com/activities/18440178049",
-      "score_model_version": 2,
-      "score_features": {
-        "version": 2,
-        "feature_version": 2,
-        "source": "streams",
-        "active_minutes": 43.6,
-        "effective_active_minutes": 43.6,
-        "strength_minutes": 0.0,
-        "strength_block_minutes": 0.0,
-        "cardio_zone_minutes": [
-          21.13,
-          18.92,
-          3.55,
-          0.0,
-          0.0
-        ],
-        "cardio_block_minutes": 43.6,
-        "strength_density": 0.0,
-        "strength_factor": 1.0,
-        "work_recovery_cycles": 0,
-        "hr_max_reference": 190.0,
-        "stream_status": "complete"
-      }
+      "estimated_exertion": 4.72,
+      "exertion": null,
+      "faulty": false
     },
     {
       "id": 18425867200,
       "name": "Afternoon Weight Training",
       "type": "WeightTraining",
-      "sport_type": "WeightTraining",
       "start_date": "2026-05-08T12:52:51Z",
       "distance_km": 0.0,
       "moving_time_min": 79.5,
@@ -1616,35 +735,14 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/18425867200",
-      "score_model_version": 2,
-      "score_features": {
-        "version": 2,
-        "feature_version": 2,
-        "source": "streams",
-        "active_minutes": 59.3,
-        "effective_active_minutes": 59.3,
-        "strength_minutes": 59.3,
-        "strength_block_minutes": 59.3,
-        "cardio_zone_minutes": [
-          0.0,
-          0.0,
-          0.0,
-          0.0,
-          0.0
-        ],
-        "cardio_block_minutes": 0.0,
-        "strength_density": 0.166,
-        "strength_factor": 1.0,
-        "work_recovery_cycles": 2,
-        "hr_max_reference": 190.0,
-        "stream_status": "complete"
-      }
+      "estimated_exertion": 3.17,
+      "exertion": null,
+      "faulty": false
     },
     {
       "id": 18368921048,
       "name": "Morning Ride",
       "type": "Ride",
-      "sport_type": "Ride",
       "start_date": "2026-05-04T08:19:13Z",
       "distance_km": 0.0,
       "moving_time_min": 38.3,
@@ -1655,35 +753,14 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/18368921048",
-      "score_model_version": 2,
-      "score_features": {
-        "version": 2,
-        "feature_version": 2,
-        "source": "streams",
-        "active_minutes": 38.28,
-        "effective_active_minutes": 38.28,
-        "strength_minutes": 0.0,
-        "strength_block_minutes": 0.0,
-        "cardio_zone_minutes": [
-          2.15,
-          12.23,
-          21.43,
-          2.47,
-          0.0
-        ],
-        "cardio_block_minutes": 38.28,
-        "strength_density": 0.0,
-        "strength_factor": 1.0,
-        "work_recovery_cycles": 0,
-        "hr_max_reference": 190.0,
-        "stream_status": "complete"
-      }
+      "estimated_exertion": 1.85,
+      "exertion": null,
+      "faulty": false
     },
     {
       "id": 18330853338,
       "name": "Lunch Weight Training",
       "type": "WeightTraining",
-      "sport_type": "WeightTraining",
       "start_date": "2026-05-01T09:45:57Z",
       "distance_km": 0.0,
       "moving_time_min": 82.9,
@@ -1694,35 +771,14 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/18330853338",
-      "score_model_version": 2,
-      "score_features": {
-        "version": 2,
-        "feature_version": 2,
-        "source": "streams",
-        "active_minutes": 71.35,
-        "effective_active_minutes": 71.35,
-        "strength_minutes": 71.35,
-        "strength_block_minutes": 71.35,
-        "cardio_zone_minutes": [
-          0.0,
-          0.0,
-          0.0,
-          0.0,
-          0.0
-        ],
-        "cardio_block_minutes": 0.0,
-        "strength_density": 0.892,
-        "strength_factor": 1.0,
-        "work_recovery_cycles": 4,
-        "hr_max_reference": 190.0,
-        "stream_status": "complete"
-      }
+      "estimated_exertion": 3.64,
+      "exertion": null,
+      "faulty": false
     },
     {
       "id": 18316904403,
       "name": "Lunch Ride",
       "type": "Ride",
-      "sport_type": "Ride",
       "start_date": "2026-04-30T09:12:00Z",
       "distance_km": 0.0,
       "moving_time_min": 56.3,
@@ -1733,35 +789,14 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/18316904403",
-      "score_model_version": 2,
-      "score_features": {
-        "version": 2,
-        "feature_version": 2,
-        "source": "streams",
-        "active_minutes": 56.3,
-        "effective_active_minutes": 56.3,
-        "strength_minutes": 0.0,
-        "strength_block_minutes": 0.0,
-        "cardio_zone_minutes": [
-          13.78,
-          25.22,
-          11.5,
-          5.8,
-          0.0
-        ],
-        "cardio_block_minutes": 56.3,
-        "strength_density": 0.0,
-        "strength_factor": 1.0,
-        "work_recovery_cycles": 0,
-        "hr_max_reference": 190.0,
-        "stream_status": "complete"
-      }
+      "estimated_exertion": 2.44,
+      "exertion": null,
+      "faulty": false
     },
     {
       "id": 18303519220,
       "name": "Morning Weight Training",
       "type": "WeightTraining",
-      "sport_type": "WeightTraining",
       "start_date": "2026-04-29T08:44:51Z",
       "distance_km": 0.0,
       "moving_time_min": 73.5,
@@ -1772,35 +807,14 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/18303519220",
-      "score_model_version": 2,
-      "score_features": {
-        "version": 2,
-        "feature_version": 2,
-        "source": "streams",
-        "active_minutes": 72.77,
-        "effective_active_minutes": 72.77,
-        "strength_minutes": 72.77,
-        "strength_block_minutes": 72.77,
-        "cardio_zone_minutes": [
-          0.0,
-          0.0,
-          0.0,
-          0.0,
-          0.0
-        ],
-        "cardio_block_minutes": 0.0,
-        "strength_density": 0.652,
-        "strength_factor": 1.0,
-        "work_recovery_cycles": 8,
-        "hr_max_reference": 190.0,
-        "stream_status": "complete"
-      }
+      "estimated_exertion": 3.35,
+      "exertion": null,
+      "faulty": false
     },
     {
       "id": 18275602792,
       "name": "Morning Weight Training",
       "type": "WeightTraining",
-      "sport_type": "WeightTraining",
       "start_date": "2026-04-27T07:46:50Z",
       "distance_km": 0.0,
       "moving_time_min": 75.0,
@@ -1811,35 +825,14 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/18275602792",
-      "score_model_version": 2,
-      "score_features": {
-        "version": 2,
-        "feature_version": 2,
-        "source": "streams",
-        "active_minutes": 66.07,
-        "effective_active_minutes": 66.07,
-        "strength_minutes": 66.07,
-        "strength_block_minutes": 66.07,
-        "cardio_zone_minutes": [
-          0.0,
-          0.0,
-          0.0,
-          0.0,
-          0.0
-        ],
-        "cardio_block_minutes": 0.0,
-        "strength_density": 0.782,
-        "strength_factor": 1.0,
-        "work_recovery_cycles": 5,
-        "hr_max_reference": 190.0,
-        "stream_status": "complete"
-      }
+      "estimated_exertion": 3.28,
+      "exertion": null,
+      "faulty": false
     },
     {
       "id": 18265789375,
       "name": "Afternoon Ride",
       "type": "Ride",
-      "sport_type": "Ride",
       "start_date": "2026-04-26T11:32:34Z",
       "distance_km": 0.0,
       "moving_time_min": 80.2,
@@ -1850,35 +843,14 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/18265789375",
-      "score_model_version": 2,
-      "score_features": {
-        "version": 2,
-        "feature_version": 2,
-        "source": "streams",
-        "active_minutes": 80.25,
-        "effective_active_minutes": 80.25,
-        "strength_minutes": 0.0,
-        "strength_block_minutes": 0.0,
-        "cardio_zone_minutes": [
-          14.52,
-          40.2,
-          25.23,
-          0.3,
-          0.0
-        ],
-        "cardio_block_minutes": 80.25,
-        "strength_density": 0.0,
-        "strength_factor": 1.0,
-        "work_recovery_cycles": 0,
-        "hr_max_reference": 190.0,
-        "stream_status": "complete"
-      }
+      "estimated_exertion": 3.81,
+      "exertion": null,
+      "faulty": false
     },
     {
       "id": 18251157808,
       "name": "Lunch Weight Training",
       "type": "WeightTraining",
-      "sport_type": "WeightTraining",
       "start_date": "2026-04-25T10:59:39Z",
       "distance_km": 0.0,
       "moving_time_min": 71.7,
@@ -1889,35 +861,14 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/18251157808",
-      "score_model_version": 2,
-      "score_features": {
-        "version": 2,
-        "feature_version": 2,
-        "source": "streams",
-        "active_minutes": 67.73,
-        "effective_active_minutes": 67.73,
-        "strength_minutes": 67.73,
-        "strength_block_minutes": 67.73,
-        "cardio_zone_minutes": [
-          0.0,
-          0.0,
-          0.0,
-          0.0,
-          0.0
-        ],
-        "cardio_block_minutes": 0.0,
-        "strength_density": 0.813,
-        "strength_factor": 1.0,
-        "work_recovery_cycles": 3,
-        "hr_max_reference": 190.0,
-        "stream_status": "complete"
-      }
+      "estimated_exertion": 3.11,
+      "exertion": null,
+      "faulty": false
     },
     {
       "id": 18237676512,
       "name": "Lunch Ride",
       "type": "Ride",
-      "sport_type": "Ride",
       "start_date": "2026-04-24T10:31:00Z",
       "distance_km": 0.91,
       "moving_time_min": 8.6,
@@ -1928,35 +879,14 @@
       "reported_exertion": null,
       "avg_speed_kmh": 6.38,
       "url": "https://www.strava.com/activities/18237676512",
-      "score_model_version": 2,
-      "score_features": {
-        "version": 2,
-        "feature_version": 2,
-        "source": "streams",
-        "active_minutes": 58.92,
-        "effective_active_minutes": 58.92,
-        "strength_minutes": 52.12,
-        "strength_block_minutes": 52.12,
-        "cardio_zone_minutes": [
-          0.28,
-          5.47,
-          1.05,
-          0.0,
-          0.0
-        ],
-        "cardio_block_minutes": 6.8,
-        "strength_density": 0.937,
-        "strength_factor": 1.0,
-        "work_recovery_cycles": 2,
-        "hr_max_reference": 190.0,
-        "stream_status": "complete"
-      }
+      "estimated_exertion": 2.84,
+      "exertion": null,
+      "faulty": false
     },
     {
       "id": 18209650193,
       "name": "Lunch Ride",
       "type": "Ride",
-      "sport_type": "Ride",
       "start_date": "2026-04-22T09:44:45Z",
       "distance_km": 0.0,
       "moving_time_min": 49.0,
@@ -1967,35 +897,14 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/18209650193",
-      "score_model_version": 2,
-      "score_features": {
-        "version": 2,
-        "feature_version": 2,
-        "source": "streams",
-        "active_minutes": 48.98,
-        "effective_active_minutes": 48.98,
-        "strength_minutes": 0.0,
-        "strength_block_minutes": 0.0,
-        "cardio_zone_minutes": [
-          12.57,
-          29.67,
-          5.48,
-          1.27,
-          0.0
-        ],
-        "cardio_block_minutes": 48.98,
-        "strength_density": 0.0,
-        "strength_factor": 1.0,
-        "work_recovery_cycles": 0,
-        "hr_max_reference": 190.0,
-        "stream_status": "complete"
-      }
+      "estimated_exertion": 2.19,
+      "exertion": null,
+      "faulty": false
     },
     {
       "id": 18198596442,
       "name": "Lunch Weight Training",
       "type": "WeightTraining",
-      "sport_type": "WeightTraining",
       "start_date": "2026-04-21T09:16:23Z",
       "distance_km": 0.0,
       "moving_time_min": 63.2,
@@ -2006,35 +915,14 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/18198596442",
-      "score_model_version": 2,
-      "score_features": {
-        "version": 2,
-        "feature_version": 2,
-        "source": "streams",
-        "active_minutes": 53.4,
-        "effective_active_minutes": 53.4,
-        "strength_minutes": 53.4,
-        "strength_block_minutes": 53.4,
-        "cardio_zone_minutes": [
-          0.0,
-          0.0,
-          0.0,
-          0.0,
-          0.0
-        ],
-        "cardio_block_minutes": 0.0,
-        "strength_density": 0.914,
-        "strength_factor": 1.0,
-        "work_recovery_cycles": 2,
-        "hr_max_reference": 190.0,
-        "stream_status": "complete"
-      }
+      "estimated_exertion": 2.82,
+      "exertion": null,
+      "faulty": false
     },
     {
       "id": 18192272548,
       "name": "Lunch Ride",
       "type": "Ride",
-      "sport_type": "Ride",
       "start_date": "2026-04-20T10:18:04Z",
       "distance_km": 0.37,
       "moving_time_min": 3.7,
@@ -2045,35 +933,14 @@
       "reported_exertion": null,
       "avg_speed_kmh": 6.0,
       "url": "https://www.strava.com/activities/18192272548",
-      "score_model_version": 2,
-      "score_features": {
-        "version": 2,
-        "feature_version": 2,
-        "source": "streams",
-        "active_minutes": 46.63,
-        "effective_active_minutes": 46.63,
-        "strength_minutes": 43.5,
-        "strength_block_minutes": 43.5,
-        "cardio_zone_minutes": [
-          0.0,
-          1.28,
-          1.85,
-          0.0,
-          0.0
-        ],
-        "cardio_block_minutes": 3.13,
-        "strength_density": 0.964,
-        "strength_factor": 1.0,
-        "work_recovery_cycles": 1,
-        "hr_max_reference": 190.0,
-        "stream_status": "complete"
-      }
+      "estimated_exertion": 2.29,
+      "exertion": null,
+      "faulty": false
     },
     {
       "id": 18102107131,
       "name": "Lunch Ride",
       "type": "Ride",
-      "sport_type": "Ride",
       "start_date": "2026-04-14T09:14:34Z",
       "distance_km": 0.0,
       "moving_time_min": 56.8,
@@ -2084,35 +951,14 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/18102107131",
-      "score_model_version": 2,
-      "score_features": {
-        "version": 2,
-        "feature_version": 2,
-        "source": "streams",
-        "active_minutes": 56.8,
-        "effective_active_minutes": 56.8,
-        "strength_minutes": 0.0,
-        "strength_block_minutes": 0.0,
-        "cardio_zone_minutes": [
-          0.87,
-          22.42,
-          28.97,
-          4.55,
-          0.0
-        ],
-        "cardio_block_minutes": 56.8,
-        "strength_density": 0.0,
-        "strength_factor": 1.0,
-        "work_recovery_cycles": 0,
-        "hr_max_reference": 190.0,
-        "stream_status": "complete"
-      }
+      "estimated_exertion": 2.68,
+      "exertion": null,
+      "faulty": false
     },
     {
       "id": 18089180150,
       "name": "Lunch Weight Training",
       "type": "WeightTraining",
-      "sport_type": "WeightTraining",
       "start_date": "2026-04-13T09:06:39Z",
       "distance_km": 0.0,
       "moving_time_min": 71.2,
@@ -2123,29 +969,9 @@
       "reported_exertion": null,
       "avg_speed_kmh": null,
       "url": "https://www.strava.com/activities/18089180150",
-      "score_model_version": 2,
-      "score_features": {
-        "version": 2,
-        "feature_version": 2,
-        "source": "streams",
-        "active_minutes": 55.95,
-        "effective_active_minutes": 55.95,
-        "strength_minutes": 55.95,
-        "strength_block_minutes": 55.95,
-        "cardio_zone_minutes": [
-          0.0,
-          0.0,
-          0.0,
-          0.0,
-          0.0
-        ],
-        "cardio_block_minutes": 0.0,
-        "strength_density": 0.772,
-        "strength_factor": 1.0,
-        "work_recovery_cycles": 3,
-        "hr_max_reference": 190.0,
-        "stream_status": "complete"
-      }
+      "estimated_exertion": 3.09,
+      "exertion": null,
+      "faulty": false
     },
     {
       "id": 18063170965,

--- a/assets/strava.json
+++ b/assets/strava.json
@@ -1,5 +1,5 @@
 {
-  "updated_utc": "2026-08-10T11:44:53.136389+00:00",
+  "updated_utc": "2026-08-10T11:56:46.294661+00:00",
   "score_model_version": 2,
   "activities": [
     {
@@ -20,6 +20,7 @@
       "score_model_version": 2,
       "score_features": {
         "version": 2,
+        "feature_version": 2,
         "source": "summary",
         "active_minutes": 68.93,
         "effective_active_minutes": 68.93,
@@ -58,6 +59,7 @@
       "score_model_version": 2,
       "score_features": {
         "version": 2,
+        "feature_version": 2,
         "source": "summary",
         "active_minutes": 70.55,
         "effective_active_minutes": 70.55,
@@ -96,6 +98,7 @@
       "score_model_version": 2,
       "score_features": {
         "version": 2,
+        "feature_version": 2,
         "source": "summary",
         "active_minutes": 101.18,
         "effective_active_minutes": 101.18,
@@ -134,6 +137,7 @@
       "score_model_version": 2,
       "score_features": {
         "version": 2,
+        "feature_version": 2,
         "source": "summary",
         "active_minutes": 83.43,
         "effective_active_minutes": 83.43,
@@ -172,6 +176,7 @@
       "score_model_version": 2,
       "score_features": {
         "version": 2,
+        "feature_version": 2,
         "source": "summary",
         "active_minutes": 90.4,
         "effective_active_minutes": 90.4,
@@ -210,6 +215,7 @@
       "score_model_version": 2,
       "score_features": {
         "version": 2,
+        "feature_version": 2,
         "source": "summary",
         "active_minutes": 66.95,
         "effective_active_minutes": 66.95,
@@ -248,6 +254,7 @@
       "score_model_version": 2,
       "score_features": {
         "version": 2,
+        "feature_version": 2,
         "source": "summary",
         "active_minutes": 195.88,
         "effective_active_minutes": 195.88,
@@ -286,6 +293,7 @@
       "score_model_version": 2,
       "score_features": {
         "version": 2,
+        "feature_version": 2,
         "source": "summary",
         "active_minutes": 2.37,
         "effective_active_minutes": 2.37,
@@ -324,6 +332,7 @@
       "score_model_version": 2,
       "score_features": {
         "version": 2,
+        "feature_version": 2,
         "source": "summary",
         "active_minutes": 84.87,
         "effective_active_minutes": 84.87,
@@ -362,6 +371,7 @@
       "score_model_version": 2,
       "score_features": {
         "version": 2,
+        "feature_version": 2,
         "source": "summary",
         "active_minutes": 70.08,
         "effective_active_minutes": 70.08,
@@ -400,6 +410,7 @@
       "score_model_version": 2,
       "score_features": {
         "version": 2,
+        "feature_version": 2,
         "source": "summary",
         "active_minutes": 67.53,
         "effective_active_minutes": 67.53,
@@ -438,6 +449,7 @@
       "score_model_version": 2,
       "score_features": {
         "version": 2,
+        "feature_version": 2,
         "source": "summary",
         "active_minutes": 80.57,
         "effective_active_minutes": 80.57,
@@ -476,6 +488,7 @@
       "score_model_version": 2,
       "score_features": {
         "version": 2,
+        "feature_version": 2,
         "source": "summary",
         "active_minutes": 61.35,
         "effective_active_minutes": 61.35,
@@ -514,6 +527,7 @@
       "score_model_version": 2,
       "score_features": {
         "version": 2,
+        "feature_version": 2,
         "source": "summary",
         "active_minutes": 75.97,
         "effective_active_minutes": 75.97,
@@ -552,6 +566,7 @@
       "score_model_version": 2,
       "score_features": {
         "version": 2,
+        "feature_version": 2,
         "source": "summary",
         "active_minutes": 83.12,
         "effective_active_minutes": 83.12,
@@ -590,6 +605,7 @@
       "score_model_version": 2,
       "score_features": {
         "version": 2,
+        "feature_version": 2,
         "source": "summary",
         "active_minutes": 37.25,
         "effective_active_minutes": 37.25,
@@ -628,6 +644,7 @@
       "score_model_version": 2,
       "score_features": {
         "version": 2,
+        "feature_version": 2,
         "source": "summary",
         "active_minutes": 71.08,
         "effective_active_minutes": 71.08,
@@ -666,6 +683,7 @@
       "score_model_version": 2,
       "score_features": {
         "version": 2,
+        "feature_version": 2,
         "source": "summary",
         "active_minutes": 0.5,
         "effective_active_minutes": 0.5,
@@ -704,6 +722,7 @@
       "score_model_version": 2,
       "score_features": {
         "version": 2,
+        "feature_version": 2,
         "source": "summary",
         "active_minutes": 29.15,
         "effective_active_minutes": 29.15,
@@ -742,6 +761,7 @@
       "score_model_version": 2,
       "score_features": {
         "version": 2,
+        "feature_version": 2,
         "source": "summary",
         "active_minutes": 68.77,
         "effective_active_minutes": 68.77,
@@ -780,6 +800,7 @@
       "score_model_version": 2,
       "score_features": {
         "version": 2,
+        "feature_version": 2,
         "source": "summary",
         "active_minutes": 62.87,
         "effective_active_minutes": 62.87,
@@ -818,6 +839,7 @@
       "score_model_version": 2,
       "score_features": {
         "version": 2,
+        "feature_version": 2,
         "source": "summary",
         "active_minutes": 82.0,
         "effective_active_minutes": 82.0,
@@ -856,6 +878,7 @@
       "score_model_version": 2,
       "score_features": {
         "version": 2,
+        "feature_version": 2,
         "source": "summary",
         "active_minutes": 53.02,
         "effective_active_minutes": 53.02,
@@ -894,6 +917,7 @@
       "score_model_version": 2,
       "score_features": {
         "version": 2,
+        "feature_version": 2,
         "source": "summary",
         "active_minutes": 75.98,
         "effective_active_minutes": 75.98,
@@ -932,6 +956,7 @@
       "score_model_version": 2,
       "score_features": {
         "version": 2,
+        "feature_version": 2,
         "source": "summary",
         "active_minutes": 68.93,
         "effective_active_minutes": 68.93,
@@ -970,6 +995,7 @@
       "score_model_version": 2,
       "score_features": {
         "version": 2,
+        "feature_version": 2,
         "source": "streams",
         "active_minutes": 72.23,
         "effective_active_minutes": 72.23,
@@ -1008,6 +1034,7 @@
       "score_model_version": 2,
       "score_features": {
         "version": 2,
+        "feature_version": 2,
         "source": "streams",
         "active_minutes": 80.72,
         "effective_active_minutes": 80.72,
@@ -1046,6 +1073,7 @@
       "score_model_version": 2,
       "score_features": {
         "version": 2,
+        "feature_version": 2,
         "source": "streams",
         "active_minutes": 54.22,
         "effective_active_minutes": 54.22,
@@ -1084,6 +1112,7 @@
       "score_model_version": 2,
       "score_features": {
         "version": 2,
+        "feature_version": 2,
         "source": "streams",
         "active_minutes": 59.95,
         "effective_active_minutes": 59.95,
@@ -1122,22 +1151,23 @@
       "score_model_version": 2,
       "score_features": {
         "version": 2,
+        "feature_version": 2,
         "source": "streams",
-        "active_minutes": 45.65,
-        "effective_active_minutes": 45.65,
-        "strength_minutes": 45.65,
-        "strength_block_minutes": 45.65,
+        "active_minutes": 45.87,
+        "effective_active_minutes": 45.87,
+        "strength_minutes": 0.0,
+        "strength_block_minutes": 0.0,
         "cardio_zone_minutes": [
-          0.0,
-          0.0,
-          0.0,
-          0.0,
+          8.95,
+          24.75,
+          9.35,
+          2.82,
           0.0
         ],
-        "cardio_block_minutes": 0.0,
-        "strength_density": 0.743,
+        "cardio_block_minutes": 45.87,
+        "strength_density": 0.0,
         "strength_factor": 1.0,
-        "work_recovery_cycles": 1,
+        "work_recovery_cycles": 0,
         "hr_max_reference": 190.0,
         "stream_status": "complete"
       }
@@ -1160,6 +1190,7 @@
       "score_model_version": 2,
       "score_features": {
         "version": 2,
+        "feature_version": 2,
         "source": "streams",
         "active_minutes": 52.17,
         "effective_active_minutes": 52.17,
@@ -1198,6 +1229,7 @@
       "score_model_version": 2,
       "score_features": {
         "version": 2,
+        "feature_version": 2,
         "source": "streams",
         "active_minutes": 100.97,
         "effective_active_minutes": 100.97,
@@ -1236,6 +1268,7 @@
       "score_model_version": 2,
       "score_features": {
         "version": 2,
+        "feature_version": 2,
         "source": "streams",
         "active_minutes": 72.53,
         "effective_active_minutes": 72.53,
@@ -1274,6 +1307,7 @@
       "score_model_version": 2,
       "score_features": {
         "version": 2,
+        "feature_version": 2,
         "source": "streams",
         "active_minutes": 60.87,
         "effective_active_minutes": 60.87,
@@ -1312,6 +1346,7 @@
       "score_model_version": 2,
       "score_features": {
         "version": 2,
+        "feature_version": 2,
         "source": "streams",
         "active_minutes": 61.97,
         "effective_active_minutes": 61.97,
@@ -1350,6 +1385,7 @@
       "score_model_version": 2,
       "score_features": {
         "version": 2,
+        "feature_version": 2,
         "source": "streams",
         "active_minutes": 100.27,
         "effective_active_minutes": 100.27,
@@ -1388,22 +1424,23 @@
       "score_model_version": 2,
       "score_features": {
         "version": 2,
+        "feature_version": 2,
         "source": "streams",
         "active_minutes": 66.32,
         "effective_active_minutes": 66.32,
-        "strength_minutes": 66.32,
-        "strength_block_minutes": 66.32,
+        "strength_minutes": 0.0,
+        "strength_block_minutes": 0.0,
         "cardio_zone_minutes": [
-          0.0,
-          0.0,
-          0.0,
-          0.0,
-          0.0
+          3.17,
+          12.03,
+          33.57,
+          15.75,
+          1.8
         ],
-        "cardio_block_minutes": 0.0,
-        "strength_density": 0.949,
+        "cardio_block_minutes": 66.32,
+        "strength_density": 0.0,
         "strength_factor": 1.0,
-        "work_recovery_cycles": 2,
+        "work_recovery_cycles": 0,
         "hr_max_reference": 190.0,
         "stream_status": "complete"
       }
@@ -1426,22 +1463,23 @@
       "score_model_version": 2,
       "score_features": {
         "version": 2,
+        "feature_version": 2,
         "source": "streams",
-        "active_minutes": 48.47,
-        "effective_active_minutes": 48.47,
-        "strength_minutes": 48.47,
-        "strength_block_minutes": 48.47,
+        "active_minutes": 48.73,
+        "effective_active_minutes": 48.73,
+        "strength_minutes": 0.0,
+        "strength_block_minutes": 0.0,
         "cardio_zone_minutes": [
-          0.0,
-          0.0,
-          0.0,
-          0.0,
-          0.0
+          5.37,
+          12.58,
+          24.13,
+          6.23,
+          0.42
         ],
-        "cardio_block_minutes": 0.0,
-        "strength_density": 0.858,
+        "cardio_block_minutes": 48.73,
+        "strength_density": 0.0,
         "strength_factor": 1.0,
-        "work_recovery_cycles": 3,
+        "work_recovery_cycles": 0,
         "hr_max_reference": 190.0,
         "stream_status": "complete"
       }
@@ -1464,6 +1502,7 @@
       "score_model_version": 2,
       "score_features": {
         "version": 2,
+        "feature_version": 2,
         "source": "streams",
         "active_minutes": 72.55,
         "effective_active_minutes": 72.55,
@@ -1502,6 +1541,7 @@
       "score_model_version": 2,
       "score_features": {
         "version": 2,
+        "feature_version": 2,
         "source": "streams",
         "active_minutes": 63.37,
         "effective_active_minutes": 63.37,
@@ -1540,19 +1580,20 @@
       "score_model_version": 2,
       "score_features": {
         "version": 2,
+        "feature_version": 2,
         "source": "streams",
-        "active_minutes": 44.98,
-        "effective_active_minutes": 44.98,
+        "active_minutes": 43.6,
+        "effective_active_minutes": 43.6,
         "strength_minutes": 0.0,
         "strength_block_minutes": 0.0,
         "cardio_zone_minutes": [
-          22.28,
-          19.13,
-          3.57,
+          21.13,
+          18.92,
+          3.55,
           0.0,
           0.0
         ],
-        "cardio_block_minutes": 44.98,
+        "cardio_block_minutes": 43.6,
         "strength_density": 0.0,
         "strength_factor": 1.0,
         "work_recovery_cycles": 0,
@@ -1578,6 +1619,7 @@
       "score_model_version": 2,
       "score_features": {
         "version": 2,
+        "feature_version": 2,
         "source": "streams",
         "active_minutes": 59.3,
         "effective_active_minutes": 59.3,
@@ -1616,22 +1658,23 @@
       "score_model_version": 2,
       "score_features": {
         "version": 2,
+        "feature_version": 2,
         "source": "streams",
         "active_minutes": 38.28,
         "effective_active_minutes": 38.28,
-        "strength_minutes": 38.28,
-        "strength_block_minutes": 38.28,
+        "strength_minutes": 0.0,
+        "strength_block_minutes": 0.0,
         "cardio_zone_minutes": [
-          0.0,
-          0.0,
-          0.0,
-          0.0,
+          2.15,
+          12.23,
+          21.43,
+          2.47,
           0.0
         ],
-        "cardio_block_minutes": 0.0,
-        "strength_density": 0.925,
+        "cardio_block_minutes": 38.28,
+        "strength_density": 0.0,
         "strength_factor": 1.0,
-        "work_recovery_cycles": 2,
+        "work_recovery_cycles": 0,
         "hr_max_reference": 190.0,
         "stream_status": "complete"
       }
@@ -1654,6 +1697,7 @@
       "score_model_version": 2,
       "score_features": {
         "version": 2,
+        "feature_version": 2,
         "source": "streams",
         "active_minutes": 71.35,
         "effective_active_minutes": 71.35,
@@ -1692,22 +1736,23 @@
       "score_model_version": 2,
       "score_features": {
         "version": 2,
+        "feature_version": 2,
         "source": "streams",
-        "active_minutes": 56.02,
-        "effective_active_minutes": 56.02,
-        "strength_minutes": 56.02,
-        "strength_block_minutes": 56.02,
+        "active_minutes": 56.3,
+        "effective_active_minutes": 56.3,
+        "strength_minutes": 0.0,
+        "strength_block_minutes": 0.0,
         "cardio_zone_minutes": [
-          0.0,
-          0.0,
-          0.0,
-          0.0,
+          13.78,
+          25.22,
+          11.5,
+          5.8,
           0.0
         ],
-        "cardio_block_minutes": 0.0,
-        "strength_density": 0.648,
+        "cardio_block_minutes": 56.3,
+        "strength_density": 0.0,
         "strength_factor": 1.0,
-        "work_recovery_cycles": 8,
+        "work_recovery_cycles": 0,
         "hr_max_reference": 190.0,
         "stream_status": "complete"
       }
@@ -1730,6 +1775,7 @@
       "score_model_version": 2,
       "score_features": {
         "version": 2,
+        "feature_version": 2,
         "source": "streams",
         "active_minutes": 72.77,
         "effective_active_minutes": 72.77,
@@ -1768,6 +1814,7 @@
       "score_model_version": 2,
       "score_features": {
         "version": 2,
+        "feature_version": 2,
         "source": "streams",
         "active_minutes": 66.07,
         "effective_active_minutes": 66.07,
@@ -1806,22 +1853,23 @@
       "score_model_version": 2,
       "score_features": {
         "version": 2,
+        "feature_version": 2,
         "source": "streams",
-        "active_minutes": 74.52,
-        "effective_active_minutes": 74.52,
-        "strength_minutes": 74.52,
-        "strength_block_minutes": 74.52,
+        "active_minutes": 80.25,
+        "effective_active_minutes": 80.25,
+        "strength_minutes": 0.0,
+        "strength_block_minutes": 0.0,
         "cardio_zone_minutes": [
-          0.0,
-          0.0,
-          0.0,
-          0.0,
+          14.52,
+          40.2,
+          25.23,
+          0.3,
           0.0
         ],
-        "cardio_block_minutes": 0.0,
-        "strength_density": 0.766,
+        "cardio_block_minutes": 80.25,
+        "strength_density": 0.0,
         "strength_factor": 1.0,
-        "work_recovery_cycles": 5,
+        "work_recovery_cycles": 0,
         "hr_max_reference": 190.0,
         "stream_status": "complete"
       }
@@ -1844,6 +1892,7 @@
       "score_model_version": 2,
       "score_features": {
         "version": 2,
+        "feature_version": 2,
         "source": "streams",
         "active_minutes": 67.73,
         "effective_active_minutes": 67.73,
@@ -1882,19 +1931,20 @@
       "score_model_version": 2,
       "score_features": {
         "version": 2,
+        "feature_version": 2,
         "source": "streams",
-        "active_minutes": 59.28,
-        "effective_active_minutes": 59.28,
+        "active_minutes": 58.92,
+        "effective_active_minutes": 58.92,
         "strength_minutes": 52.12,
         "strength_block_minutes": 52.12,
         "cardio_zone_minutes": [
-          0.3,
-          5.67,
-          1.2,
+          0.28,
+          5.47,
+          1.05,
           0.0,
           0.0
         ],
-        "cardio_block_minutes": 7.17,
+        "cardio_block_minutes": 6.8,
         "strength_density": 0.937,
         "strength_factor": 1.0,
         "work_recovery_cycles": 2,
@@ -1920,16 +1970,17 @@
       "score_model_version": 2,
       "score_features": {
         "version": 2,
-        "source": "summary",
+        "feature_version": 2,
+        "source": "streams",
         "active_minutes": 48.98,
         "effective_active_minutes": 48.98,
         "strength_minutes": 0.0,
         "strength_block_minutes": 0.0,
         "cardio_zone_minutes": [
-          0.0,
-          48.98,
-          0.0,
-          0.0,
+          12.57,
+          29.67,
+          5.48,
+          1.27,
           0.0
         ],
         "cardio_block_minutes": 48.98,
@@ -1937,7 +1988,7 @@
         "strength_factor": 1.0,
         "work_recovery_cycles": 0,
         "hr_max_reference": 190.0,
-        "stream_status": "unavailable"
+        "stream_status": "complete"
       }
     },
     {
@@ -1958,6 +2009,7 @@
       "score_model_version": 2,
       "score_features": {
         "version": 2,
+        "feature_version": 2,
         "source": "streams",
         "active_minutes": 53.4,
         "effective_active_minutes": 53.4,
@@ -1996,19 +2048,20 @@
       "score_model_version": 2,
       "score_features": {
         "version": 2,
+        "feature_version": 2,
         "source": "streams",
-        "active_minutes": 46.8,
-        "effective_active_minutes": 46.8,
+        "active_minutes": 46.63,
+        "effective_active_minutes": 46.63,
         "strength_minutes": 43.5,
         "strength_block_minutes": 43.5,
         "cardio_zone_minutes": [
           0.0,
-          1.3,
-          2.0,
+          1.28,
+          1.85,
           0.0,
           0.0
         ],
-        "cardio_block_minutes": 3.3,
+        "cardio_block_minutes": 3.13,
         "strength_density": 0.964,
         "strength_factor": 1.0,
         "work_recovery_cycles": 1,
@@ -2034,22 +2087,23 @@
       "score_model_version": 2,
       "score_features": {
         "version": 2,
+        "feature_version": 2,
         "source": "streams",
-        "active_minutes": 56.3,
-        "effective_active_minutes": 56.3,
-        "strength_minutes": 56.3,
-        "strength_block_minutes": 56.3,
+        "active_minutes": 56.8,
+        "effective_active_minutes": 56.8,
+        "strength_minutes": 0.0,
+        "strength_block_minutes": 0.0,
         "cardio_zone_minutes": [
-          0.0,
-          0.0,
-          0.0,
-          0.0,
+          0.87,
+          22.42,
+          28.97,
+          4.55,
           0.0
         ],
-        "cardio_block_minutes": 0.0,
-        "strength_density": 0.981,
+        "cardio_block_minutes": 56.8,
+        "strength_density": 0.0,
         "strength_factor": 1.0,
-        "work_recovery_cycles": 1,
+        "work_recovery_cycles": 0,
         "hr_max_reference": 190.0,
         "stream_status": "complete"
       }
@@ -2072,6 +2126,7 @@
       "score_model_version": 2,
       "score_features": {
         "version": 2,
+        "feature_version": 2,
         "source": "streams",
         "active_minutes": 55.95,
         "effective_active_minutes": 55.95,

--- a/scripts/fetch_strava.py
+++ b/scripts/fetch_strava.py
@@ -7,6 +7,7 @@ import requests
 if __package__:
     from .strava_score_features import (
         SCORE_MODEL_VERSION,
+        STREAM_FEATURE_VERSION,
         derive_stream_score_features,
         estimate_hr_reference,
         get_summary_score_features,
@@ -14,6 +15,7 @@ if __package__:
 else:
     from strava_score_features import (
         SCORE_MODEL_VERSION,
+        STREAM_FEATURE_VERSION,
         derive_stream_score_features,
         estimate_hr_reference,
         get_summary_score_features,
@@ -259,6 +261,11 @@ def has_final_score_features(activity: dict | None) -> bool:
         return False
     try:
         if int(features.get("version") or 0) < SCORE_MODEL_VERSION:
+            return False
+    except (TypeError, ValueError):
+        return False
+    try:
+        if int(features.get("feature_version") or 0) < STREAM_FEATURE_VERSION:
             return False
     except (TypeError, ValueError):
         return False

--- a/scripts/fetch_strava.py
+++ b/scripts/fetch_strava.py
@@ -4,12 +4,20 @@ from datetime import datetime, timedelta, timezone
 
 import requests
 
-from strava_score_features import (
-    SCORE_MODEL_VERSION,
-    derive_stream_score_features,
-    estimate_hr_reference,
-    get_summary_score_features,
-)
+if __package__:
+    from .strava_score_features import (
+        SCORE_MODEL_VERSION,
+        derive_stream_score_features,
+        estimate_hr_reference,
+        get_summary_score_features,
+    )
+else:
+    from strava_score_features import (
+        SCORE_MODEL_VERSION,
+        derive_stream_score_features,
+        estimate_hr_reference,
+        get_summary_score_features,
+    )
 
 CLIENT_ID = os.environ.get("STRAVA_CLIENT_ID", "").strip()
 CLIENT_SECRET = os.environ.get("STRAVA_CLIENT_SECRET", "").strip()
@@ -28,7 +36,6 @@ STREAM_KEYS = (
 
 OUTFILE = "assets/strava.json"
 TOKEN_FILE = "_private/strava_token.json"
-OVERRIDES_FILE = "assets/strava_overrides.json"
 
 
 class StravaConfigurationError(RuntimeError):
@@ -244,37 +251,20 @@ def enrich_activity(activity: dict, access_token: str) -> dict:
     return activity
 
 
-def load_exertion_overrides() -> dict[str, dict[str, float | bool]]:
-    if not os.path.exists(OVERRIDES_FILE):
-        return {}
-    with open(OVERRIDES_FILE, "r", encoding="utf-8") as overrides_file:
-        payload = json.load(overrides_file)
-    overrides: dict[str, dict[str, float | bool]] = {}
-    for key, value in payload.items():
-        record: dict[str, float | bool] = {}
-        if isinstance(value, dict):
-            exertion = value.get("exertion")
-            if isinstance(value.get("faulty"), bool) and value.get("faulty"):
-                record["faulty"] = True
-        else:
-            exertion = value
-        if isinstance(exertion, (int, float)):
-            record["exertion"] = float(exertion)
-        if record:
-            overrides[str(key)] = record
-    return overrides
-
-
-def has_v2_score_features(activity: dict | None) -> bool:
+def has_final_score_features(activity: dict | None) -> bool:
     if not isinstance(activity, dict):
         return False
     features = activity.get("score_features")
     if not isinstance(features, dict):
         return False
     try:
-        return int(features.get("version") or 0) >= SCORE_MODEL_VERSION
+        if int(features.get("version") or 0) < SCORE_MODEL_VERSION:
+            return False
     except (TypeError, ValueError):
         return False
+    if features.get("source") == "streams":
+        return True
+    return features.get("stream_status") == "unavailable"
 
 
 def slim(activity: dict) -> dict:
@@ -376,7 +366,6 @@ def main() -> None:
                 "Missing STRAVA_CLIENT_ID or STRAVA_CLIENT_SECRET."
             )
         refresh_tokens = load_refresh_token_candidates()
-        overrides = load_exertion_overrides()
         existing_payload = read_existing_payload() or {}
         existing_activities = existing_payload.get("activities") or []
         existing_by_id = {
@@ -425,8 +414,8 @@ def main() -> None:
                     )
                 else:
                     try:
-                        enriched = enrich_activity(activity, access_token)
                         detail_requests += 1
+                        enriched = enrich_activity(activity, access_token)
                     except requests.HTTPError as error:
                         status_code = get_http_status_code(error)
                         if status_code == 429:
@@ -444,7 +433,8 @@ def main() -> None:
                     except requests.RequestException as error:
                         print(
                             "Skipping Strava activity "
-                            f"{activity.get('id')} details after request error: {error}."
+                            f"{activity.get('id')} details after request "
+                            f"error: {error}."
                         )
             enriched_activities.append(enriched)
 
@@ -459,10 +449,11 @@ def main() -> None:
             existing = existing_by_id.get(str(payload.get("id")))
             cached_features = (
                 existing.get("score_features")
-                if has_v2_score_features(existing)
+                if has_final_score_features(existing)
                 else None
             )
             score_features = cached_features
+            stream_status = "deferred"
 
             if score_features is None and stream_requests_enabled and payload.get("id"):
                 if stream_requests >= STREAM_REQUEST_LIMIT:
@@ -473,10 +464,13 @@ def main() -> None:
                     )
                 else:
                     try:
-                        streams = get_activity_streams(access_token, payload["id"])
                         stream_requests += 1
+                        streams = get_activity_streams(access_token, payload["id"])
                         score_features = derive_stream_score_features(
                             activity, streams, hr_reference
+                        )
+                        stream_status = (
+                            "complete" if score_features is not None else "unavailable"
                         )
                     except requests.HTTPError as error:
                         status_code = get_http_status_code(error)
@@ -486,24 +480,33 @@ def main() -> None:
                                 "Strava stream rate limit reached; deriving "
                                 "remaining features from activity summaries."
                             )
+                        elif status_code in {400, 404}:
+                            stream_status = "unavailable"
+                            print(
+                                "Strava activity "
+                                f"{activity.get('id')} has no usable streams."
+                            )
                         else:
+                            stream_status = "retry"
                             print(
                                 "Skipping Strava activity "
                                 f"{activity.get('id')} streams after HTTP "
                                 f"{status_code or 'error'}."
                             )
                     except requests.RequestException as error:
+                        stream_status = "retry"
                         print(
                             "Skipping Strava activity "
-                            f"{activity.get('id')} streams after request error: {error}."
+                            f"{activity.get('id')} streams after request "
+                            f"error: {error}."
                         )
 
             if score_features is None:
                 score_features = get_summary_score_features(activity, hr_reference)
+                score_features["stream_status"] = stream_status
+            elif score_features.get("source") == "streams":
+                score_features["stream_status"] = "complete"
             payload["score_features"] = score_features
-            override = overrides.get(str(payload.get("id")))
-            payload["exertion"] = override.get("exertion") if override else None
-            payload["faulty"] = bool(override.get("faulty")) if override else False
             slimmed.append(payload)
 
         merged = merge_activities(existing_activities, slimmed)
@@ -531,7 +534,7 @@ def main() -> None:
         message = str(error)
         write_failure_payload(message)
         raise SystemExit(1) from error
-    except (requests.RequestException, json.JSONDecodeError, KeyError, Exception) as error:
+    except Exception as error:
         message = f"Unexpected error while fetching Strava data: {error}"
         write_failure_payload(message)
         raise SystemExit(1) from error

--- a/scripts/fetch_strava.py
+++ b/scripts/fetch_strava.py
@@ -4,11 +4,27 @@ from datetime import datetime, timedelta, timezone
 
 import requests
 
+from strava_score_features import (
+    SCORE_MODEL_VERSION,
+    derive_stream_score_features,
+    estimate_hr_reference,
+    get_summary_score_features,
+)
+
 CLIENT_ID = os.environ.get("STRAVA_CLIENT_ID", "").strip()
 CLIENT_SECRET = os.environ.get("STRAVA_CLIENT_SECRET", "").strip()
 PER_PAGE = 200
 DEFAULT_LOOKBACK_DAYS = 120
 DEFAULT_DETAIL_REQUEST_LIMIT = 40
+DEFAULT_STREAM_REQUEST_LIMIT = 30
+STREAM_KEYS = (
+    "time",
+    "heartrate",
+    "moving",
+    "cadence",
+    "watts",
+    "velocity_smooth",
+)
 
 OUTFILE = "assets/strava.json"
 TOKEN_FILE = "_private/strava_token.json"
@@ -33,6 +49,9 @@ def read_int_env(name: str, default: int, minimum: int = 1) -> int:
 LOOKBACK_DAYS = read_int_env("STRAVA_LOOKBACK_DAYS", DEFAULT_LOOKBACK_DAYS)
 DETAIL_REQUEST_LIMIT = read_int_env(
     "STRAVA_DETAIL_REQUEST_LIMIT", DEFAULT_DETAIL_REQUEST_LIMIT, minimum=0
+)
+STREAM_REQUEST_LIMIT = read_int_env(
+    "STRAVA_STREAM_REQUEST_LIMIT", DEFAULT_STREAM_REQUEST_LIMIT, minimum=0
 )
 
 
@@ -175,6 +194,32 @@ def get_activity_details(access_token: str, activity_id: int) -> dict:
     return response.json()
 
 
+def get_activity_streams(access_token: str, activity_id: int) -> dict[str, list]:
+    response = requests.get(
+        f"https://www.strava.com/api/v3/activities/{activity_id}/streams",
+        headers={"Authorization": f"Bearer {access_token}"},
+        params={"keys": ",".join(STREAM_KEYS), "key_by_type": "true"},
+        timeout=30,
+    )
+    response.raise_for_status()
+    payload = response.json()
+    streams: dict[str, list] = {}
+    if isinstance(payload, dict):
+        for key, value in payload.items():
+            data = value.get("data") if isinstance(value, dict) else value
+            if isinstance(data, list):
+                streams[str(key)] = data
+    elif isinstance(payload, list):
+        for value in payload:
+            if not isinstance(value, dict):
+                continue
+            key = value.get("type")
+            data = value.get("data")
+            if key and isinstance(data, list):
+                streams[str(key)] = data
+    return streams
+
+
 def activity_needs_details(activity: dict) -> bool:
     if not activity.get("id"):
         return False
@@ -188,7 +233,12 @@ def enrich_activity(activity: dict, access_token: str) -> dict:
     if not activity_needs_details(activity):
         return activity
     details = get_activity_details(access_token, activity["id"])
-    for key in ("average_heartrate", "max_heartrate", "perceived_exertion"):
+    for key in (
+        "average_heartrate",
+        "max_heartrate",
+        "perceived_exertion",
+        "sport_type",
+    ):
         if activity.get(key) is None and details.get(key) is not None:
             activity[key] = details.get(key)
     return activity
@@ -215,17 +265,16 @@ def load_exertion_overrides() -> dict[str, dict[str, float | bool]]:
     return overrides
 
 
-def estimate_exertion(
-    avg_hr: float | None, max_hr: float | None, elapsed_time_min: float | None
-) -> float | None:
-    if not avg_hr or not max_hr or not elapsed_time_min:
-        return None
-    if max_hr <= 0 or elapsed_time_min <= 0:
-        return None
-    intensity = avg_hr / max_hr
-    score = intensity * (elapsed_time_min / 60.0) * 3.5
-    score = max(0.0, score)
-    return round(score, 2)
+def has_v2_score_features(activity: dict | None) -> bool:
+    if not isinstance(activity, dict):
+        return False
+    features = activity.get("score_features")
+    if not isinstance(features, dict):
+        return False
+    try:
+        return int(features.get("version") or 0) >= SCORE_MODEL_VERSION
+    except (TypeError, ValueError):
+        return False
 
 
 def slim(activity: dict) -> dict:
@@ -233,6 +282,7 @@ def slim(activity: dict) -> dict:
         "id": activity.get("id"),
         "name": activity.get("name"),
         "type": activity.get("type"),
+        "sport_type": activity.get("sport_type") or activity.get("type"),
         "start_date": activity.get("start_date"),
         "distance_km": round(((activity.get("distance") or 0.0) / 1000.0), 2),
         "moving_time_min": round(((activity.get("moving_time") or 0) / 60.0), 1),
@@ -251,6 +301,7 @@ def slim(activity: dict) -> dict:
             if activity.get("id")
             else None
         ),
+        "score_model_version": SCORE_MODEL_VERSION,
     }
 
 
@@ -279,6 +330,7 @@ def merge_activities(existing: list[dict], fresh: list[dict]) -> list[dict]:
 def write_payload(activities: list[dict], error: str | None = None) -> None:
     payload = {
         "updated_utc": datetime.now(timezone.utc).isoformat(),
+        "score_model_version": SCORE_MODEL_VERSION,
         "activities": activities,
         "error": error,
     }
@@ -327,6 +379,11 @@ def main() -> None:
         overrides = load_exertion_overrides()
         existing_payload = read_existing_payload() or {}
         existing_activities = existing_payload.get("activities") or []
+        existing_by_id = {
+            str(activity.get("id")): activity
+            for activity in existing_activities
+            if activity.get("id") is not None
+        }
         access_token = ""
         next_refresh_token = None
         refresh_token = ""
@@ -353,9 +410,10 @@ def main() -> None:
                 raise
         if next_refresh_token and next_refresh_token != refresh_token:
             persist_refresh_token(next_refresh_token)
-        slimmed: list[dict] = []
+
         detail_requests = 0
         detail_requests_enabled = DETAIL_REQUEST_LIMIT > 0
+        enriched_activities: list[dict] = []
         for activity in activities:
             enriched = activity
             if detail_requests_enabled and activity_needs_details(activity):
@@ -370,11 +428,7 @@ def main() -> None:
                         enriched = enrich_activity(activity, access_token)
                         detail_requests += 1
                     except requests.HTTPError as error:
-                        status_code = (
-                            error.response.status_code
-                            if error.response is not None
-                            else None
-                        )
+                        status_code = get_http_status_code(error)
                         if status_code == 429:
                             detail_requests_enabled = False
                             print(
@@ -392,22 +446,73 @@ def main() -> None:
                             "Skipping Strava activity "
                             f"{activity.get('id')} details after request error: {error}."
                         )
-            payload = slim(enriched)
-            payload["estimated_exertion"] = estimate_exertion(
-                payload.get("avg_hr"),
-                payload.get("max_hr"),
-                payload.get("elapsed_time_min"),
+            enriched_activities.append(enriched)
+
+        hr_reference = estimate_hr_reference(
+            enriched_activities, existing_activities
+        )
+        slimmed: list[dict] = []
+        stream_requests = 0
+        stream_requests_enabled = STREAM_REQUEST_LIMIT > 0
+        for activity in enriched_activities:
+            payload = slim(activity)
+            existing = existing_by_id.get(str(payload.get("id")))
+            cached_features = (
+                existing.get("score_features")
+                if has_v2_score_features(existing)
+                else None
             )
+            score_features = cached_features
+
+            if score_features is None and stream_requests_enabled and payload.get("id"):
+                if stream_requests >= STREAM_REQUEST_LIMIT:
+                    stream_requests_enabled = False
+                    print(
+                        "Reached Strava stream request limit; deriving remaining "
+                        "features from activity summaries."
+                    )
+                else:
+                    try:
+                        streams = get_activity_streams(access_token, payload["id"])
+                        stream_requests += 1
+                        score_features = derive_stream_score_features(
+                            activity, streams, hr_reference
+                        )
+                    except requests.HTTPError as error:
+                        status_code = get_http_status_code(error)
+                        if status_code == 429:
+                            stream_requests_enabled = False
+                            print(
+                                "Strava stream rate limit reached; deriving "
+                                "remaining features from activity summaries."
+                            )
+                        else:
+                            print(
+                                "Skipping Strava activity "
+                                f"{activity.get('id')} streams after HTTP "
+                                f"{status_code or 'error'}."
+                            )
+                    except requests.RequestException as error:
+                        print(
+                            "Skipping Strava activity "
+                            f"{activity.get('id')} streams after request error: {error}."
+                        )
+
+            if score_features is None:
+                score_features = get_summary_score_features(activity, hr_reference)
+            payload["score_features"] = score_features
             override = overrides.get(str(payload.get("id")))
             payload["exertion"] = override.get("exertion") if override else None
             payload["faulty"] = bool(override.get("faulty")) if override else False
             slimmed.append(payload)
+
         merged = merge_activities(existing_activities, slimmed)
         write_payload(merged)
         print(
             f"Published {len(merged)} Strava activities "
             f"({len(slimmed)} fetched from the last {LOOKBACK_DAYS} days, "
-            f"{detail_requests} detail requests)."
+            f"{detail_requests} detail requests, {stream_requests} stream requests, "
+            f"score model v{SCORE_MODEL_VERSION})."
         )
     except requests.HTTPError as error:
         status_code = get_http_status_code(error)

--- a/scripts/strava_score_features.py
+++ b/scripts/strava_score_features.py
@@ -1,0 +1,402 @@
+import math
+import statistics
+
+SCORE_MODEL_VERSION = 2
+DEFAULT_MAX_HR = 190.0
+
+STRENGTH_TYPES = {"weighttraining"}
+HYBRID_TYPES = {
+    "crossfit",
+    "highintensityintervaltraining",
+    "hiit",
+    "workout",
+}
+MOBILITY_TYPES = {"pilates", "yoga"}
+CARDIO_TYPES = {
+    "alpineski",
+    "backcountryski",
+    "canoeing",
+    "ebikeride",
+    "elliptical",
+    "gravelride",
+    "handcycle",
+    "hike",
+    "iceskate",
+    "inlineskate",
+    "kayaking",
+    "kitesurf",
+    "mountainbikeride",
+    "nordicski",
+    "ride",
+    "rockclimbing",
+    "rollerski",
+    "rowing",
+    "run",
+    "sail",
+    "skateboard",
+    "snowboard",
+    "snowshoe",
+    "soccer",
+    "stairstepper",
+    "standuppaddling",
+    "surfing",
+    "swim",
+    "trailrun",
+    "velomobile",
+    "virtualride",
+    "virtualrow",
+    "virtualrun",
+    "walk",
+    "watersport",
+    "wheelchair",
+    "windsurf",
+}
+
+
+def normalize_type(value: object) -> str:
+    normalized = str(value or "").lower()
+    return "".join(character for character in normalized if character.isalnum())
+
+
+def get_modality(activity: dict) -> str:
+    activity_type = normalize_type(
+        activity.get("sport_type") or activity.get("type")
+    )
+    if activity_type in STRENGTH_TYPES:
+        return "strength"
+    if activity_type in HYBRID_TYPES:
+        return "hybrid"
+    if activity_type in MOBILITY_TYPES:
+        return "mobility"
+    if activity_type in CARDIO_TYPES:
+        return "cardio"
+    if (activity.get("distance") or 0) > 0:
+        return "cardio"
+    if (activity.get("average_speed") or 0) > 0:
+        return "cardio"
+    return "strength"
+
+
+def get_effective_active_minutes(activity: dict, modality: str) -> float:
+    moving = max(0.0, float(activity.get("moving_time") or 0) / 60.0)
+    elapsed = max(0.0, float(activity.get("elapsed_time") or 0) / 60.0)
+    if modality == "cardio":
+        return min(360.0, moving or elapsed)
+    if moving >= 5.0:
+        return min(360.0, moving)
+    return min(360.0, elapsed or moving)
+
+
+def estimate_hr_reference(activities: list[dict], existing: list[dict]) -> float:
+    observed: list[float] = []
+    for activity in [*activities, *existing]:
+        value = activity.get("max_heartrate")
+        if value is None:
+            value = activity.get("max_hr")
+        try:
+            numeric = float(value)
+        except (TypeError, ValueError):
+            continue
+        if 100 <= numeric <= 240:
+            observed.append(numeric)
+    if not observed:
+        return DEFAULT_MAX_HR
+    observed.sort()
+    percentile_index = min(
+        len(observed) - 1, max(0, math.ceil(0.95 * len(observed)) - 1)
+    )
+    return max(185.0, observed[percentile_index])
+
+
+def get_hr_zone(heart_rate: float | None, hr_reference: float) -> int:
+    if heart_rate is None or not math.isfinite(heart_rate) or heart_rate <= 0:
+        return 1
+    ratio = heart_rate / hr_reference
+    if ratio < 0.60:
+        return 0
+    if ratio < 0.70:
+        return 1
+    if ratio < 0.80:
+        return 2
+    if ratio < 0.90:
+        return 3
+    return 4
+
+
+def get_summary_score_features(activity: dict, hr_reference: float) -> dict:
+    modality = get_modality(activity)
+    active_minutes = get_effective_active_minutes(activity, modality)
+    zone_minutes = [0.0, 0.0, 0.0, 0.0, 0.0]
+    average_hr = activity.get("average_heartrate")
+    if average_hr is None:
+        average_hr = activity.get("avg_hr")
+    try:
+        average_hr_value = float(average_hr) if average_hr is not None else None
+    except (TypeError, ValueError):
+        average_hr_value = None
+    strength_minutes = 0.0
+    strength_density = 0.0
+    strength_factor = 1.0
+
+    if modality == "cardio":
+        zone_minutes[get_hr_zone(average_hr_value, hr_reference)] = active_minutes
+    elif modality == "hybrid":
+        strength_minutes = active_minutes * 0.75
+        zone_minutes[get_hr_zone(average_hr_value, hr_reference)] = (
+            active_minutes * 0.25
+        )
+        strength_density = 0.25
+    else:
+        strength_minutes = active_minutes
+        if modality == "mobility":
+            strength_density = 0.2
+            strength_factor = 0.65
+
+    cardio_minutes = sum(zone_minutes)
+    return {
+        "version": SCORE_MODEL_VERSION,
+        "source": "summary",
+        "active_minutes": round(strength_minutes + cardio_minutes, 2),
+        "effective_active_minutes": round(strength_minutes + cardio_minutes, 2),
+        "strength_minutes": round(strength_minutes, 2),
+        "strength_block_minutes": round(strength_minutes, 2),
+        "cardio_zone_minutes": [round(value, 2) for value in zone_minutes],
+        "cardio_block_minutes": round(cardio_minutes, 2),
+        "strength_density": round(strength_density, 3),
+        "strength_factor": strength_factor,
+        "work_recovery_cycles": 0,
+        "hr_max_reference": round(hr_reference, 1),
+    }
+
+
+def safe_stream_value(values: list | None, index: int) -> object | None:
+    if not isinstance(values, list) or index >= len(values):
+        return None
+    return values[index]
+
+
+def numeric_stream_value(values: list | None, index: int) -> float | None:
+    value = safe_stream_value(values, index)
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return None
+    return numeric if math.isfinite(numeric) else None
+
+
+def get_sample_durations(times: list) -> list[float]:
+    numeric_times: list[float] = []
+    for index, value in enumerate(times):
+        try:
+            numeric = float(value)
+        except (TypeError, ValueError):
+            numeric = float(index)
+        numeric_times.append(numeric)
+    positive_steps = [
+        numeric_times[index + 1] - numeric_times[index]
+        for index in range(len(numeric_times) - 1)
+        if 0 < numeric_times[index + 1] - numeric_times[index] <= 30
+    ]
+    default_step = statistics.median(positive_steps) if positive_steps else 1.0
+    durations: list[float] = []
+    for index, value in enumerate(numeric_times):
+        if index + 1 < len(numeric_times):
+            step = numeric_times[index + 1] - value
+        else:
+            step = default_step
+        durations.append(min(30.0, max(0.0, step)))
+    return durations
+
+
+def find_stable_cardio_samples(
+    heart_rates: list[float | None],
+    durations: list[float],
+    hr_reference: float,
+    minimum_minutes: float,
+) -> set[int]:
+    stable_indices: set[int] = set()
+    segment: list[int] = []
+
+    def close_segment() -> None:
+        if not segment:
+            return
+        duration = sum(durations[index] for index in segment)
+        values = [
+            heart_rates[index]
+            for index in segment
+            if heart_rates[index] is not None
+        ]
+        if duration >= minimum_minutes * 60 and len(values) >= 2:
+            variability = statistics.pstdev(values)
+            if variability <= 12:
+                stable_indices.update(segment)
+        segment.clear()
+
+    for index, heart_rate in enumerate(heart_rates):
+        if heart_rate is not None and heart_rate / hr_reference >= 0.65:
+            segment.append(index)
+        else:
+            close_segment()
+    close_segment()
+    return stable_indices
+
+
+def derive_stream_score_features(
+    activity: dict, streams: dict[str, list], hr_reference: float
+) -> dict | None:
+    times = streams.get("time")
+    if not isinstance(times, list) or len(times) < 2:
+        return None
+    durations = get_sample_durations(times)
+    sample_count = len(durations)
+    heartrate_stream = streams.get("heartrate")
+    moving_stream = streams.get("moving")
+    cadence_stream = streams.get("cadence")
+    watts_stream = streams.get("watts")
+    velocity_stream = streams.get("velocity_smooth")
+
+    has_hr = isinstance(heartrate_stream, list) and bool(heartrate_stream)
+    has_movement_signal = any(
+        isinstance(stream, list) and bool(stream)
+        for stream in (moving_stream, cadence_stream, watts_stream, velocity_stream)
+    )
+    if not has_hr and not has_movement_signal:
+        return None
+
+    modality = get_modality(activity)
+    heart_rates = [
+        numeric_stream_value(heartrate_stream, index)
+        for index in range(sample_count)
+    ]
+    stable_cardio = find_stable_cardio_samples(
+        heart_rates,
+        durations,
+        hr_reference,
+        6.0 if modality == "hybrid" else 8.0,
+    )
+
+    density_active_flags: list[bool] = []
+    cardio_flags: list[bool] = []
+    for index in range(sample_count):
+        heart_rate = heart_rates[index]
+        moving_value = safe_stream_value(moving_stream, index)
+        moving = bool(moving_value) if moving_value is not None else False
+        cadence = numeric_stream_value(cadence_stream, index) or 0.0
+        watts = numeric_stream_value(watts_stream, index) or 0.0
+        velocity = numeric_stream_value(velocity_stream, index) or 0.0
+        explicit_locomotion = bool(
+            (moving and velocity >= 0.5)
+            or cadence >= 20
+            or watts >= 35
+            or velocity >= 0.8
+        )
+        hr_work = bool(
+            heart_rate is not None and heart_rate / hr_reference >= 0.62
+        )
+        hr_cardio_active = bool(
+            heart_rate is not None and heart_rate / hr_reference >= 0.45
+        )
+        stable = index in stable_cardio
+
+        if modality in {"strength", "hybrid", "mobility"}:
+            density_active = explicit_locomotion or hr_work or (not has_hr and moving)
+        else:
+            density_active = explicit_locomotion or moving or hr_cardio_active
+
+        if modality == "mobility":
+            cardio = False
+        else:
+            cardio = explicit_locomotion or (
+                stable and modality in {"cardio", "hybrid"}
+            )
+
+        density_active_flags.append(density_active)
+        cardio_flags.append(cardio)
+
+    if modality == "cardio":
+        non_cardio_active_seconds = sum(
+            duration
+            for duration, active, cardio in zip(
+                durations, density_active_flags, cardio_flags, strict=True
+            )
+            if active and not cardio
+        )
+        if non_cardio_active_seconds < 8 * 60:
+            cardio_flags = list(density_active_flags)
+
+    strength_flags = [False] * sample_count
+    if modality in {"strength", "hybrid", "mobility"}:
+        evidence_indices = [
+            index
+            for index in range(sample_count)
+            if density_active_flags[index] and not cardio_flags[index]
+        ]
+        if evidence_indices:
+            first_strength = evidence_indices[0]
+            last_strength = evidence_indices[-1]
+            for index in range(first_strength, last_strength + 1):
+                strength_flags[index] = not cardio_flags[index]
+    else:
+        for index in range(sample_count):
+            strength_flags[index] = bool(
+                density_active_flags[index] and not cardio_flags[index]
+            )
+
+    zone_seconds = [0.0, 0.0, 0.0, 0.0, 0.0]
+    cardio_seconds = 0.0
+    strength_seconds = 0.0
+    active_strength_seconds = 0.0
+    strength_indices: list[int] = []
+    for index, duration in enumerate(durations):
+        if duration <= 0:
+            continue
+        if cardio_flags[index] and density_active_flags[index]:
+            zone = get_hr_zone(heart_rates[index], hr_reference)
+            zone_seconds[zone] += duration
+            cardio_seconds += duration
+        elif strength_flags[index]:
+            strength_seconds += duration
+            strength_indices.append(index)
+            if density_active_flags[index]:
+                active_strength_seconds += duration
+
+    if strength_seconds <= 0 and cardio_seconds <= 0:
+        return None
+
+    strength_density = (
+        active_strength_seconds / strength_seconds if strength_seconds > 0 else 0.0
+    )
+
+    cycles = 0
+    cycle_state = "recovery"
+    for index in strength_indices:
+        heart_rate = heart_rates[index]
+        if heart_rate is None:
+            continue
+        ratio = heart_rate / hr_reference
+        if cycle_state == "recovery" and ratio >= 0.68:
+            cycles += 1
+            cycle_state = "work"
+        elif cycle_state == "work" and ratio <= 0.58:
+            cycle_state = "recovery"
+
+    strength_factor = 0.65 if modality == "mobility" else 1.0
+    strength_minutes = strength_seconds / 60.0
+    cardio_minutes = cardio_seconds / 60.0
+    effective_minutes = strength_minutes + cardio_minutes
+    return {
+        "version": SCORE_MODEL_VERSION,
+        "source": "streams",
+        "active_minutes": round(effective_minutes, 2),
+        "effective_active_minutes": round(effective_minutes, 2),
+        "strength_minutes": round(strength_minutes, 2),
+        "strength_block_minutes": round(strength_minutes, 2),
+        "cardio_zone_minutes": [
+            round(seconds / 60.0, 2) for seconds in zone_seconds
+        ],
+        "cardio_block_minutes": round(cardio_minutes, 2),
+        "strength_density": round(min(1.0, max(0.0, strength_density)), 3),
+        "strength_factor": strength_factor,
+        "work_recovery_cycles": cycles,
+        "hr_max_reference": round(hr_reference, 1),
+    }

--- a/scripts/strava_score_features.py
+++ b/scripts/strava_score_features.py
@@ -2,6 +2,7 @@ import math
 import statistics
 
 SCORE_MODEL_VERSION = 2
+STREAM_FEATURE_VERSION = 2
 DEFAULT_MAX_HR = 190.0
 
 STRENGTH_TYPES = {"weighttraining"}
@@ -198,6 +199,7 @@ def get_summary_score_features(activity: dict, hr_reference: float) -> dict:
     cardio_minutes = sum(zone_minutes)
     return {
         "version": SCORE_MODEL_VERSION,
+        "feature_version": STREAM_FEATURE_VERSION,
         "source": "summary",
         "active_minutes": round(strength_minutes + cardio_minutes, 2),
         "effective_active_minutes": round(strength_minutes + cardio_minutes, 2),
@@ -346,43 +348,52 @@ def derive_stream_score_features(
 
     has_hr = isinstance(heartrate_stream, list) and bool(heartrate_stream)
     has_moving_stream = isinstance(moving_stream, list) and bool(moving_stream)
-    has_detailed_motion = any(
+    has_detailed_stream = any(
         isinstance(stream, list) and bool(stream)
         for stream in (cadence_stream, watts_stream, velocity_stream)
     )
-    has_movement_signal = has_moving_stream or has_detailed_motion
-    if not has_hr and not has_movement_signal:
+    if not has_hr and not has_moving_stream and not has_detailed_stream:
         return None
 
     modality = get_modality(activity)
-    if modality == "hybrid" and not has_movement_signal:
-        return None
-
     heart_rates = [
         numeric_stream_value(heartrate_stream, index)
         for index in range(sample_count)
     ]
+    moving_flags = [
+        bool(safe_stream_value(moving_stream, index))
+        for index in range(sample_count)
+    ]
+    detailed_locomotion_flags = []
+    for index in range(sample_count):
+        cadence = numeric_stream_value(cadence_stream, index) or 0.0
+        watts = numeric_stream_value(watts_stream, index) or 0.0
+        velocity = numeric_stream_value(velocity_stream, index) or 0.0
+        detailed_locomotion_flags.append(
+            bool(cadence >= 20 or watts >= 35 or velocity >= 0.8)
+        )
+    has_meaningful_detailed_motion = any(detailed_locomotion_flags)
+    has_movement_signal = has_moving_stream or has_meaningful_detailed_motion
+    if modality == "hybrid" and not has_movement_signal:
+        return None
+
     density_active_flags: list[bool] = []
     locomotion_flags: list[bool] = []
     for index in range(sample_count):
         heart_rate = heart_rates[index]
-        moving_value = safe_stream_value(moving_stream, index)
-        moving = bool(moving_value) if moving_value is not None else False
-        cadence = numeric_stream_value(cadence_stream, index) or 0.0
-        watts = numeric_stream_value(watts_stream, index) or 0.0
-        velocity = numeric_stream_value(velocity_stream, index) or 0.0
-        detailed_locomotion = bool(
-            (moving and velocity >= 0.5)
-            or cadence >= 20
-            or watts >= 35
-            or velocity >= 0.8
-        )
-        if has_detailed_motion:
-            locomotion = detailed_locomotion
-        elif has_moving_stream:
-            locomotion = moving
+        moving = moving_flags[index]
+        detailed_locomotion = detailed_locomotion_flags[index]
+        if modality == "cardio":
+            locomotion = (
+                detailed_locomotion
+                if has_meaningful_detailed_motion
+                else moving
+            )
         else:
-            locomotion = False
+            # A generic moving flag is too permissive for strength-tagged
+            # activities. Require cadence, power or velocity evidence before
+            # assigning any part of them to cardio.
+            locomotion = detailed_locomotion
 
         hr_work = bool(
             heart_rate is not None and heart_rate / hr_reference >= 0.62
@@ -393,13 +404,12 @@ def derive_stream_score_features(
         if modality in {"strength", "hybrid", "mobility"}:
             density_active = locomotion or hr_work or (not has_hr and moving)
         else:
-            density_active = locomotion or (
-                not has_movement_signal and hr_cardio_active
-            )
+            density_active = locomotion or hr_cardio_active
 
         locomotion_flags.append(locomotion)
         density_active_flags.append(density_active)
 
+    has_affirmative_locomotion = any(locomotion_flags)
     detected_strength = (
         find_strength_like_samples(
             locomotion_flags, heart_rates, durations, hr_reference
@@ -434,7 +444,7 @@ def derive_stream_score_features(
                     and (
                         locomotion_flags[index]
                         or (
-                            not has_movement_signal
+                            not has_affirmative_locomotion
                             and density_active_flags[index]
                         )
                     )
@@ -491,6 +501,7 @@ def derive_stream_score_features(
     effective_minutes = strength_minutes + cardio_minutes
     return {
         "version": SCORE_MODEL_VERSION,
+        "feature_version": STREAM_FEATURE_VERSION,
         "source": "streams",
         "active_minutes": round(effective_minutes, 2),
         "effective_active_minutes": round(effective_minutes, 2),

--- a/scripts/strava_score_features.py
+++ b/scripts/strava_score_features.py
@@ -15,9 +15,11 @@ MOBILITY_TYPES = {"pilates", "yoga"}
 CARDIO_TYPES = {
     "alpineski",
     "backcountryski",
+    "badminton",
     "canoeing",
     "ebikeride",
     "elliptical",
+    "golf",
     "gravelride",
     "handcycle",
     "hike",
@@ -27,6 +29,8 @@ CARDIO_TYPES = {
     "kitesurf",
     "mountainbikeride",
     "nordicski",
+    "pickleball",
+    "racquetball",
     "ride",
     "rockclimbing",
     "rollerski",
@@ -37,9 +41,12 @@ CARDIO_TYPES = {
     "snowboard",
     "snowshoe",
     "soccer",
+    "squash",
     "stairstepper",
     "standuppaddling",
     "surfing",
+    "tabletennis",
+    "tennis",
     "swim",
     "trailrun",
     "velomobile",
@@ -77,14 +84,50 @@ def get_modality(activity: dict) -> str:
     return "strength"
 
 
+def parse_non_negative_number(value: object) -> float | None:
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(numeric) or numeric < 0:
+        return None
+    return numeric
+
+
+def estimate_cardio_seconds_from_distance(activity: dict) -> float:
+    distance = parse_non_negative_number(activity.get("distance"))
+    average_speed = parse_non_negative_number(activity.get("average_speed"))
+    if not distance or not average_speed:
+        return 0.0
+    estimate = distance / average_speed
+    return estimate if math.isfinite(estimate) and estimate > 0 else 0.0
+
+
 def get_effective_active_minutes(activity: dict, modality: str) -> float:
-    moving = max(0.0, float(activity.get("moving_time") or 0) / 60.0)
-    elapsed = max(0.0, float(activity.get("elapsed_time") or 0) / 60.0)
+    moving_seconds = parse_non_negative_number(activity.get("moving_time"))
+    elapsed_seconds = parse_non_negative_number(activity.get("elapsed_time"))
+    has_moving_time = "moving_time" in activity and moving_seconds is not None
+
     if modality == "cardio":
-        return min(360.0, moving or elapsed)
-    if moving >= 5.0:
-        return min(360.0, moving)
-    return min(360.0, elapsed or moving)
+        if has_moving_time:
+            active_seconds = moving_seconds
+        else:
+            active_seconds = estimate_cardio_seconds_from_distance(activity)
+        if elapsed_seconds is not None:
+            active_seconds = min(active_seconds, elapsed_seconds)
+        return min(360.0, active_seconds / 60.0)
+
+    moving = (moving_seconds or 0.0) / 60.0
+    elapsed = (elapsed_seconds or 0.0) / 60.0
+    if elapsed > 0:
+        if not has_moving_time or moving < 5.0:
+            return min(360.0, elapsed)
+        return min(
+            360.0,
+            elapsed,
+            max(moving + 30.0, moving * 1.5, 15.0),
+        )
+    return min(360.0, moving)
 
 
 def estimate_hr_reference(activities: list[dict], existing: list[dict]) -> float:
@@ -105,7 +148,7 @@ def estimate_hr_reference(activities: list[dict], existing: list[dict]) -> float
     percentile_index = min(
         len(observed) - 1, max(0, math.ceil(0.95 * len(observed)) - 1)
     )
-    return max(185.0, observed[percentile_index])
+    return max(DEFAULT_MAX_HR, observed[percentile_index])
 
 
 def get_hr_zone(heart_rate: float | None, hr_reference: float) -> int:
@@ -195,26 +238,64 @@ def get_sample_durations(times: list) -> list[float]:
     positive_steps = [
         numeric_times[index + 1] - numeric_times[index]
         for index in range(len(numeric_times) - 1)
-        if 0 < numeric_times[index + 1] - numeric_times[index] <= 30
+        if 0 < numeric_times[index + 1] - numeric_times[index] <= 300
     ]
     default_step = statistics.median(positive_steps) if positive_steps else 1.0
+    maximum_step = max(30.0, min(300.0, default_step * 3.0))
     durations: list[float] = []
     for index, value in enumerate(numeric_times):
-        if index + 1 < len(numeric_times):
-            step = numeric_times[index + 1] - value
-        else:
-            step = default_step
-        durations.append(min(30.0, max(0.0, step)))
+        if index + 1 >= len(numeric_times):
+            durations.append(0.0)
+            continue
+        step = numeric_times[index + 1] - value
+        durations.append(min(maximum_step, max(0.0, step)))
     return durations
 
 
-def find_stable_cardio_samples(
+def percentile(values: list[float], fraction: float) -> float:
+    ordered = sorted(values)
+    if not ordered:
+        return 0.0
+    position = (len(ordered) - 1) * min(1.0, max(0.0, fraction))
+    lower_index = math.floor(position)
+    upper_index = math.ceil(position)
+    if lower_index == upper_index:
+        return ordered[lower_index]
+    weight = position - lower_index
+    return (
+        ordered[lower_index] * (1.0 - weight)
+        + ordered[upper_index] * weight
+    )
+
+
+def count_work_recovery_cycles(values: list[float]) -> int:
+    if len(values) < 4:
+        return 0
+    low = percentile(values, 0.30)
+    high = percentile(values, 0.70)
+    if high - low < 10.0:
+        return 0
+
+    cycles = 0
+    state = "seek_low"
+    for value in values:
+        if state == "seek_low":
+            if value <= low:
+                state = "seek_high"
+        elif value >= high:
+            cycles += 1
+            state = "seek_low"
+    return cycles
+
+
+def find_strength_like_samples(
+    locomotion_flags: list[bool],
     heart_rates: list[float | None],
     durations: list[float],
     hr_reference: float,
-    minimum_minutes: float,
+    minimum_minutes: float = 8.0,
 ) -> set[int]:
-    stable_indices: set[int] = set()
+    strength_indices: set[int] = set()
     segment: list[int] = []
 
     def close_segment() -> None:
@@ -226,19 +307,27 @@ def find_stable_cardio_samples(
             for index in segment
             if heart_rates[index] is not None
         ]
-        if duration >= minimum_minutes * 60 and len(values) >= 2:
-            variability = statistics.pstdev(values)
-            if variability <= 12:
-                stable_indices.update(segment)
+        high_enough = any(value / hr_reference >= 0.62 for value in values)
+        if (
+            duration >= minimum_minutes * 60
+            and high_enough
+            and count_work_recovery_cycles(values) >= 2
+        ):
+            strength_indices.update(segment)
         segment.clear()
 
     for index, heart_rate in enumerate(heart_rates):
-        if heart_rate is not None and heart_rate / hr_reference >= 0.65:
+        candidate = bool(
+            not locomotion_flags[index]
+            and heart_rate is not None
+            and heart_rate / hr_reference >= 0.45
+        )
+        if candidate:
             segment.append(index)
         else:
             close_segment()
     close_segment()
-    return stable_indices
+    return strength_indices
 
 
 def derive_stream_score_features(
@@ -256,27 +345,25 @@ def derive_stream_score_features(
     velocity_stream = streams.get("velocity_smooth")
 
     has_hr = isinstance(heartrate_stream, list) and bool(heartrate_stream)
-    has_movement_signal = any(
+    has_moving_stream = isinstance(moving_stream, list) and bool(moving_stream)
+    has_detailed_motion = any(
         isinstance(stream, list) and bool(stream)
-        for stream in (moving_stream, cadence_stream, watts_stream, velocity_stream)
+        for stream in (cadence_stream, watts_stream, velocity_stream)
     )
+    has_movement_signal = has_moving_stream or has_detailed_motion
     if not has_hr and not has_movement_signal:
         return None
 
     modality = get_modality(activity)
+    if modality == "hybrid" and not has_movement_signal:
+        return None
+
     heart_rates = [
         numeric_stream_value(heartrate_stream, index)
         for index in range(sample_count)
     ]
-    stable_cardio = find_stable_cardio_samples(
-        heart_rates,
-        durations,
-        hr_reference,
-        6.0 if modality == "hybrid" else 8.0,
-    )
-
     density_active_flags: list[bool] = []
-    cardio_flags: list[bool] = []
+    locomotion_flags: list[bool] = []
     for index in range(sample_count):
         heart_rate = heart_rates[index]
         moving_value = safe_stream_value(moving_stream, index)
@@ -284,48 +371,50 @@ def derive_stream_score_features(
         cadence = numeric_stream_value(cadence_stream, index) or 0.0
         watts = numeric_stream_value(watts_stream, index) or 0.0
         velocity = numeric_stream_value(velocity_stream, index) or 0.0
-        explicit_locomotion = bool(
+        detailed_locomotion = bool(
             (moving and velocity >= 0.5)
             or cadence >= 20
             or watts >= 35
             or velocity >= 0.8
         )
+        if has_detailed_motion:
+            locomotion = detailed_locomotion
+        elif has_moving_stream:
+            locomotion = moving
+        else:
+            locomotion = False
+
         hr_work = bool(
             heart_rate is not None and heart_rate / hr_reference >= 0.62
         )
         hr_cardio_active = bool(
             heart_rate is not None and heart_rate / hr_reference >= 0.45
         )
-        stable = index in stable_cardio
-
         if modality in {"strength", "hybrid", "mobility"}:
-            density_active = explicit_locomotion or hr_work or (not has_hr and moving)
+            density_active = locomotion or hr_work or (not has_hr and moving)
         else:
-            density_active = explicit_locomotion or moving or hr_cardio_active
-
-        if modality == "mobility":
-            cardio = False
-        else:
-            cardio = explicit_locomotion or (
-                stable and modality in {"cardio", "hybrid"}
+            density_active = locomotion or (
+                not has_movement_signal and hr_cardio_active
             )
 
+        locomotion_flags.append(locomotion)
         density_active_flags.append(density_active)
-        cardio_flags.append(cardio)
 
-    if modality == "cardio":
-        non_cardio_active_seconds = sum(
-            duration
-            for duration, active, cardio in zip(
-                durations, density_active_flags, cardio_flags, strict=True
-            )
-            if active and not cardio
+    detected_strength = (
+        find_strength_like_samples(
+            locomotion_flags, heart_rates, durations, hr_reference
         )
-        if non_cardio_active_seconds < 8 * 60:
-            cardio_flags = list(density_active_flags)
+        if modality == "cardio" and has_movement_signal and has_hr
+        else set()
+    )
 
-    strength_flags = [False] * sample_count
+    cardio_flags: list[bool] = []
+    strength_flags: list[bool] = [False] * sample_count
     if modality in {"strength", "hybrid", "mobility"}:
+        cardio_flags = [
+            locomotion and modality != "mobility"
+            for locomotion in locomotion_flags
+        ]
         evidence_indices = [
             index
             for index in range(sample_count)
@@ -338,9 +427,25 @@ def derive_stream_score_features(
                 strength_flags[index] = not cardio_flags[index]
     else:
         for index in range(sample_count):
-            strength_flags[index] = bool(
-                density_active_flags[index] and not cardio_flags[index]
+            strength_flags[index] = index in detected_strength
+            cardio_flags.append(
+                bool(
+                    not strength_flags[index]
+                    and (
+                        locomotion_flags[index]
+                        or (
+                            not has_movement_signal
+                            and density_active_flags[index]
+                        )
+                    )
+                )
             )
+            if strength_flags[index]:
+                heart_rate = heart_rates[index]
+                density_active_flags[index] = bool(
+                    heart_rate is not None
+                    and heart_rate / hr_reference >= 0.62
+                )
 
     zone_seconds = [0.0, 0.0, 0.0, 0.0, 0.0]
     cardio_seconds = 0.0

--- a/service-worker.js
+++ b/service-worker.js
@@ -3,7 +3,7 @@
 const sw = /** @type {ServiceWorkerGlobalScope} */ (
   /** @type {unknown} */ (self)
 );
-const CACHE_NAME = 'timekeeper-app-v18';
+const CACHE_NAME = 'timekeeper-app-v19';
 const APP_SHELL = [
   './',
   './index.html',
@@ -17,6 +17,8 @@ const APP_SHELL = [
   './src/features/time-usage/core.mjs',
   './src/features/strava/core.mjs',
   './src/features/strava/import.mjs',
+  './src/features/strava/score-model.mjs',
+  './src/features/strava/sessions.mjs',
   './src/features/wealth/core.mjs',
   './src/features/workouts/runtime.mjs',
   './src/features/company-operator/core.mjs',
@@ -66,8 +68,8 @@ sw.addEventListener('activate', (event) => {
         if (!refreshExistingClients) return;
         clients.forEach((client) => {
           const url = new URL(client.url);
-          if (url.searchParams.get('timekeeper-update') === '16') return;
-          url.searchParams.set('timekeeper-update', '16');
+          if (url.searchParams.get('timekeeper-update') === '17') return;
+          url.searchParams.set('timekeeper-update', '17');
           client.navigate(url.href).catch(() => undefined);
         });
       })

--- a/src/features/strava/core.mjs
+++ b/src/features/strava/core.mjs
@@ -90,21 +90,57 @@ export function computeStravaRawScore(activity) {
   return score > 0 ? score : null;
 }
 
+function getSessionPrimaryIndex(session) {
+  let primaryIndex = 0;
+  let primaryScore = Number.NEGATIVE_INFINITY;
+  let primaryMinutes = Number.NEGATIVE_INFINITY;
+
+  session.activities.forEach((activity, index) => {
+    const breakdown = getStravaWorkoutScoreBreakdown(activity);
+    const score = Number(breakdown.total) || 0;
+    const minutes = Number(breakdown.features?.active_minutes) || 0;
+    if (
+      score > primaryScore ||
+      (Math.abs(score - primaryScore) < 1e-9 && minutes > primaryMinutes)
+    ) {
+      primaryIndex = index;
+      primaryScore = score;
+      primaryMinutes = minutes;
+    }
+  });
+
+  return primaryIndex;
+}
+
 export function computeStravaScoreScale(activities) {
   sessionScoreByActivityKey = new Map();
   sessionBreakdownByActivityKey = new Map();
-  const sessions = groupStravaActivitiesIntoSessions(activities);
+  const normalizedActivities = Array.isArray(activities) ? activities : [];
+  normalizedActivities.forEach((activity) => {
+    if (!activity || typeof activity !== 'object') return;
+    delete activity.exertion;
+    delete activity.local_exertion;
+    delete activity.faulty;
+    delete activity.local_faulty;
+    delete activity.estimated_exertion;
+  });
+  const sessions = groupStravaActivitiesIntoSessions(normalizedActivities);
 
   sessions.forEach((session) => {
     const breakdown = getStravaWorkoutScoreBreakdown(session.activity);
+    const primaryIndex = getSessionPrimaryIndex(session);
     session.activities.forEach((activity, index) => {
       const key = getActivityKey(activity);
       if (!key) return;
-      sessionScoreByActivityKey.set(key, index === 0 ? breakdown.total : null);
+      const sessionPrimary = index === primaryIndex;
+      sessionScoreByActivityKey.set(
+        key,
+        sessionPrimary ? breakdown.total : null
+      );
       sessionBreakdownByActivityKey.set(key, {
         ...breakdown,
         sessionActivityCount: session.activities.length,
-        sessionPrimary: index === 0
+        sessionPrimary
       });
     });
   });

--- a/src/features/strava/core.mjs
+++ b/src/features/strava/core.mjs
@@ -116,14 +116,6 @@ export function computeStravaScoreScale(activities) {
   sessionScoreByActivityKey = new Map();
   sessionBreakdownByActivityKey = new Map();
   const normalizedActivities = Array.isArray(activities) ? activities : [];
-  normalizedActivities.forEach((activity) => {
-    if (!activity || typeof activity !== 'object') return;
-    delete activity.exertion;
-    delete activity.local_exertion;
-    delete activity.faulty;
-    delete activity.local_faulty;
-    delete activity.estimated_exertion;
-  });
   const sessions = groupStravaActivitiesIntoSessions(normalizedActivities);
 
   sessions.forEach((session) => {

--- a/src/features/strava/core.mjs
+++ b/src/features/strava/core.mjs
@@ -1,4 +1,5 @@
 import {
+  STRAVA_FEATURE_VERSION,
   STRAVA_SCORE_DEFAULT_SCALE,
   STRAVA_SCORE_MODEL_VERSION,
   combineWorkoutComponents,
@@ -12,6 +13,7 @@ import {
 import { groupStravaActivitiesIntoSessions } from './sessions.mjs';
 
 export {
+  STRAVA_FEATURE_VERSION,
   STRAVA_SCORE_DEFAULT_SCALE,
   STRAVA_SCORE_MODEL_VERSION,
   combineWorkoutComponents,

--- a/src/features/strava/core.mjs
+++ b/src/features/strava/core.mjs
@@ -1,17 +1,62 @@
-const STRAVA_SCORE_BASELINE_HR = 250;
-const STRAVA_SCORE_BASE_HR = 70;
-export const STRAVA_SCORE_DEFAULT_SCALE = 12;
-const STRAVA_SCORE_SCALE_MIN = 0.5;
-const STRAVA_SCORE_SCALE_MAX = 30;
-const STRAVA_SCORE_INTENSITY_EXP = 1.6;
-const STRAVA_SCORE_DURATION_EXP = 0.9;
-const STRAVA_SCORE_SPIKE_WEIGHT = 0.6;
+import {
+  STRAVA_SCORE_DEFAULT_SCALE,
+  STRAVA_SCORE_MODEL_VERSION,
+  combineWorkoutComponents,
+  computeCardioCredit,
+  computeStravaRecoveryLoad,
+  computeStrengthCredit,
+  getStravaActivityModality,
+  getStravaScoreFeatures,
+  getStravaWorkoutScoreBreakdown
+} from './score-model.mjs';
+import { groupStravaActivitiesIntoSessions } from './sessions.mjs';
+
+export {
+  STRAVA_SCORE_DEFAULT_SCALE,
+  STRAVA_SCORE_MODEL_VERSION,
+  combineWorkoutComponents,
+  computeCardioCredit,
+  computeStravaRecoveryLoad,
+  computeStrengthCredit,
+  getStravaActivityModality,
+  getStravaScoreFeatures,
+  getStravaWorkoutScoreBreakdown,
+  groupStravaActivitiesIntoSessions
+};
+
+let sessionScoreByActivityKey = new Map();
+let sessionBreakdownByActivityKey = new Map();
+
+function getActivityKey(activity) {
+  if (!activity || typeof activity !== 'object') return null;
+  if (activity.id !== null && activity.id !== undefined && activity.id !== '') {
+    return `id:${String(activity.id)}`;
+  }
+  const start = String(activity.start_date || '');
+  const name = String(activity.name || '');
+  const type = String(activity.sport_type || activity.type || '');
+  if (!start && !name && !type) return null;
+  return `fallback:${start}|${name}|${type}`;
+}
+
+function getCachedSessionScore(activity) {
+  const key = getActivityKey(activity);
+  if (!key || !sessionScoreByActivityKey.has(key)) {
+    return { found: false, value: null };
+  }
+  return { found: true, value: sessionScoreByActivityKey.get(key) };
+}
+
+function roundScore(value) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return null;
+  return Math.round(Math.max(0, numeric) * 10) / 10;
+}
 
 export function parseExertionValue(rawValue) {
   const value = Number.parseFloat(rawValue);
   if (!Number.isFinite(value)) return null;
-  const clamped = Math.max(0, value);
-  return Math.round(clamped * 10) / 10;
+  return Math.round(Math.max(0, value) * 10) / 10;
 }
 
 export function formatExertion(value) {
@@ -25,35 +70,7 @@ export function formatExertion(value) {
 
 export function isStravaActivityFaulty(activity) {
   if (!activity || typeof activity !== 'object') return false;
-  if (activity.local_faulty === true) return true;
-  return activity.faulty === true;
-}
-
-export function computeStravaRawScore(activity) {
-  const avgHr = Number(activity?.avg_hr);
-  let maxHr = Number(activity?.max_hr);
-  const elapsed = Number(activity?.elapsed_time_min);
-  if (!Number.isFinite(avgHr) || !Number.isFinite(elapsed)) return null;
-  if (avgHr <= 0 || elapsed <= 0) return null;
-  if (!Number.isFinite(maxHr) || maxHr <= 0) {
-    maxHr = avgHr;
-  }
-  const denom = STRAVA_SCORE_BASELINE_HR - STRAVA_SCORE_BASE_HR;
-  if (!Number.isFinite(denom) || denom <= 0) return null;
-  const avgAdj = avgHr - STRAVA_SCORE_BASE_HR;
-  let maxAdj = maxHr - STRAVA_SCORE_BASE_HR;
-  if (!Number.isFinite(avgAdj) || avgAdj <= 0) return null;
-  if (!Number.isFinite(maxAdj) || maxAdj <= 0) {
-    maxAdj = avgAdj;
-  }
-  const intensity = avgAdj / denom;
-  const durationHours = elapsed / 60;
-  const spike = Math.max(0, Math.min(1, (maxAdj - avgAdj) / denom));
-  const quality = Math.pow(intensity, STRAVA_SCORE_INTENSITY_EXP);
-  const duration = Math.pow(durationHours, STRAVA_SCORE_DURATION_EXP);
-  const spikeFactor = 1 + STRAVA_SCORE_SPIKE_WEIGHT * spike;
-  const raw = quality * duration * spikeFactor;
-  return raw > 0 ? raw : null;
+  return activity.local_faulty === true || activity.faulty === true;
 }
 
 export function getMeasuredStravaScore(activity) {
@@ -67,49 +84,50 @@ export function getMeasuredStravaScore(activity) {
   return parseExertionValue(activity.reported_exertion);
 }
 
+export function computeStravaRawScore(activity) {
+  if (!activity) return null;
+  const score = getStravaWorkoutScoreBreakdown(activity).total;
+  return score > 0 ? score : null;
+}
+
 export function computeStravaScoreScale(activities) {
-  if (!Array.isArray(activities)) {
-    return { scale: STRAVA_SCORE_DEFAULT_SCALE, samples: 0 };
-  }
-  let numerator = 0;
-  let denominator = 0;
-  let samples = 0;
-  activities.forEach((activity) => {
-    if (isStravaActivityFaulty(activity)) return;
-    const measured = getMeasuredStravaScore(activity);
-    if (measured === null) return;
-    const raw = computeStravaRawScore(activity);
-    if (!Number.isFinite(raw) || raw <= 0) return;
-    numerator += raw * measured;
-    denominator += raw * raw;
-    samples += 1;
+  sessionScoreByActivityKey = new Map();
+  sessionBreakdownByActivityKey = new Map();
+  const sessions = groupStravaActivitiesIntoSessions(activities);
+
+  sessions.forEach((session) => {
+    const breakdown = getStravaWorkoutScoreBreakdown(session.activity);
+    session.activities.forEach((activity, index) => {
+      const key = getActivityKey(activity);
+      if (!key) return;
+      sessionScoreByActivityKey.set(key, index === 0 ? breakdown.total : null);
+      sessionBreakdownByActivityKey.set(key, {
+        ...breakdown,
+        sessionActivityCount: session.activities.length,
+        sessionPrimary: index === 0
+      });
+    });
   });
-  if (samples === 0 || denominator <= 0) {
-    return { scale: STRAVA_SCORE_DEFAULT_SCALE, samples: 0 };
-  }
-  let scale = numerator / denominator;
-  if (!Number.isFinite(scale) || scale <= 0) {
-    scale = STRAVA_SCORE_DEFAULT_SCALE;
-  }
-  scale = Math.max(
-    STRAVA_SCORE_SCALE_MIN,
-    Math.min(STRAVA_SCORE_SCALE_MAX, scale)
-  );
-  return { scale, samples };
+
+  return {
+    scale: STRAVA_SCORE_DEFAULT_SCALE,
+    samples: 0,
+    sessions: sessions.length,
+    modelVersion: STRAVA_SCORE_MODEL_VERSION
+  };
 }
 
 export function estimateStravaExertion(
   activity,
   scale = STRAVA_SCORE_DEFAULT_SCALE
 ) {
+  void scale;
+  const cached = getCachedSessionScore(activity);
+  if (cached.found) {
+    return cached.value === null ? null : roundScore(cached.value);
+  }
   const raw = computeStravaRawScore(activity);
-  if (raw === null) return null;
-  const effectiveScale = Number.isFinite(scale)
-    ? scale
-    : STRAVA_SCORE_DEFAULT_SCALE;
-  const score = raw * effectiveScale;
-  const clamped = Math.max(0, score);
-  return Math.round(clamped * 10) / 10;
+  return raw === null ? null : roundScore(raw);
 }
 
 export function resolveStravaExertion(
@@ -117,18 +135,11 @@ export function resolveStravaExertion(
   scale = STRAVA_SCORE_DEFAULT_SCALE
 ) {
   if (!activity) return null;
-  const override =
-    activity.local_exertion !== undefined
-      ? activity.local_exertion
-      : activity.exertion;
-  let resolved = parseExertionValue(override);
-  if (resolved !== null) return resolved;
-  resolved = parseExertionValue(activity.reported_exertion);
-  if (resolved !== null) return resolved;
-  const estimated = estimateStravaExertion(activity, scale);
-  const fallback =
-    estimated !== null && estimated !== undefined
-      ? estimated
-      : activity.estimated_exertion;
-  return parseExertionValue(fallback);
+  return estimateStravaExertion(activity, scale);
+}
+
+export function getCachedStravaScoreBreakdown(activity) {
+  const key = getActivityKey(activity);
+  if (!key || !sessionBreakdownByActivityKey.has(key)) return null;
+  return sessionBreakdownByActivityKey.get(key);
 }

--- a/src/features/strava/score-model.mjs
+++ b/src/features/strava/score-model.mjs
@@ -80,6 +80,28 @@ function toPositiveNumber(value) {
   return Number.isFinite(numeric) && numeric > 0 ? numeric : null;
 }
 
+function toNonNegativeNumber(value) {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) && numeric >= 0 ? numeric : null;
+}
+
+function hasExplicitValue(value) {
+  return value !== undefined && value !== null && value !== '';
+}
+
+function estimateCardioMinutesFromDistance(activity, elapsedMinutes) {
+  const distanceKm = toPositiveNumber(activity?.distance_km);
+  const speedKmh = toPositiveNumber(activity?.avg_speed_kmh);
+  if (distanceKm === null || speedKmh === null) return 0;
+  const estimated = (distanceKm / speedKmh) * 60;
+  if (!Number.isFinite(estimated) || estimated <= 0) return 0;
+  return Math.min(
+    360,
+    estimated,
+    elapsedMinutes === null ? estimated : elapsedMinutes
+  );
+}
+
 export function normalizeCardioZoneMinutes(raw) {
   let values;
   if (Array.isArray(raw)) {
@@ -123,29 +145,36 @@ export function getStravaActivityModality(activity) {
 }
 
 export function getStravaActivityActiveMinutes(activity, modality) {
-  const featureMinutes = toPositiveNumber(
+  const featureRaw =
     activity?.score_features?.active_minutes ??
-      activity?.score_features?.effective_active_minutes
-  );
-  if (featureMinutes !== null) return Math.min(360, featureMinutes);
-
-  const moving = toPositiveNumber(
-    activity?.effective_active_minutes ?? activity?.moving_time_min
-  );
-  const elapsed = toPositiveNumber(activity?.elapsed_time_min);
-  if (modality === 'cardio') {
-    if (moving !== null) return Math.min(360, moving);
-    return elapsed !== null ? Math.min(360, elapsed) : 0;
+    activity?.score_features?.effective_active_minutes;
+  const featureMinutes = toNonNegativeNumber(featureRaw);
+  if (hasExplicitValue(featureRaw) && featureMinutes !== null) {
+    return Math.min(360, featureMinutes);
   }
+
+  const movingRaw =
+    activity?.effective_active_minutes ?? activity?.moving_time_min;
+  const moving = toNonNegativeNumber(movingRaw);
+  const hasMoving = hasExplicitValue(movingRaw) && moving !== null;
+  const elapsed = toPositiveNumber(activity?.elapsed_time_min);
+
+  if (modality === 'cardio') {
+    if (hasMoving) {
+      return Math.min(360, moving, elapsed === null ? moving : elapsed);
+    }
+    return estimateCardioMinutesFromDistance(activity, elapsed);
+  }
+
   if (elapsed !== null) {
-    if (moving === null || moving < 5) return Math.min(360, elapsed);
+    if (!hasMoving || moving < 5) return Math.min(360, elapsed);
     return Math.min(
       360,
       elapsed,
       Math.max(moving + 30, moving * 1.5, 15)
     );
   }
-  return moving !== null ? Math.min(360, moving) : 0;
+  return hasMoving ? Math.min(360, moving) : 0;
 }
 
 function getAverageHrZone(activity, hrReference) {

--- a/src/features/strava/score-model.mjs
+++ b/src/features/strava/score-model.mjs
@@ -1,4 +1,5 @@
 export const STRAVA_SCORE_MODEL_VERSION = 2;
+export const STRAVA_FEATURE_VERSION = 2;
 export const STRAVA_SCORE_DEFAULT_SCALE = 1;
 
 const MAX_SESSION_SCORE = 6;
@@ -214,6 +215,7 @@ function buildSummaryFeatures(activity) {
 
   return {
     version: STRAVA_SCORE_MODEL_VERSION,
+    feature_version: STRAVA_FEATURE_VERSION,
     source: 'summary',
     active_minutes: activeMinutes,
     strength_minutes: strengthMinutes,
@@ -256,6 +258,7 @@ function normalizeScoreFeatures(activity, rawFeatures) {
 
   return {
     version: STRAVA_SCORE_MODEL_VERSION,
+    feature_version: STRAVA_FEATURE_VERSION,
     source: String(rawFeatures?.source || fallback.source),
     active_minutes:
       activeMinutes > 0 ? activeMinutes : strengthMinutes + cardioMinutes,
@@ -286,7 +289,8 @@ export function getStravaScoreFeatures(activity) {
   if (
     rawFeatures &&
     typeof rawFeatures === 'object' &&
-    Number(rawFeatures.version) >= STRAVA_SCORE_MODEL_VERSION
+    Number(rawFeatures.version) >= STRAVA_SCORE_MODEL_VERSION &&
+    Number(rawFeatures.feature_version) >= STRAVA_FEATURE_VERSION
   ) {
     return normalizeScoreFeatures(activity, rawFeatures);
   }

--- a/src/features/strava/score-model.mjs
+++ b/src/features/strava/score-model.mjs
@@ -2,7 +2,7 @@ export const STRAVA_SCORE_MODEL_VERSION = 2;
 export const STRAVA_FEATURE_VERSION = 2;
 export const STRAVA_SCORE_DEFAULT_SCALE = 1;
 
-const MAX_SESSION_SCORE = 6;
+const SCORE_CURVE_SCALE = 6;
 const CARDIO_LOAD_SCALE = 70;
 const CARDIO_ZONE_WEIGHTS = [0.2, 0.45, 0.9, 1.45, 2.1];
 const RECOVERY_ZONE_WEIGHTS = [0.5, 1, 2, 3, 4];
@@ -169,11 +169,7 @@ export function getStravaActivityActiveMinutes(activity, modality) {
 
   if (elapsed !== null) {
     if (!hasMoving || moving < 5) return Math.min(360, elapsed);
-    return Math.min(
-      360,
-      elapsed,
-      Math.max(moving + 30, moving * 1.5, 15)
-    );
+    return Math.min(360, elapsed, Math.max(moving + 30, moving * 1.5, 15));
   }
   return hasMoving ? Math.min(360, moving) : 0;
 }
@@ -303,23 +299,21 @@ export function computeStrengthCredit(features) {
   const density = clampScoreValue(features?.strength_density, 0, 1);
   const factor = clampScoreValue(features?.strength_factor ?? 1, 0.5, 1.1);
   const base =
-    MAX_SESSION_SCORE * (1 - Math.exp(-Math.max(0, minutes - 5) / 45));
+    SCORE_CURVE_SCALE * (1 - Math.exp(-Math.max(0, minutes - 5) / 45));
   const durationQuality = 0.1 * clampScoreValue((minutes - 60) / 45, 0, 1);
   const multiplier = 0.9 + 0.2 * density + durationQuality;
-  return clampScoreValue(base * multiplier * factor, 0, MAX_SESSION_SCORE);
+  return Math.max(0, base * multiplier * factor);
 }
 
 export function computeCardioCredit(features) {
-  const zoneMinutes = normalizeCardioZoneMinutes(
-    features?.cardio_zone_minutes
-  );
+  const zoneMinutes = normalizeCardioZoneMinutes(features?.cardio_zone_minutes);
   const load = zoneMinutes.reduce(
     (sum, minutes, index) => sum + minutes * CARDIO_ZONE_WEIGHTS[index],
     0
   );
   if (load <= 0) return 0;
-  const score = MAX_SESSION_SCORE * (1 - Math.exp(-load / CARDIO_LOAD_SCALE));
-  return clampScoreValue(score, 0, MAX_SESSION_SCORE);
+  const score = SCORE_CURVE_SCALE * (1 - Math.exp(-load / CARDIO_LOAD_SCALE));
+  return Math.max(0, score);
 }
 
 export function computeStravaRecoveryLoad(features) {
@@ -330,15 +324,11 @@ export function computeStravaRecoveryLoad(features) {
 }
 
 export function combineWorkoutComponents(strengthCredit, cardioCredit) {
-  const strength = clampScoreValue(strengthCredit, 0, MAX_SESSION_SCORE);
-  const cardio = clampScoreValue(cardioCredit, 0, MAX_SESSION_SCORE);
+  const strength = clampScoreValue(strengthCredit, 0, Number.POSITIVE_INFINITY);
+  const cardio = clampScoreValue(cardioCredit, 0, Number.POSITIVE_INFINITY);
   const primary = Math.max(strength, cardio);
   const secondary = Math.min(strength, cardio);
-  return clampScoreValue(
-    primary + Math.min(1, 0.25 * secondary),
-    0,
-    MAX_SESSION_SCORE
-  );
+  return primary + Math.min(1, 0.25 * secondary);
 }
 
 export function getStravaWorkoutScoreBreakdown(activity) {

--- a/src/features/strava/score-model.mjs
+++ b/src/features/strava/score-model.mjs
@@ -18,9 +18,11 @@ const MOBILITY_TYPES = new Set(['pilates', 'yoga']);
 const CARDIO_TYPES = new Set([
   'alpineski',
   'backcountryski',
+  'badminton',
   'canoeing',
   'ebikeride',
   'elliptical',
+  'golf',
   'gravelride',
   'handcycle',
   'hike',
@@ -30,6 +32,8 @@ const CARDIO_TYPES = new Set([
   'kitesurf',
   'mountainbikeride',
   'nordicski',
+  'pickleball',
+  'racquetball',
   'ride',
   'rockclimbing',
   'rollerski',
@@ -40,9 +44,12 @@ const CARDIO_TYPES = new Set([
   'snowboard',
   'snowshoe',
   'soccer',
+  'squash',
   'stairstepper',
   'standuppaddling',
   'surfing',
+  'tabletennis',
+  'tennis',
   'swim',
   'trailrun',
   'velomobile',
@@ -130,8 +137,14 @@ export function getStravaActivityActiveMinutes(activity, modality) {
     if (moving !== null) return Math.min(360, moving);
     return elapsed !== null ? Math.min(360, elapsed) : 0;
   }
-  if (moving !== null && moving >= 5) return Math.min(360, moving);
-  if (elapsed !== null) return Math.min(360, elapsed);
+  if (elapsed !== null) {
+    if (moving === null || moving < 5) return Math.min(360, elapsed);
+    return Math.min(
+      360,
+      elapsed,
+      Math.max(moving + 30, moving * 1.5, 15)
+    );
+  }
   return moving !== null ? Math.min(360, moving) : 0;
 }
 

--- a/src/features/strava/score-model.mjs
+++ b/src/features/strava/score-model.mjs
@@ -1,0 +1,311 @@
+export const STRAVA_SCORE_MODEL_VERSION = 2;
+export const STRAVA_SCORE_DEFAULT_SCALE = 1;
+
+const MAX_SESSION_SCORE = 6;
+const CARDIO_LOAD_SCALE = 70;
+const CARDIO_ZONE_WEIGHTS = [0.2, 0.45, 0.9, 1.45, 2.1];
+const RECOVERY_ZONE_WEIGHTS = [0.5, 1, 2, 3, 4];
+const DEFAULT_MAX_HR = 190;
+
+const STRENGTH_TYPES = new Set(['weighttraining']);
+const HYBRID_TYPES = new Set([
+  'crossfit',
+  'highintensityintervaltraining',
+  'hiit',
+  'workout'
+]);
+const MOBILITY_TYPES = new Set(['pilates', 'yoga']);
+const CARDIO_TYPES = new Set([
+  'alpineski',
+  'backcountryski',
+  'canoeing',
+  'ebikeride',
+  'elliptical',
+  'gravelride',
+  'handcycle',
+  'hike',
+  'iceskate',
+  'inlineskate',
+  'kayaking',
+  'kitesurf',
+  'mountainbikeride',
+  'nordicski',
+  'ride',
+  'rockclimbing',
+  'rollerski',
+  'rowing',
+  'run',
+  'sail',
+  'skateboard',
+  'snowboard',
+  'snowshoe',
+  'soccer',
+  'stairstepper',
+  'standuppaddling',
+  'surfing',
+  'swim',
+  'trailrun',
+  'velomobile',
+  'virtualride',
+  'virtualrow',
+  'virtualrun',
+  'walk',
+  'watersport',
+  'wheelchair',
+  'windsurf'
+]);
+
+export function clampScoreValue(value, min, max) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return min;
+  return Math.min(max, Math.max(min, numeric));
+}
+
+function normalizeType(value) {
+  return String(value || '')
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, '');
+}
+
+function toPositiveNumber(value) {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) && numeric > 0 ? numeric : null;
+}
+
+export function normalizeCardioZoneMinutes(raw) {
+  let values;
+  if (Array.isArray(raw)) {
+    values = raw.slice(0, 5);
+  } else if (raw && typeof raw === 'object') {
+    values = [raw.z1, raw.z2, raw.z3, raw.z4, raw.z5];
+  } else {
+    values = [];
+  }
+  while (values.length < 5) values.push(0);
+  return values.map((value) => Math.max(0, Number(value) || 0));
+}
+
+function getHrReference(activity, rawFeatures = null) {
+  const featureReference = toPositiveNumber(rawFeatures?.hr_max_reference);
+  const activityReference = toPositiveNumber(activity?.hr_max_reference);
+  const observedMax = toPositiveNumber(activity?.max_hr);
+  const average = toPositiveNumber(activity?.avg_hr);
+  return Math.max(
+    DEFAULT_MAX_HR,
+    featureReference || 0,
+    activityReference || 0,
+    observedMax || 0,
+    average ? average / 0.98 : 0
+  );
+}
+
+export function getStravaActivityModality(activity) {
+  const type = normalizeType(activity?.sport_type || activity?.type);
+  if (STRENGTH_TYPES.has(type)) return 'strength';
+  if (HYBRID_TYPES.has(type)) return 'hybrid';
+  if (MOBILITY_TYPES.has(type)) return 'mobility';
+  if (CARDIO_TYPES.has(type)) return 'cardio';
+  if (
+    toPositiveNumber(activity?.distance_km) !== null ||
+    toPositiveNumber(activity?.avg_speed_kmh) !== null
+  ) {
+    return 'cardio';
+  }
+  return 'strength';
+}
+
+export function getStravaActivityActiveMinutes(activity, modality) {
+  const featureMinutes = toPositiveNumber(
+    activity?.score_features?.active_minutes ??
+      activity?.score_features?.effective_active_minutes
+  );
+  if (featureMinutes !== null) return Math.min(360, featureMinutes);
+
+  const moving = toPositiveNumber(
+    activity?.effective_active_minutes ?? activity?.moving_time_min
+  );
+  const elapsed = toPositiveNumber(activity?.elapsed_time_min);
+  if (modality === 'cardio') {
+    if (moving !== null) return Math.min(360, moving);
+    return elapsed !== null ? Math.min(360, elapsed) : 0;
+  }
+  if (moving !== null && moving >= 5) return Math.min(360, moving);
+  if (elapsed !== null) return Math.min(360, elapsed);
+  return moving !== null ? Math.min(360, moving) : 0;
+}
+
+function getAverageHrZone(activity, hrReference) {
+  const average = toPositiveNumber(activity?.avg_hr);
+  if (average === null || !Number.isFinite(hrReference) || hrReference <= 0) {
+    return 1;
+  }
+  const ratio = average / hrReference;
+  if (ratio < 0.6) return 0;
+  if (ratio < 0.7) return 1;
+  if (ratio < 0.8) return 2;
+  if (ratio < 0.9) return 3;
+  return 4;
+}
+
+function buildSummaryFeatures(activity) {
+  const modality = getStravaActivityModality(activity);
+  const activeMinutes = getStravaActivityActiveMinutes(activity, modality);
+  const hrReference = getHrReference(activity);
+  const cardioZoneMinutes = [0, 0, 0, 0, 0];
+  let strengthMinutes = 0;
+  let strengthDensity = 0;
+  let strengthFactor = 1;
+
+  if (modality === 'cardio') {
+    cardioZoneMinutes[getAverageHrZone(activity, hrReference)] = activeMinutes;
+  } else if (modality === 'hybrid') {
+    strengthMinutes = activeMinutes * 0.75;
+    cardioZoneMinutes[getAverageHrZone(activity, hrReference)] =
+      activeMinutes * 0.25;
+    strengthDensity = 0.25;
+  } else {
+    strengthMinutes = activeMinutes;
+    strengthDensity = modality === 'mobility' ? 0.2 : 0;
+    strengthFactor = modality === 'mobility' ? 0.65 : 1;
+  }
+
+  return {
+    version: STRAVA_SCORE_MODEL_VERSION,
+    source: 'summary',
+    active_minutes: activeMinutes,
+    strength_minutes: strengthMinutes,
+    cardio_zone_minutes: cardioZoneMinutes,
+    strength_density: strengthDensity,
+    strength_factor: strengthFactor,
+    work_recovery_cycles: 0,
+    hr_max_reference: hrReference
+  };
+}
+
+function normalizeScoreFeatures(activity, rawFeatures) {
+  const fallback = buildSummaryFeatures(activity);
+  const activeMinutes = Math.max(
+    0,
+    Number(
+      rawFeatures?.active_minutes ??
+        rawFeatures?.effective_active_minutes ??
+        fallback.active_minutes
+    ) || 0
+  );
+  let strengthMinutes = Math.max(
+    0,
+    Number(rawFeatures?.strength_minutes ?? fallback.strength_minutes) || 0
+  );
+  const cardioZoneMinutes = normalizeCardioZoneMinutes(
+    rawFeatures?.cardio_zone_minutes ?? fallback.cardio_zone_minutes
+  );
+  let cardioMinutes = cardioZoneMinutes.reduce((sum, value) => sum + value, 0);
+  const componentMinutes = strengthMinutes + cardioMinutes;
+
+  if (activeMinutes > 0 && componentMinutes > activeMinutes * 1.05) {
+    const scale = activeMinutes / componentMinutes;
+    strengthMinutes *= scale;
+    cardioZoneMinutes.forEach((value, index) => {
+      cardioZoneMinutes[index] = value * scale;
+    });
+    cardioMinutes *= scale;
+  }
+
+  return {
+    version: STRAVA_SCORE_MODEL_VERSION,
+    source: String(rawFeatures?.source || fallback.source),
+    active_minutes:
+      activeMinutes > 0 ? activeMinutes : strengthMinutes + cardioMinutes,
+    strength_minutes: strengthMinutes,
+    cardio_zone_minutes: cardioZoneMinutes,
+    strength_density: clampScoreValue(
+      rawFeatures?.strength_density ?? fallback.strength_density,
+      0,
+      1
+    ),
+    strength_factor: clampScoreValue(
+      rawFeatures?.strength_factor ?? fallback.strength_factor,
+      0.5,
+      1.1
+    ),
+    work_recovery_cycles: Math.max(
+      0,
+      Number(
+        rawFeatures?.work_recovery_cycles ?? fallback.work_recovery_cycles
+      ) || 0
+    ),
+    hr_max_reference: getHrReference(activity, rawFeatures)
+  };
+}
+
+export function getStravaScoreFeatures(activity) {
+  const rawFeatures = activity?.score_features;
+  if (
+    rawFeatures &&
+    typeof rawFeatures === 'object' &&
+    Number(rawFeatures.version) >= STRAVA_SCORE_MODEL_VERSION
+  ) {
+    return normalizeScoreFeatures(activity, rawFeatures);
+  }
+  return buildSummaryFeatures(activity);
+}
+
+export function computeStrengthCredit(features) {
+  const minutes = Math.max(0, Number(features?.strength_minutes) || 0);
+  if (minutes <= 5) return 0;
+  const density = clampScoreValue(features?.strength_density, 0, 1);
+  const factor = clampScoreValue(features?.strength_factor ?? 1, 0.5, 1.1);
+  const base =
+    MAX_SESSION_SCORE * (1 - Math.exp(-Math.max(0, minutes - 5) / 45));
+  const durationQuality = 0.1 * clampScoreValue((minutes - 60) / 45, 0, 1);
+  const multiplier = 0.9 + 0.2 * density + durationQuality;
+  return clampScoreValue(base * multiplier * factor, 0, MAX_SESSION_SCORE);
+}
+
+export function computeCardioCredit(features) {
+  const zoneMinutes = normalizeCardioZoneMinutes(
+    features?.cardio_zone_minutes
+  );
+  const load = zoneMinutes.reduce(
+    (sum, minutes, index) => sum + minutes * CARDIO_ZONE_WEIGHTS[index],
+    0
+  );
+  if (load <= 0) return 0;
+  const score = MAX_SESSION_SCORE * (1 - Math.exp(-load / CARDIO_LOAD_SCALE));
+  return clampScoreValue(score, 0, MAX_SESSION_SCORE);
+}
+
+export function computeStravaRecoveryLoad(features) {
+  return normalizeCardioZoneMinutes(features?.cardio_zone_minutes).reduce(
+    (sum, minutes, index) => sum + minutes * RECOVERY_ZONE_WEIGHTS[index],
+    0
+  );
+}
+
+export function combineWorkoutComponents(strengthCredit, cardioCredit) {
+  const strength = clampScoreValue(strengthCredit, 0, MAX_SESSION_SCORE);
+  const cardio = clampScoreValue(cardioCredit, 0, MAX_SESSION_SCORE);
+  const primary = Math.max(strength, cardio);
+  const secondary = Math.min(strength, cardio);
+  return clampScoreValue(
+    primary + Math.min(1, 0.25 * secondary),
+    0,
+    MAX_SESSION_SCORE
+  );
+}
+
+export function getStravaWorkoutScoreBreakdown(activity) {
+  const features = getStravaScoreFeatures(activity);
+  const strength = computeStrengthCredit(features);
+  const cardio = computeCardioCredit(features);
+  return {
+    version: STRAVA_SCORE_MODEL_VERSION,
+    modality: getStravaActivityModality(activity),
+    strength,
+    cardio,
+    total: combineWorkoutComponents(strength, cardio),
+    recoveryLoad: computeStravaRecoveryLoad(features),
+    features
+  };
+}

--- a/src/features/strava/sessions.mjs
+++ b/src/features/strava/sessions.mjs
@@ -1,0 +1,171 @@
+import {
+  STRAVA_SCORE_MODEL_VERSION,
+  clampScoreValue,
+  getStravaActivityActiveMinutes,
+  getStravaActivityModality,
+  getStravaScoreFeatures,
+  normalizeCardioZoneMinutes
+} from './score-model.mjs';
+
+const SESSION_GAP_MINUTES = 15;
+const DEFAULT_MAX_HR = 190;
+
+function getSessionDurationMinutes(activity) {
+  const modality = getStravaActivityModality(activity);
+  const active = getStravaActivityActiveMinutes(activity, modality);
+  const elapsed = Number(activity?.elapsed_time_min);
+  if (!Number.isFinite(elapsed) || elapsed <= 0) return active;
+  return Math.min(elapsed, Math.max(active + 30, active * 1.5, 15), 360);
+}
+
+function mergeSessionFeatures(activities, sessionSpanMinutes) {
+  const records = activities.map((activity) =>
+    getStravaScoreFeatures(activity)
+  );
+  let activeMinutes = 0;
+  let strengthMinutes = 0;
+  const cardioZoneMinutes = [0, 0, 0, 0, 0];
+  let densityNumerator = 0;
+  let factorNumerator = 0;
+  let workRecoveryCycles = 0;
+  let hrReference = DEFAULT_MAX_HR;
+
+  records.forEach((features) => {
+    activeMinutes += Math.max(0, Number(features.active_minutes) || 0);
+    const strength = Math.max(0, Number(features.strength_minutes) || 0);
+    strengthMinutes += strength;
+    densityNumerator +=
+      strength * clampScoreValue(features.strength_density, 0, 1);
+    factorNumerator +=
+      strength * clampScoreValue(features.strength_factor ?? 1, 0.5, 1.1);
+    normalizeCardioZoneMinutes(features.cardio_zone_minutes).forEach(
+      (minutes, index) => {
+        cardioZoneMinutes[index] += minutes;
+      }
+    );
+    workRecoveryCycles += Math.max(
+      0,
+      Number(features.work_recovery_cycles) || 0
+    );
+    hrReference = Math.max(
+      hrReference,
+      Number(features.hr_max_reference) || 0
+    );
+  });
+
+  const originalStrengthMinutes = strengthMinutes;
+  const averageDensity =
+    originalStrengthMinutes > 0
+      ? clampScoreValue(densityNumerator / originalStrengthMinutes, 0, 1)
+      : 0;
+  const averageFactor =
+    originalStrengthMinutes > 0
+      ? clampScoreValue(factorNumerator / originalStrengthMinutes, 0.5, 1.1)
+      : 1;
+  const componentMinutes =
+    strengthMinutes +
+    cardioZoneMinutes.reduce((sum, minutes) => sum + minutes, 0);
+  const availableMinutes = Math.max(0, Number(sessionSpanMinutes) || 0);
+  if (availableMinutes > 0 && componentMinutes > availableMinutes) {
+    const scale = availableMinutes / componentMinutes;
+    strengthMinutes *= scale;
+    cardioZoneMinutes.forEach((minutes, index) => {
+      cardioZoneMinutes[index] = minutes * scale;
+    });
+    activeMinutes = Math.min(activeMinutes, availableMinutes);
+  }
+
+  return {
+    version: STRAVA_SCORE_MODEL_VERSION,
+    source: activities.length > 1 ? 'session' : records[0]?.source || 'summary',
+    active_minutes: Math.min(
+      activeMinutes,
+      availableMinutes > 0 ? availableMinutes : activeMinutes
+    ),
+    strength_minutes: strengthMinutes,
+    cardio_zone_minutes: cardioZoneMinutes,
+    strength_density: averageDensity,
+    strength_factor: averageFactor,
+    work_recovery_cycles: workRecoveryCycles,
+    hr_max_reference: hrReference
+  };
+}
+
+function createSessionRecord(activities, startMs, endMs) {
+  const first = activities[0];
+  const activityIds = activities
+    .map((activity) => activity?.id)
+    .filter((id) => id !== null && id !== undefined);
+  const activity = Object.assign({}, first, {
+    id:
+      activityIds.length > 0
+        ? `session:${activityIds.join('+')}`
+        : `session:${String(first?.start_date || startMs)}`,
+    name:
+      activities.length > 1
+        ? `${String(first?.name || 'Workout')} + ${activities.length - 1}`
+        : first?.name,
+    score_model_version: STRAVA_SCORE_MODEL_VERSION,
+    score_features: mergeSessionFeatures(
+      activities,
+      Math.max(0, (endMs - startMs) / 60000)
+    ),
+    session_activity_count: activities.length,
+    session_activity_ids: activityIds
+  });
+  return { activities, activity, startMs, endMs };
+}
+
+export function groupStravaActivitiesIntoSessions(
+  activities,
+  gapMinutes = SESSION_GAP_MINUTES
+) {
+  if (!Array.isArray(activities) || activities.length === 0) return [];
+  const valid = activities
+    .filter((activity) => activity && activity.start_date)
+    .map((activity) => {
+      const startMs = Date.parse(activity.start_date);
+      const durationMinutes = getSessionDurationMinutes(activity);
+      return {
+        activity,
+        startMs,
+        endMs: startMs + Math.max(0, durationMinutes) * 60000
+      };
+    })
+    .filter((record) => Number.isFinite(record.startMs))
+    .sort((a, b) => a.startMs - b.startMs);
+
+  const sessions = [];
+  const allowedGapMs = Math.max(0, Number(gapMinutes) || 0) * 60000;
+  /** @type {{ activities: object[], startMs: number, endMs: number } | null} */
+  let current = null;
+
+  for (const record of valid) {
+    if (!current || record.startMs > current.endMs + allowedGapMs) {
+      if (current) {
+        sessions.push(
+          createSessionRecord(
+            current.activities,
+            current.startMs,
+            current.endMs
+          )
+        );
+      }
+      current = {
+        activities: [record.activity],
+        startMs: record.startMs,
+        endMs: record.endMs
+      };
+      continue;
+    }
+    current.activities.push(record.activity);
+    current.endMs = Math.max(current.endMs, record.endMs);
+  }
+
+  if (current) {
+    sessions.push(
+      createSessionRecord(current.activities, current.startMs, current.endMs)
+    );
+  }
+  return sessions;
+}

--- a/src/features/strava/sessions.mjs
+++ b/src/features/strava/sessions.mjs
@@ -1,4 +1,5 @@
 import {
+  STRAVA_FEATURE_VERSION,
   STRAVA_SCORE_MODEL_VERSION,
   clampScoreValue,
   getStravaActivityActiveMinutes,
@@ -77,6 +78,7 @@ function mergeSessionFeatures(activities, sessionSpanMinutes) {
 
   return {
     version: STRAVA_SCORE_MODEL_VERSION,
+    feature_version: STRAVA_FEATURE_VERSION,
     source: activities.length > 1 ? 'session' : records[0]?.source || 'summary',
     active_minutes: Math.min(
       activeMinutes,

--- a/src/features/workouts/runtime.mjs
+++ b/src/features/workouts/runtime.mjs
@@ -3,6 +3,7 @@ import {
   parseLocalDateString
 } from '../../shared/runtime-helpers.mjs';
 import { uuid } from '../../shared/id.mjs';
+import { groupStravaActivitiesIntoSessions } from '../strava/core.mjs';
 
 export const FITNESS_MODES = {
   gentle: { label: 'Gentle (6% / 4%)', alpha: 0.06, beta: 0.04 },
@@ -558,11 +559,15 @@ export function createWorkoutRuntime({
       }
     });
     const activities = applyStravaExertionOverrides(getStravaActivities());
-    activities.forEach((activity) => {
-      if (!activity || !activity.start_date) return;
-      const ts = Date.parse(activity.start_date);
+    const sessions = groupStravaActivitiesIntoSessions(activities);
+    sessions.forEach((session) => {
+      const sessionActivity = session?.activity;
+      if (!sessionActivity || !sessionActivity.start_date) return;
+      const ts = Number.isFinite(session.startMs)
+        ? session.startMs
+        : Date.parse(sessionActivity.start_date);
       if (!Number.isFinite(ts) || ts < startMs || ts >= endMs) return;
-      const exertion = resolveStravaExertion(activity);
+      const exertion = resolveStravaExertion(sessionActivity);
       if (exertion === null) return;
       totalPoints += exertion;
       counts.strava += 1;
@@ -594,10 +599,10 @@ export function createWorkoutRuntime({
       options.weekEnd instanceof Date
         ? new Date(options.weekEnd)
         : (() => {
-            const end = new Date(weekStart);
-            end.setDate(end.getDate() + 7);
-            return end;
-          })();
+          const end = new Date(weekStart);
+          end.setDate(end.getDate() + 7);
+          return end;
+        })();
     const fitness = options.fitness || ensureFitnessDefaults();
     const plan = getWorkoutPointPlan(fitness);
     const boundedStart = weekStart < plan.start ? plan.start : weekStart;

--- a/tests/python/test_strava_score_features.py
+++ b/tests/python/test_strava_score_features.py
@@ -1,0 +1,186 @@
+import unittest
+
+from scripts.fetch_strava import has_final_score_features
+from scripts.strava_score_features import (
+    derive_stream_score_features,
+    get_effective_active_minutes,
+)
+
+
+class StravaScoreFeaturesTest(unittest.TestCase):
+    def test_stream_cache_retries_deferred_summary_features(self):
+        complete = {
+            "score_features": {
+                "version": 2,
+                "source": "streams",
+                "stream_status": "complete",
+            }
+        }
+        deferred = {
+            "score_features": {
+                "version": 2,
+                "source": "summary",
+                "stream_status": "deferred",
+            }
+        }
+        unavailable = {
+            "score_features": {
+                "version": 2,
+                "source": "summary",
+                "stream_status": "unavailable",
+            }
+        }
+        self.assertTrue(has_final_score_features(complete))
+        self.assertFalse(has_final_score_features(deferred))
+        self.assertTrue(has_final_score_features(unavailable))
+
+    def test_zero_moving_time_does_not_fall_back_to_elapsed_cardio_time(self):
+        minutes = get_effective_active_minutes(
+            {
+                "moving_time": 0,
+                "elapsed_time": 75 * 60,
+                "distance": 10_000,
+                "average_speed": 20 / 3.6,
+            },
+            "cardio",
+        )
+        self.assertEqual(minutes, 0)
+
+    def test_missing_moving_time_uses_distance_and_speed_conservatively(self):
+        minutes = get_effective_active_minutes(
+            {
+                "elapsed_time": 90 * 60,
+                "distance": 10_000,
+                "average_speed": 20 / 3.6,
+            },
+            "cardio",
+        )
+        self.assertAlmostEqual(minutes, 30)
+
+    def test_cardio_inside_strength_is_detected_from_locomotion(self):
+        streams = self._strength_with_cardio_warmup()
+        features = derive_stream_score_features(
+            {"sport_type": "WeightTraining", "type": "WeightTraining"},
+            streams,
+            190,
+        )
+        self.assertIsNotNone(features)
+        self.assertGreaterEqual(features["cardio_block_minutes"], 9)
+        self.assertGreaterEqual(features["strength_block_minutes"], 45)
+
+    def test_strength_inside_cardio_requires_repeated_work_recovery(self):
+        streams = self._ride_with_strength_block()
+        features = derive_stream_score_features(
+            {"sport_type": "Ride", "type": "Ride"}, streams, 190
+        )
+        self.assertIsNotNone(features)
+        self.assertGreaterEqual(features["strength_block_minutes"], 10)
+        self.assertGreaterEqual(features["cardio_block_minutes"], 35)
+        self.assertGreaterEqual(features["work_recovery_cycles"], 2)
+        self.assertLess(features["strength_density"], 0.6)
+
+    def test_monotonic_cardio_pause_is_not_invented_as_strength(self):
+        streams = self._ride_with_monotonic_pause()
+        features = derive_stream_score_features(
+            {"sport_type": "Ride", "type": "Ride"}, streams, 190
+        )
+        self.assertIsNotNone(features)
+        self.assertEqual(features["strength_block_minutes"], 0)
+        self.assertGreaterEqual(features["cardio_block_minutes"], 34)
+        self.assertLessEqual(features["cardio_block_minutes"], 36)
+
+    def test_hr_only_cardio_remains_cardio(self):
+        times = list(range(0, 30 * 60, 10))
+        features = derive_stream_score_features(
+            {"sport_type": "Run", "type": "Run"},
+            {"time": times, "heartrate": [145] * len(times)},
+            190,
+        )
+        self.assertIsNotNone(features)
+        self.assertEqual(features["strength_block_minutes"], 0)
+        self.assertGreaterEqual(features["cardio_block_minutes"], 29)
+
+    @staticmethod
+    def _strength_with_cardio_warmup():
+        times = list(range(0, 60 * 60, 10))
+        heart_rate = []
+        moving = []
+        cadence = []
+        velocity = []
+        for second in times:
+            if second < 10 * 60:
+                heart_rate.append(140)
+                moving.append(True)
+                cadence.append(80)
+                velocity.append(4.0)
+            else:
+                phase = (second - 10 * 60) % 180
+                heart_rate.append(135 if phase < 60 else 100)
+                moving.append(False)
+                cadence.append(0)
+                velocity.append(0.0)
+        return {
+            "time": times,
+            "heartrate": heart_rate,
+            "moving": moving,
+            "cadence": cadence,
+            "velocity_smooth": velocity,
+        }
+
+    @staticmethod
+    def _ride_with_strength_block():
+        times = list(range(0, 50 * 60, 10))
+        heart_rate = []
+        moving = []
+        cadence = []
+        velocity = []
+        for second in times:
+            if 20 * 60 <= second < 32 * 60:
+                phase = (second - 20 * 60) % 180
+                heart_rate.append(135 if phase < 60 else 100)
+                moving.append(False)
+                cadence.append(0)
+                velocity.append(0.0)
+            else:
+                heart_rate.append(145)
+                moving.append(True)
+                cadence.append(85)
+                velocity.append(5.0)
+        return {
+            "time": times,
+            "heartrate": heart_rate,
+            "moving": moving,
+            "cadence": cadence,
+            "velocity_smooth": velocity,
+        }
+
+    @staticmethod
+    def _ride_with_monotonic_pause():
+        times = list(range(0, 50 * 60, 10))
+        heart_rate = []
+        moving = []
+        cadence = []
+        velocity = []
+        for second in times:
+            if 20 * 60 <= second < 35 * 60:
+                fraction = (second - 20 * 60) / (15 * 60)
+                heart_rate.append(145 - 50 * fraction)
+                moving.append(False)
+                cadence.append(0)
+                velocity.append(0.0)
+            else:
+                heart_rate.append(145)
+                moving.append(True)
+                cadence.append(85)
+                velocity.append(5.0)
+        return {
+            "time": times,
+            "heartrate": heart_rate,
+            "moving": moving,
+            "cadence": cadence,
+            "velocity_smooth": velocity,
+        }
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/python/test_strava_score_features.py
+++ b/tests/python/test_strava_score_features.py
@@ -12,6 +12,7 @@ class StravaScoreFeaturesTest(unittest.TestCase):
         complete = {
             "score_features": {
                 "version": 2,
+                "feature_version": 2,
                 "source": "streams",
                 "stream_status": "complete",
             }
@@ -19,6 +20,7 @@ class StravaScoreFeaturesTest(unittest.TestCase):
         deferred = {
             "score_features": {
                 "version": 2,
+                "feature_version": 2,
                 "source": "summary",
                 "stream_status": "deferred",
             }
@@ -26,13 +28,22 @@ class StravaScoreFeaturesTest(unittest.TestCase):
         unavailable = {
             "score_features": {
                 "version": 2,
+                "feature_version": 2,
                 "source": "summary",
                 "stream_status": "unavailable",
+            }
+        }
+        stale = {
+            "score_features": {
+                "version": 2,
+                "source": "streams",
+                "stream_status": "complete",
             }
         }
         self.assertTrue(has_final_score_features(complete))
         self.assertFalse(has_final_score_features(deferred))
         self.assertTrue(has_final_score_features(unavailable))
+        self.assertFalse(has_final_score_features(stale))
 
     def test_zero_moving_time_does_not_fall_back_to_elapsed_cardio_time(self):
         minutes = get_effective_active_minutes(
@@ -94,6 +105,22 @@ class StravaScoreFeaturesTest(unittest.TestCase):
         features = derive_stream_score_features(
             {"sport_type": "Run", "type": "Run"},
             {"time": times, "heartrate": [145] * len(times)},
+            190,
+        )
+        self.assertIsNotNone(features)
+        self.assertEqual(features["strength_block_minutes"], 0)
+        self.assertGreaterEqual(features["cardio_block_minutes"], 29)
+
+    def test_indoor_ride_uses_moving_stream_when_velocity_is_zero(self):
+        times = list(range(0, 30 * 60, 10))
+        features = derive_stream_score_features(
+            {"sport_type": "Ride", "type": "Ride"},
+            {
+                "time": times,
+                "heartrate": [145] * len(times),
+                "moving": [True] * len(times),
+                "velocity_smooth": [0.0] * len(times),
+            },
             190,
         )
         self.assertIsNotNone(features)

--- a/tests/unit/strava-scoring.test.mjs
+++ b/tests/unit/strava-scoring.test.mjs
@@ -9,14 +9,22 @@ import {
   computeStrengthCredit,
   estimateStravaExertion,
   getCachedStravaScoreBreakdown,
+  getStravaActivityModality,
   getStravaWorkoutScoreBreakdown,
   groupStravaActivitiesIntoSessions,
   resolveStravaExertion
 } from '../../src/features/strava/core.mjs';
+import { createWorkoutRuntime } from '../../src/features/workouts/runtime.mjs';
 
+let nextActivityId = 1_000;
+
+/**
+ * @param {Record<string, any>} [overrides]
+ * @returns {Record<string, any>}
+ */
 function activity(overrides = {}) {
   return {
-    id: Math.floor(Math.random() * 1_000_000_000),
+    id: nextActivityId++,
     name: 'Workout',
     type: 'WeightTraining',
     sport_type: 'WeightTraining',
@@ -29,6 +37,10 @@ function activity(overrides = {}) {
   };
 }
 
+/**
+ * @param {Record<string, any>} [overrides]
+ * @returns {Record<string, any>}
+ */
 function features(overrides = {}) {
   return {
     version: STRAVA_SCORE_MODEL_VERSION,
@@ -54,6 +66,49 @@ test('strength scoring is not driven by average heart rate', () => {
 
   assert.equal(lowHr, highHr);
   assert.equal(lowHr, 4.4);
+});
+
+test('known field sports remain cardio without manual classification', () => {
+  assert.equal(
+    getStravaActivityModality(
+      activity({ type: 'Tennis', sport_type: 'Tennis', distance_km: 0 })
+    ),
+    'cardio'
+  );
+});
+
+test('strength fallback includes normal rest between sets', () => {
+  const restingStrength = activity({
+    id: 3,
+    moving_time_min: 30,
+    elapsed_time_min: 60
+  });
+
+  assert.equal(estimateStravaExertion(restingStrength), 3.8);
+});
+
+test('legacy score metadata is preserved but ignored by automatic scoring', () => {
+  const overridden = activity({
+    id: 4,
+    moving_time_min: 60,
+    elapsed_time_min: 60,
+    exertion: 9,
+    local_exertion: 8,
+    faulty: true,
+    local_faulty: true,
+    estimated_exertion: 7,
+    reported_exertion: 6
+  });
+
+  computeStravaScoreScale([overridden]);
+
+  assert.equal(overridden.exertion, 9);
+  assert.equal(overridden.local_exertion, 8);
+  assert.equal(overridden.faulty, true);
+  assert.equal(overridden.local_faulty, true);
+  assert.equal(overridden.estimated_exertion, 7);
+  assert.equal(overridden.reported_exertion, 6);
+  assert.equal(resolveStravaExertion(overridden), 3.8);
 });
 
 test(
@@ -138,16 +193,80 @@ test('adjacent Strava records are scored as one bounded mixed session', () => {
   assert.equal(model.modelVersion, STRAVA_SCORE_MODEL_VERSION);
   assert.equal(model.sessions, 1);
 
-  const sessionScore = resolveStravaExertion(warmup);
+  const sessionScore = resolveStravaExertion(lifting);
   assert.ok(sessionScore > 4.5);
   assert.ok(sessionScore <= 6);
-  assert.equal(resolveStravaExertion(lifting), null);
+  assert.equal(resolveStravaExertion(warmup), null);
   assert.equal(resolveStravaExertion(cooldown), null);
 
-  const breakdown = getCachedStravaScoreBreakdown(warmup);
+  const breakdown = getCachedStravaScoreBreakdown(lifting);
   assert.equal(breakdown.sessionActivityCount, 3);
   assert.equal(breakdown.sessionPrimary, true);
   assert.ok(breakdown.strength > breakdown.cardio);
+});
+
+test('workout runtime scores adjacent Strava records as one session', () => {
+  const warmup = activity({
+    id: 50,
+    name: 'Warm-up ride',
+    type: 'Ride',
+    sport_type: 'Ride',
+    start_date: '2026-08-03T08:00:00Z',
+    moving_time_min: 12,
+    elapsed_time_min: 12,
+    score_features: features({
+      active_minutes: 12,
+      strength_minutes: 0,
+      cardio_zone_minutes: [0, 0, 12, 0, 0],
+      strength_density: 0
+    })
+  });
+  const lifting = activity({
+    id: 51,
+    start_date: '2026-08-03T08:14:00Z',
+    moving_time_min: 70,
+    elapsed_time_min: 70,
+    score_features: features({
+      active_minutes: 70,
+      strength_minutes: 70,
+      strength_density: 0.7
+    })
+  });
+  const cooldown = activity({
+    id: 52,
+    name: 'Cooldown',
+    type: 'Ride',
+    sport_type: 'Ride',
+    start_date: '2026-08-03T09:26:00Z',
+    moving_time_min: 10,
+    elapsed_time_min: 10,
+    score_features: features({
+      active_minutes: 10,
+      strength_minutes: 0,
+      cardio_zone_minutes: [0, 10, 0, 0, 0],
+      strength_density: 0
+    })
+  });
+  const records = [cooldown, lifting, warmup];
+  const expectedSession = groupStravaActivitiesIntoSessions(records)[0];
+  const expectedScore = resolveStravaExertion(expectedSession.activity);
+  const runtime = createWorkoutRuntime({
+    ensureFitnessDefaults: () => ({ pointSettings: {} }),
+    ensureWorkoutData: () => ({ entries: [] }),
+    isWeekPaused: () => false,
+    processWorkoutWeekIfNeeded: () => {},
+    applyStravaExertionOverrides: (activities) => activities,
+    resolveStravaExertion,
+    getStravaActivities: () => records
+  });
+
+  const stats = runtime.collectWorkoutPoints({
+    start: new Date('2026-08-03T00:00:00Z'),
+    end: new Date('2026-08-04T00:00:00Z')
+  });
+
+  assert.equal(stats.counts.strava, 1);
+  assert.equal(stats.totalPoints, expectedScore);
 });
 
 test('paused elapsed time does not generate cardio credit', () => {
@@ -161,6 +280,56 @@ test('paused elapsed time does not generate cardio credit', () => {
     max_hr: 180
   });
   assert.equal(estimateStravaExertion(pausedRide), 0);
+});
+
+test('explicit zero moving time does not fall back to elapsed cardio time', () => {
+  const stoppedRide = activity({
+    id: 21,
+    type: 'Ride',
+    sport_type: 'Ride',
+    moving_time_min: 0,
+    elapsed_time_min: 75,
+    distance_km: 10,
+    avg_speed_kmh: 20,
+    avg_hr: 145,
+    max_hr: 180
+  });
+
+  assert.equal(estimateStravaExertion(stoppedRide), null);
+});
+
+test('missing moving time does not treat all elapsed cardio time as active', () => {
+  const incompleteRide = activity({
+    id: 22,
+    type: 'Ride',
+    sport_type: 'Ride',
+    elapsed_time_min: 75,
+    distance_km: 0,
+    avg_speed_kmh: null,
+    avg_hr: 145,
+    max_hr: 180
+  });
+  delete incompleteRide.moving_time_min;
+
+  assert.equal(estimateStravaExertion(incompleteRide), null);
+});
+
+test('missing moving time can be estimated conservatively from distance and speed', () => {
+  const estimatedRide = activity({
+    id: 23,
+    type: 'Ride',
+    sport_type: 'Ride',
+    elapsed_time_min: 90,
+    distance_km: 10,
+    avg_speed_kmh: 20,
+    avg_hr: 145,
+    max_hr: 180
+  });
+  delete estimatedRide.moving_time_min;
+
+  const score = estimateStravaExertion(estimatedRide);
+  assert.ok(score > 0);
+  assert.ok(score < 3);
 });
 
 test(

--- a/tests/unit/strava-scoring.test.mjs
+++ b/tests/unit/strava-scoring.test.mjs
@@ -137,34 +137,42 @@ test('legacy score metadata is preserved but ignored by automatic scoring', () =
   assert.equal(resolveStravaExertion(overridden), 3.8);
 });
 
-test(
-  'dense strength outranks a moderate cardio workout of similar duration',
-  () => {
-    const strength = computeStrengthCredit(features());
-    const cardio = computeCardioCredit(
-      features({
-        strength_minutes: 0,
-        cardio_zone_minutes: [0, 0, 70, 0, 0],
-        strength_density: 0
-      })
-    );
+test('dense strength outranks a moderate cardio workout of similar duration', () => {
+  const strength = computeStrengthCredit(features());
+  const cardio = computeCardioCredit(
+    features({
+      strength_minutes: 0,
+      cardio_zone_minutes: [0, 0, 70, 0, 0],
+      strength_density: 0
+    })
+  );
 
-    assert.ok(strength > cardio + 1);
-    assert.ok(strength > 4.5);
-    assert.ok(cardio < 4);
-  }
-);
+  assert.ok(strength > cardio + 1);
+  assert.ok(strength > 4.5);
+  assert.ok(cardio < 4);
+});
 
-test(
-  'secondary modality adds limited credit and never creates two workouts',
-  () => {
-    assert.equal(combineWorkoutComponents(5.2, 0.8), 5.4);
-    assert.equal(combineWorkoutComponents(4, 4), 5);
-    assert.equal(combineWorkoutComponents(6, 6), 6);
-  }
-);
+test('secondary modality adds limited credit and never creates two workouts', () => {
+  assert.equal(combineWorkoutComponents(5.2, 0.8), 5.4);
+  assert.equal(combineWorkoutComponents(4, 4), 5);
+  assert.equal(combineWorkoutComponents(6, 6), 7);
+  assert.equal(combineWorkoutComponents(9, 6), 10);
+});
 
-test('adjacent Strava records are scored as one bounded mixed session', () => {
+test('long dense strength sessions can exceed six points', () => {
+  const strength = computeStrengthCredit(
+    features({
+      active_minutes: 240,
+      strength_minutes: 240,
+      strength_density: 1,
+      strength_factor: 1.1
+    })
+  );
+
+  assert.ok(strength > 6);
+});
+
+test('adjacent Strava records are scored as one mixed session', () => {
   const warmup = activity({
     id: 10,
     name: 'Warm-up ride',
@@ -221,7 +229,6 @@ test('adjacent Strava records are scored as one bounded mixed session', () => {
 
   const sessionScore = resolveStravaExertion(lifting);
   assert.ok(sessionScore > 4.5);
-  assert.ok(sessionScore <= 6);
   assert.equal(resolveStravaExertion(warmup), null);
   assert.equal(resolveStravaExertion(cooldown), null);
 
@@ -358,52 +365,45 @@ test('missing moving time can be estimated conservatively from distance and spee
   assert.ok(score < 3);
 });
 
-test(
-  'manual and reported exertion values do not replace automatic scoring',
-  () => {
-    const baseline = activity({
-      id: 30,
-      moving_time_min: 60.3,
-      elapsed_time_min: 60.3
-    });
-    const overridden = activity({
-      ...baseline,
-      id: 31,
-      exertion: 99,
-      local_exertion: 99,
-      reported_exertion: 10
-    });
+test('manual and reported exertion values do not replace automatic scoring', () => {
+  const baseline = activity({
+    id: 30,
+    moving_time_min: 60.3,
+    elapsed_time_min: 60.3
+  });
+  const overridden = activity({
+    ...baseline,
+    id: 31,
+    exertion: 99,
+    local_exertion: 99,
+    reported_exertion: 10
+  });
 
-    assert.equal(estimateStravaExertion(baseline), 3.8);
-    assert.equal(estimateStravaExertion(overridden), 3.8);
-  }
-);
+  assert.equal(estimateStravaExertion(baseline), 3.8);
+  assert.equal(estimateStravaExertion(overridden), 3.8);
+});
 
-test(
-  'stream-derived mixed features retain a bounded secondary contribution',
-  () => {
-    const mixed = activity({
-      id: 40,
-      score_features: features({
-        active_minutes: 80,
-        strength_minutes: 65,
-        cardio_zone_minutes: [0, 0, 15, 0, 0],
-        strength_density: 0.65
-      })
-    });
-    const pureStrength = activity({
-      id: 41,
-      score_features: features({
-        active_minutes: 65,
-        strength_minutes: 65,
-        strength_density: 0.65
-      })
-    });
+test('stream-derived mixed features retain a bounded secondary contribution', () => {
+  const mixed = activity({
+    id: 40,
+    score_features: features({
+      active_minutes: 80,
+      strength_minutes: 65,
+      cardio_zone_minutes: [0, 0, 15, 0, 0],
+      strength_density: 0.65
+    })
+  });
+  const pureStrength = activity({
+    id: 41,
+    score_features: features({
+      active_minutes: 65,
+      strength_minutes: 65,
+      strength_density: 0.65
+    })
+  });
 
-    const mixedScore = getStravaWorkoutScoreBreakdown(mixed);
-    const strengthScore = getStravaWorkoutScoreBreakdown(pureStrength);
-    assert.ok(mixedScore.total > strengthScore.total);
-    assert.ok(mixedScore.total - strengthScore.total < 1);
-    assert.ok(mixedScore.total <= 6);
-  }
-);
+  const mixedScore = getStravaWorkoutScoreBreakdown(mixed);
+  const strengthScore = getStravaWorkoutScoreBreakdown(pureStrength);
+  assert.ok(mixedScore.total > strengthScore.total);
+  assert.ok(mixedScore.total - strengthScore.total < 1);
+});

--- a/tests/unit/strava-scoring.test.mjs
+++ b/tests/unit/strava-scoring.test.mjs
@@ -1,0 +1,214 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  STRAVA_SCORE_MODEL_VERSION,
+  combineWorkoutComponents,
+  computeCardioCredit,
+  computeStravaScoreScale,
+  computeStrengthCredit,
+  estimateStravaExertion,
+  getCachedStravaScoreBreakdown,
+  getStravaWorkoutScoreBreakdown,
+  groupStravaActivitiesIntoSessions,
+  resolveStravaExertion
+} from '../../src/features/strava/core.mjs';
+
+function activity(overrides = {}) {
+  return {
+    id: Math.floor(Math.random() * 1_000_000_000),
+    name: 'Workout',
+    type: 'WeightTraining',
+    sport_type: 'WeightTraining',
+    start_date: '2026-08-03T08:00:00Z',
+    moving_time_min: 75,
+    elapsed_time_min: 75,
+    avg_hr: 130,
+    max_hr: 175,
+    ...overrides
+  };
+}
+
+function features(overrides = {}) {
+  return {
+    version: STRAVA_SCORE_MODEL_VERSION,
+    source: 'test',
+    active_minutes: 75,
+    strength_minutes: 75,
+    cardio_zone_minutes: [0, 0, 0, 0, 0],
+    strength_density: 0.6,
+    strength_factor: 1,
+    work_recovery_cycles: 12,
+    hr_max_reference: 190,
+    ...overrides
+  };
+}
+
+test('strength scoring is not driven by average heart rate', () => {
+  const lowHr = estimateStravaExertion(
+    activity({ id: 1, avg_hr: 105, max_hr: 145 })
+  );
+  const highHr = estimateStravaExertion(
+    activity({ id: 2, avg_hr: 170, max_hr: 190 })
+  );
+
+  assert.equal(lowHr, highHr);
+  assert.equal(lowHr, 4.4);
+});
+
+test(
+  'dense strength outranks a moderate cardio workout of similar duration',
+  () => {
+    const strength = computeStrengthCredit(features());
+    const cardio = computeCardioCredit(
+      features({
+        strength_minutes: 0,
+        cardio_zone_minutes: [0, 0, 70, 0, 0],
+        strength_density: 0
+      })
+    );
+
+    assert.ok(strength > cardio + 1);
+    assert.ok(strength > 4.5);
+    assert.ok(cardio < 4);
+  }
+);
+
+test(
+  'secondary modality adds limited credit and never creates two workouts',
+  () => {
+    assert.equal(combineWorkoutComponents(5.2, 0.8), 5.4);
+    assert.equal(combineWorkoutComponents(4, 4), 5);
+    assert.equal(combineWorkoutComponents(6, 6), 6);
+  }
+);
+
+test('adjacent Strava records are scored as one bounded mixed session', () => {
+  const warmup = activity({
+    id: 10,
+    name: 'Warm-up ride',
+    type: 'Ride',
+    sport_type: 'Ride',
+    start_date: '2026-08-03T08:00:00Z',
+    moving_time_min: 12,
+    elapsed_time_min: 12,
+    score_features: features({
+      active_minutes: 12,
+      strength_minutes: 0,
+      cardio_zone_minutes: [0, 0, 12, 0, 0],
+      strength_density: 0
+    })
+  });
+  const lifting = activity({
+    id: 11,
+    start_date: '2026-08-03T08:14:00Z',
+    moving_time_min: 70,
+    elapsed_time_min: 70,
+    score_features: features({
+      active_minutes: 70,
+      strength_minutes: 70,
+      strength_density: 0.7
+    })
+  });
+  const cooldown = activity({
+    id: 12,
+    name: 'Cooldown',
+    type: 'Ride',
+    sport_type: 'Ride',
+    start_date: '2026-08-03T09:26:00Z',
+    moving_time_min: 10,
+    elapsed_time_min: 10,
+    score_features: features({
+      active_minutes: 10,
+      strength_minutes: 0,
+      cardio_zone_minutes: [0, 10, 0, 0, 0],
+      strength_density: 0
+    })
+  });
+
+  const sessions = groupStravaActivitiesIntoSessions([
+    cooldown,
+    lifting,
+    warmup
+  ]);
+  assert.equal(sessions.length, 1);
+  assert.equal(sessions[0].activities.length, 3);
+
+  const model = computeStravaScoreScale([cooldown, lifting, warmup]);
+  assert.equal(model.modelVersion, STRAVA_SCORE_MODEL_VERSION);
+  assert.equal(model.sessions, 1);
+
+  const sessionScore = resolveStravaExertion(warmup);
+  assert.ok(sessionScore > 4.5);
+  assert.ok(sessionScore <= 6);
+  assert.equal(resolveStravaExertion(lifting), null);
+  assert.equal(resolveStravaExertion(cooldown), null);
+
+  const breakdown = getCachedStravaScoreBreakdown(warmup);
+  assert.equal(breakdown.sessionActivityCount, 3);
+  assert.equal(breakdown.sessionPrimary, true);
+  assert.ok(breakdown.strength > breakdown.cardio);
+});
+
+test('paused elapsed time does not generate cardio credit', () => {
+  const pausedRide = activity({
+    id: 20,
+    type: 'Ride',
+    sport_type: 'Ride',
+    moving_time_min: 0.5,
+    elapsed_time_min: 75.5,
+    avg_hr: 145,
+    max_hr: 180
+  });
+  assert.equal(estimateStravaExertion(pausedRide), 0);
+});
+
+test(
+  'manual and reported exertion values do not replace automatic scoring',
+  () => {
+    const baseline = activity({
+      id: 30,
+      moving_time_min: 60.3,
+      elapsed_time_min: 60.3
+    });
+    const overridden = activity({
+      ...baseline,
+      id: 31,
+      exertion: 99,
+      local_exertion: 99,
+      reported_exertion: 10
+    });
+
+    assert.equal(estimateStravaExertion(baseline), 3.8);
+    assert.equal(estimateStravaExertion(overridden), 3.8);
+  }
+);
+
+test(
+  'stream-derived mixed features retain a bounded secondary contribution',
+  () => {
+    const mixed = activity({
+      id: 40,
+      score_features: features({
+        active_minutes: 80,
+        strength_minutes: 65,
+        cardio_zone_minutes: [0, 0, 15, 0, 0],
+        strength_density: 0.65
+      })
+    });
+    const pureStrength = activity({
+      id: 41,
+      score_features: features({
+        active_minutes: 65,
+        strength_minutes: 65,
+        strength_density: 0.65
+      })
+    });
+
+    const mixedScore = getStravaWorkoutScoreBreakdown(mixed);
+    const strengthScore = getStravaWorkoutScoreBreakdown(pureStrength);
+    assert.ok(mixedScore.total > strengthScore.total);
+    assert.ok(mixedScore.total - strengthScore.total < 1);
+    assert.ok(mixedScore.total <= 6);
+  }
+);

--- a/tests/unit/strava-scoring.test.mjs
+++ b/tests/unit/strava-scoring.test.mjs
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import {
+  STRAVA_FEATURE_VERSION,
   STRAVA_SCORE_MODEL_VERSION,
   combineWorkoutComponents,
   computeCardioCredit,
@@ -44,6 +45,7 @@ function activity(overrides = {}) {
 function features(overrides = {}) {
   return {
     version: STRAVA_SCORE_MODEL_VERSION,
+    feature_version: STRAVA_FEATURE_VERSION,
     source: 'test',
     active_minutes: 75,
     strength_minutes: 75,
@@ -66,6 +68,30 @@ test('strength scoring is not driven by average heart rate', () => {
 
   assert.equal(lowHr, highHr);
   assert.equal(lowHr, 4.4);
+});
+
+test('stale stream features fall back to the current automatic model', () => {
+  const staleRide = activity({
+    id: 5,
+    type: 'Ride',
+    sport_type: 'Ride',
+    moving_time_min: 60,
+    elapsed_time_min: 60,
+    avg_hr: 145,
+    score_features: {
+      version: STRAVA_SCORE_MODEL_VERSION,
+      source: 'streams',
+      active_minutes: 60,
+      strength_minutes: 60,
+      cardio_zone_minutes: [0, 0, 0, 0, 0],
+      strength_density: 1
+    }
+  });
+
+  const breakdown = getStravaWorkoutScoreBreakdown(staleRide);
+  assert.equal(breakdown.features.source, 'summary');
+  assert.equal(breakdown.features.strength_minutes, 0);
+  assert.ok(breakdown.cardio > 0);
 });
 
 test('known field sports remain cardio without manual classification', () => {


### PR DESCRIPTION
## Why

The previous Strava score was primarily an HR-duration calculation. That made moderate cardio score too close to intense strength work and allowed cardio segments to dominate mixed sessions.

## What changed

- Add score model v2 with separate 0–6 strength and cardio components.
- Score strength from effective session duration and automatically derived density, not average HR.
- Score cardio from zone-weighted active minutes, not elapsed time.
- Combine mixed work with a bounded secondary bonus: 25% of the secondary component, capped at one point; the full session remains capped at six.
- Group overlapping or adjacent Strava records into one session, so warm-up, lifting and cooldown are not counted as separate workouts.
- Derive compact stream features in both directions:
  - cadence, power or velocity can identify cardio inside strength;
  - repeated non-locomotion work/recovery blocks can identify strength inside cardio.
- Preserve the activity type as a conservative prior; steady elevated HR alone cannot turn strength into cardio.
- Stop explicit zero or missing movement data from inheriting paused elapsed time.
- Version extracted features independently, reject stale cached features immediately, and backfill them automatically across later fetch runs.
- Keep legacy override metadata non-destructively available to the UI, but do not use manual or reported exertion to calibrate or replace automatic scores.
- Precache the new scoring modules in the service worker.

## Validation

- 15 focused Node unit tests pass.
- 8 Python `unittest` tests pass.
- Changed JavaScript modules pass `node --check`.
- The Python publisher, extractor and tests pass `py_compile`.
- Regression coverage includes:
  - strength outranking similar-duration moderate cardio;
  - bounded secondary credit;
  - warm-up + strength + cooldown counted once;
  - paused, zero and missing movement data;
  - cardio inside strength and strength inside cardio;
  - indoor rides with zero velocity;
  - stale feature migration;
  - no manual intervention.

## Spot check

Using the repository's recorded activities with the conservative summary fallback:

- 67.5-minute strength session: approximately 4.1 points.
- 66.3-minute moderate ride: approximately 3.4 points.
- 37.2 moving / 146.6 elapsed ride: approximately 0.6 points.
- 0.5 moving / 75.5 elapsed ride: 0 points.

## Scope

The PR remains draft. Focused tests passed locally; a full repository npm/Playwright run was not available in this environment.