### PR TITLE
Add measured Codex efficiency analysis

### DIFF
--- a/.github/workflows/codex-analysis-ci.yml
+++ b/.github/workflows/codex-analysis-ci.yml
@@ -3,13 +3,13 @@ name: Codex analysis checks
 on:
   pull_request:
     paths:
-      - "codex-analysis.html"
-      - "src/features/codex/**"
-      - "scripts/codex-usage-history.mjs"
-      - "tests/unit/codex-analytics.test.mjs"
-      - "tests/unit/codex-usage-history.test.mjs"
-      - ".github/workflows/codex-analysis-ci.yml"
-      - ".github/workflows/codex-usage-history.yml"
+      - 'codex-analysis.html'
+      - 'src/features/codex/**'
+      - 'scripts/codex-usage-history.mjs'
+      - 'tests/unit/codex-analytics.test.mjs'
+      - 'tests/unit/codex-usage-history.test.mjs'
+      - '.github/workflows/codex-analysis-ci.yml'
+      - '.github/workflows/codex-usage-history.yml'
   workflow_dispatch:
 
 permissions:
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: '22'
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/codex-analysis-ci.yml
+++ b/.github/workflows/codex-analysis-ci.yml
@@ -13,15 +13,13 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref || github.ref_name }}
 
       - uses: actions/setup-node@v4
         with:
@@ -31,19 +29,25 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Normalize formatting on the pull-request branch
-        if: github.event_name == 'pull_request'
-        run: |
-          npx prettier --write codex-analysis.html docs/codex-analysis.md scripts/codex-usage-history.mjs src/features/codex/analytics.mjs src/features/codex/analysis-page.mjs tests/unit/codex-analytics.test.mjs tests/unit/codex-usage-history.test.mjs .github/workflows/codex-analysis-ci.yml .github/workflows/codex-usage-history.yml
-          if git diff --quiet; then
-            echo "Formatting is already normalized."
-            exit 0
-          fi
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add codex-analysis.html docs/codex-analysis.md scripts/codex-usage-history.mjs src/features/codex/analytics.mjs src/features/codex/analysis-page.mjs tests/unit/codex-analytics.test.mjs tests/unit/codex-usage-history.test.mjs .github/workflows/codex-analysis-ci.yml .github/workflows/codex-usage-history.yml
-          git commit -m "Format Codex analysis implementation [skip ci]"
-          git push origin "HEAD:${GITHUB_HEAD_REF}"
+      - name: Normalize files for validation and handoff
+        run: npx prettier --write codex-analysis.html docs/codex-analysis.md scripts/codex-usage-history.mjs src/features/codex/analytics.mjs src/features/codex/analysis-page.mjs tests/unit/codex-analytics.test.mjs tests/unit/codex-usage-history.test.mjs .github/workflows/codex-analysis-ci.yml .github/workflows/codex-usage-history.yml
+
+      - name: Upload normalized implementation
+        uses: actions/upload-artifact@v4
+        with:
+          name: codex-analysis-formatted
+          if-no-files-found: error
+          retention-days: 1
+          path: |
+            codex-analysis.html
+            docs/codex-analysis.md
+            scripts/codex-usage-history.mjs
+            src/features/codex/analytics.mjs
+            src/features/codex/analysis-page.mjs
+            tests/unit/codex-analytics.test.mjs
+            tests/unit/codex-usage-history.test.mjs
+            .github/workflows/codex-analysis-ci.yml
+            .github/workflows/codex-usage-history.yml
 
       - name: Check syntax
         run: |

--- a/.github/workflows/codex-analysis-ci.yml
+++ b/.github/workflows/codex-analysis-ci.yml
@@ -13,13 +13,15 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref || github.ref_name }}
 
       - uses: actions/setup-node@v4
         with:
@@ -28,6 +30,20 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Normalize formatting on the pull-request branch
+        if: github.event_name == 'pull_request'
+        run: |
+          npx prettier --write codex-analysis.html docs/codex-analysis.md scripts/codex-usage-history.mjs src/features/codex/analytics.mjs src/features/codex/analysis-page.mjs tests/unit/codex-analytics.test.mjs tests/unit/codex-usage-history.test.mjs .github/workflows/codex-analysis-ci.yml .github/workflows/codex-usage-history.yml
+          if git diff --quiet; then
+            echo "Formatting is already normalized."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add codex-analysis.html docs/codex-analysis.md scripts/codex-usage-history.mjs src/features/codex/analytics.mjs src/features/codex/analysis-page.mjs tests/unit/codex-analytics.test.mjs tests/unit/codex-usage-history.test.mjs .github/workflows/codex-analysis-ci.yml .github/workflows/codex-usage-history.yml
+          git commit -m "Format Codex analysis implementation [skip ci]"
+          git push origin "HEAD:${GITHUB_HEAD_REF}"
 
       - name: Check syntax
         run: |

--- a/.github/workflows/codex-analysis-ci.yml
+++ b/.github/workflows/codex-analysis-ci.yml
@@ -4,10 +4,16 @@ on:
   pull_request:
     paths:
       - 'codex-analysis.html'
+      - 'index.html'
+      - 'service-worker.js'
+      - 'assets/timekeeper-codex-usage-history.json'
+      - 'docs/codex-analysis.md'
       - 'src/features/codex/**'
+      - 'src/styles/features.css'
       - 'scripts/codex-usage-history.mjs'
       - 'tests/unit/codex-analytics.test.mjs'
       - 'tests/unit/codex-usage-history.test.mjs'
+      - 'tests/smoke/timekeeper.spec.js'
       - '.github/workflows/codex-analysis-ci.yml'
       - '.github/workflows/codex-usage-history.yml'
   workflow_dispatch:
@@ -30,7 +36,7 @@ jobs:
         run: npm ci
 
       - name: Normalize files for validation and handoff
-        run: npx prettier --write codex-analysis.html docs/codex-analysis.md scripts/codex-usage-history.mjs src/features/codex/analytics.mjs src/features/codex/analysis-page.mjs tests/unit/codex-analytics.test.mjs tests/unit/codex-usage-history.test.mjs .github/workflows/codex-analysis-ci.yml .github/workflows/codex-usage-history.yml
+        run: npx prettier --write codex-analysis.html docs/codex-analysis.md index.html service-worker.js scripts/codex-usage-history.mjs src/features/codex/analytics.mjs src/features/codex/analysis-page.mjs src/styles/features.css tests/smoke/timekeeper.spec.js tests/unit/codex-analytics.test.mjs tests/unit/codex-usage-history.test.mjs .github/workflows/codex-analysis-ci.yml .github/workflows/codex-usage-history.yml
 
       - name: Upload normalized implementation
         uses: actions/upload-artifact@v4
@@ -41,9 +47,14 @@ jobs:
           path: |
             codex-analysis.html
             docs/codex-analysis.md
+            index.html
+            service-worker.js
+            assets/timekeeper-codex-usage-history.json
             scripts/codex-usage-history.mjs
             src/features/codex/analytics.mjs
             src/features/codex/analysis-page.mjs
+            src/styles/features.css
+            tests/smoke/timekeeper.spec.js
             tests/unit/codex-analytics.test.mjs
             tests/unit/codex-usage-history.test.mjs
             .github/workflows/codex-analysis-ci.yml
@@ -54,12 +65,13 @@ jobs:
           node --check scripts/codex-usage-history.mjs
           node --check src/features/codex/analytics.mjs
           node --check src/features/codex/analysis-page.mjs
+          node --check service-worker.js
 
       - name: Run focused unit tests
         run: node --test tests/unit/codex-analytics.test.mjs tests/unit/codex-usage-history.test.mjs
 
       - name: Check formatting
-        run: npx prettier --check codex-analysis.html docs/codex-analysis.md scripts/codex-usage-history.mjs src/features/codex/analytics.mjs src/features/codex/analysis-page.mjs tests/unit/codex-analytics.test.mjs tests/unit/codex-usage-history.test.mjs .github/workflows/codex-analysis-ci.yml .github/workflows/codex-usage-history.yml
+        run: npx prettier --check codex-analysis.html docs/codex-analysis.md index.html service-worker.js scripts/codex-usage-history.mjs src/features/codex/analytics.mjs src/features/codex/analysis-page.mjs src/styles/features.css tests/smoke/timekeeper.spec.js tests/unit/codex-analytics.test.mjs tests/unit/codex-usage-history.test.mjs .github/workflows/codex-analysis-ci.yml .github/workflows/codex-usage-history.yml
 
       - name: Lint new JavaScript
         run: npx eslint scripts/codex-usage-history.mjs src/features/codex/analytics.mjs src/features/codex/analysis-page.mjs tests/unit/codex-analytics.test.mjs tests/unit/codex-usage-history.test.mjs

--- a/.github/workflows/codex-analysis-ci.yml
+++ b/.github/workflows/codex-analysis-ci.yml
@@ -1,0 +1,48 @@
+name: Codex analysis checks
+
+on:
+  pull_request:
+    paths:
+      - "codex-analysis.html"
+      - "src/features/codex/**"
+      - "scripts/codex-usage-history.mjs"
+      - "tests/unit/codex-analytics.test.mjs"
+      - "tests/unit/codex-usage-history.test.mjs"
+      - ".github/workflows/codex-analysis-ci.yml"
+      - ".github/workflows/codex-usage-history.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check syntax
+        run: |
+          node --check scripts/codex-usage-history.mjs
+          node --check src/features/codex/analytics.mjs
+          node --check src/features/codex/analysis-page.mjs
+
+      - name: Run focused unit tests
+        run: node --test tests/unit/codex-analytics.test.mjs tests/unit/codex-usage-history.test.mjs
+
+      - name: Check formatting
+        run: npx prettier --check codex-analysis.html docs/codex-analysis.md scripts/codex-usage-history.mjs src/features/codex/analytics.mjs src/features/codex/analysis-page.mjs tests/unit/codex-analytics.test.mjs tests/unit/codex-usage-history.test.mjs .github/workflows/codex-analysis-ci.yml .github/workflows/codex-usage-history.yml
+
+      - name: Lint new JavaScript
+        run: npx eslint scripts/codex-usage-history.mjs src/features/codex/analytics.mjs src/features/codex/analysis-page.mjs tests/unit/codex-analytics.test.mjs tests/unit/codex-usage-history.test.mjs
+
+      - name: Type-check repository
+        run: npm run typecheck

--- a/.github/workflows/codex-usage-history.yml
+++ b/.github/workflows/codex-usage-history.yml
@@ -1,0 +1,48 @@
+name: Update Codex usage history
+
+on:
+  schedule:
+    - cron: "*/10 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: codex-usage-history
+  cancel-in-progress: false
+
+jobs:
+  sample:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Sample current Codex limit state
+        run: node scripts/codex-usage-history.mjs
+
+      - name: Commit usage history when changed
+        run: |
+          if git diff --quiet -- assets/timekeeper-codex-usage-history.json; then
+            echo "No new Codex usage sample to publish."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add assets/timekeeper-codex-usage-history.json
+          git commit -m "Update Codex usage history [skip ci]"
+          for attempt in 1 2 3; do
+            git pull --rebase origin "${GITHUB_REF_NAME}"
+            if git push; then
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "Unable to push Codex usage history after three attempts."
+          exit 1

--- a/.github/workflows/codex-usage-history.yml
+++ b/.github/workflows/codex-usage-history.yml
@@ -2,7 +2,7 @@ name: Update Codex usage history
 
 on:
   schedule:
-    - cron: "*/10 * * * *"
+    - cron: '*/10 * * * *'
   workflow_dispatch:
 
 permissions:
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: '22'
 
       - name: Sample current Codex limit state
         run: node scripts/codex-usage-history.mjs

--- a/assets/strava.json
+++ b/assets/strava.json
@@ -1,5 +1,5 @@
 {
-  "updated_utc": "2026-08-13T10:38:51.078212+00:00",
+  "updated_utc": "2026-08-13T12:19:50.533231+00:00",
   "score_model_version": 2,
   "activities": [
     {
@@ -21,11 +21,11 @@
       "score_features": {
         "version": 2,
         "feature_version": 2,
-        "source": "summary",
-        "active_minutes": 52.13,
-        "effective_active_minutes": 52.13,
-        "strength_minutes": 52.13,
-        "strength_block_minutes": 52.13,
+        "source": "streams",
+        "active_minutes": 51.9,
+        "effective_active_minutes": 51.9,
+        "strength_minutes": 51.9,
+        "strength_block_minutes": 51.9,
         "cardio_zone_minutes": [
           0.0,
           0.0,
@@ -34,11 +34,11 @@
           0.0
         ],
         "cardio_block_minutes": 0.0,
-        "strength_density": 0.0,
+        "strength_density": 0.812,
         "strength_factor": 1.0,
-        "work_recovery_cycles": 0,
+        "work_recovery_cycles": 4,
         "hr_max_reference": 190.0,
-        "stream_status": "deferred"
+        "stream_status": "complete"
       }
     },
     {
@@ -60,11 +60,11 @@
       "score_features": {
         "version": 2,
         "feature_version": 2,
-        "source": "summary",
-        "active_minutes": 55.15,
-        "effective_active_minutes": 55.15,
-        "strength_minutes": 55.15,
-        "strength_block_minutes": 55.15,
+        "source": "streams",
+        "active_minutes": 53.87,
+        "effective_active_minutes": 53.87,
+        "strength_minutes": 53.87,
+        "strength_block_minutes": 53.87,
         "cardio_zone_minutes": [
           0.0,
           0.0,
@@ -73,11 +73,11 @@
           0.0
         ],
         "cardio_block_minutes": 0.0,
-        "strength_density": 0.0,
+        "strength_density": 1.0,
         "strength_factor": 1.0,
-        "work_recovery_cycles": 0,
+        "work_recovery_cycles": 1,
         "hr_max_reference": 190.0,
-        "stream_status": "deferred"
+        "stream_status": "complete"
       }
     },
     {
@@ -99,11 +99,11 @@
       "score_features": {
         "version": 2,
         "feature_version": 2,
-        "source": "summary",
-        "active_minutes": 68.93,
-        "effective_active_minutes": 68.93,
-        "strength_minutes": 68.93,
-        "strength_block_minutes": 68.93,
+        "source": "streams",
+        "active_minutes": 68.45,
+        "effective_active_minutes": 68.45,
+        "strength_minutes": 68.45,
+        "strength_block_minutes": 68.45,
         "cardio_zone_minutes": [
           0.0,
           0.0,
@@ -112,11 +112,11 @@
           0.0
         ],
         "cardio_block_minutes": 0.0,
-        "strength_density": 0.0,
+        "strength_density": 0.632,
         "strength_factor": 1.0,
-        "work_recovery_cycles": 0,
+        "work_recovery_cycles": 2,
         "hr_max_reference": 190.0,
-        "stream_status": "deferred"
+        "stream_status": "complete"
       }
     },
     {
@@ -138,11 +138,11 @@
       "score_features": {
         "version": 2,
         "feature_version": 2,
-        "source": "summary",
-        "active_minutes": 70.55,
-        "effective_active_minutes": 70.55,
-        "strength_minutes": 70.55,
-        "strength_block_minutes": 70.55,
+        "source": "streams",
+        "active_minutes": 44.62,
+        "effective_active_minutes": 44.62,
+        "strength_minutes": 44.62,
+        "strength_block_minutes": 44.62,
         "cardio_zone_minutes": [
           0.0,
           0.0,
@@ -151,11 +151,11 @@
           0.0
         ],
         "cardio_block_minutes": 0.0,
-        "strength_density": 0.0,
+        "strength_density": 0.976,
         "strength_factor": 1.0,
-        "work_recovery_cycles": 0,
+        "work_recovery_cycles": 1,
         "hr_max_reference": 190.0,
-        "stream_status": "deferred"
+        "stream_status": "complete"
       }
     },
     {
@@ -177,11 +177,11 @@
       "score_features": {
         "version": 2,
         "feature_version": 2,
-        "source": "summary",
-        "active_minutes": 101.18,
-        "effective_active_minutes": 101.18,
-        "strength_minutes": 101.18,
-        "strength_block_minutes": 101.18,
+        "source": "streams",
+        "active_minutes": 86.38,
+        "effective_active_minutes": 86.38,
+        "strength_minutes": 86.38,
+        "strength_block_minutes": 86.38,
         "cardio_zone_minutes": [
           0.0,
           0.0,
@@ -190,11 +190,11 @@
           0.0
         ],
         "cardio_block_minutes": 0.0,
-        "strength_density": 0.0,
+        "strength_density": 0.643,
         "strength_factor": 1.0,
-        "work_recovery_cycles": 0,
+        "work_recovery_cycles": 3,
         "hr_max_reference": 190.0,
-        "stream_status": "deferred"
+        "stream_status": "complete"
       }
     },
     {
@@ -216,11 +216,11 @@
       "score_features": {
         "version": 2,
         "feature_version": 2,
-        "source": "summary",
-        "active_minutes": 83.43,
-        "effective_active_minutes": 83.43,
-        "strength_minutes": 83.43,
-        "strength_block_minutes": 83.43,
+        "source": "streams",
+        "active_minutes": 68.67,
+        "effective_active_minutes": 68.67,
+        "strength_minutes": 68.67,
+        "strength_block_minutes": 68.67,
         "cardio_zone_minutes": [
           0.0,
           0.0,
@@ -229,11 +229,11 @@
           0.0
         ],
         "cardio_block_minutes": 0.0,
-        "strength_density": 0.0,
+        "strength_density": 0.693,
         "strength_factor": 1.0,
-        "work_recovery_cycles": 0,
+        "work_recovery_cycles": 4,
         "hr_max_reference": 190.0,
-        "stream_status": "deferred"
+        "stream_status": "complete"
       }
     },
     {
@@ -255,11 +255,11 @@
       "score_features": {
         "version": 2,
         "feature_version": 2,
-        "source": "summary",
-        "active_minutes": 90.4,
-        "effective_active_minutes": 90.4,
-        "strength_minutes": 90.4,
-        "strength_block_minutes": 90.4,
+        "source": "streams",
+        "active_minutes": 83.88,
+        "effective_active_minutes": 83.88,
+        "strength_minutes": 83.88,
+        "strength_block_minutes": 83.88,
         "cardio_zone_minutes": [
           0.0,
           0.0,
@@ -268,11 +268,11 @@
           0.0
         ],
         "cardio_block_minutes": 0.0,
-        "strength_density": 0.0,
+        "strength_density": 0.778,
         "strength_factor": 1.0,
-        "work_recovery_cycles": 0,
+        "work_recovery_cycles": 6,
         "hr_max_reference": 190.0,
-        "stream_status": "deferred"
+        "stream_status": "complete"
       }
     },
     {
@@ -294,11 +294,11 @@
       "score_features": {
         "version": 2,
         "feature_version": 2,
-        "source": "summary",
-        "active_minutes": 66.95,
-        "effective_active_minutes": 66.95,
-        "strength_minutes": 66.95,
-        "strength_block_minutes": 66.95,
+        "source": "streams",
+        "active_minutes": 62.35,
+        "effective_active_minutes": 62.35,
+        "strength_minutes": 62.35,
+        "strength_block_minutes": 62.35,
         "cardio_zone_minutes": [
           0.0,
           0.0,
@@ -307,11 +307,11 @@
           0.0
         ],
         "cardio_block_minutes": 0.0,
-        "strength_density": 0.0,
+        "strength_density": 0.941,
         "strength_factor": 1.0,
-        "work_recovery_cycles": 0,
+        "work_recovery_cycles": 1,
         "hr_max_reference": 190.0,
-        "stream_status": "deferred"
+        "stream_status": "complete"
       }
     },
     {
@@ -333,11 +333,11 @@
       "score_features": {
         "version": 2,
         "feature_version": 2,
-        "source": "summary",
-        "active_minutes": 195.88,
-        "effective_active_minutes": 195.88,
-        "strength_minutes": 195.88,
-        "strength_block_minutes": 195.88,
+        "source": "streams",
+        "active_minutes": 117.75,
+        "effective_active_minutes": 117.75,
+        "strength_minutes": 117.75,
+        "strength_block_minutes": 117.75,
         "cardio_zone_minutes": [
           0.0,
           0.0,
@@ -346,11 +346,11 @@
           0.0
         ],
         "cardio_block_minutes": 0.0,
-        "strength_density": 0.0,
+        "strength_density": 0.613,
         "strength_factor": 1.0,
-        "work_recovery_cycles": 0,
+        "work_recovery_cycles": 7,
         "hr_max_reference": 190.0,
-        "stream_status": "deferred"
+        "stream_status": "complete"
       }
     },
     {
@@ -389,7 +389,7 @@
         "strength_factor": 1.0,
         "work_recovery_cycles": 0,
         "hr_max_reference": 190.0,
-        "stream_status": "deferred"
+        "stream_status": "unavailable"
       }
     },
     {
@@ -411,11 +411,11 @@
       "score_features": {
         "version": 2,
         "feature_version": 2,
-        "source": "summary",
-        "active_minutes": 84.87,
-        "effective_active_minutes": 84.87,
-        "strength_minutes": 84.87,
-        "strength_block_minutes": 84.87,
+        "source": "streams",
+        "active_minutes": 84.35,
+        "effective_active_minutes": 84.35,
+        "strength_minutes": 84.35,
+        "strength_block_minutes": 84.35,
         "cardio_zone_minutes": [
           0.0,
           0.0,
@@ -424,11 +424,11 @@
           0.0
         ],
         "cardio_block_minutes": 0.0,
-        "strength_density": 0.0,
+        "strength_density": 0.85,
         "strength_factor": 1.0,
-        "work_recovery_cycles": 0,
+        "work_recovery_cycles": 4,
         "hr_max_reference": 190.0,
-        "stream_status": "deferred"
+        "stream_status": "complete"
       }
     },
     {
@@ -450,11 +450,11 @@
       "score_features": {
         "version": 2,
         "feature_version": 2,
-        "source": "summary",
-        "active_minutes": 70.08,
-        "effective_active_minutes": 70.08,
-        "strength_minutes": 70.08,
-        "strength_block_minutes": 70.08,
+        "source": "streams",
+        "active_minutes": 58.67,
+        "effective_active_minutes": 58.67,
+        "strength_minutes": 58.67,
+        "strength_block_minutes": 58.67,
         "cardio_zone_minutes": [
           0.0,
           0.0,
@@ -463,11 +463,11 @@
           0.0
         ],
         "cardio_block_minutes": 0.0,
-        "strength_density": 0.0,
+        "strength_density": 0.928,
         "strength_factor": 1.0,
-        "work_recovery_cycles": 0,
+        "work_recovery_cycles": 2,
         "hr_max_reference": 190.0,
-        "stream_status": "deferred"
+        "stream_status": "complete"
       }
     },
     {
@@ -489,11 +489,11 @@
       "score_features": {
         "version": 2,
         "feature_version": 2,
-        "source": "summary",
-        "active_minutes": 67.53,
-        "effective_active_minutes": 67.53,
-        "strength_minutes": 67.53,
-        "strength_block_minutes": 67.53,
+        "source": "streams",
+        "active_minutes": 23.53,
+        "effective_active_minutes": 23.53,
+        "strength_minutes": 23.53,
+        "strength_block_minutes": 23.53,
         "cardio_zone_minutes": [
           0.0,
           0.0,
@@ -502,11 +502,11 @@
           0.0
         ],
         "cardio_block_minutes": 0.0,
-        "strength_density": 0.0,
+        "strength_density": 1.0,
         "strength_factor": 1.0,
-        "work_recovery_cycles": 0,
+        "work_recovery_cycles": 1,
         "hr_max_reference": 190.0,
-        "stream_status": "deferred"
+        "stream_status": "complete"
       }
     },
     {
@@ -528,11 +528,11 @@
       "score_features": {
         "version": 2,
         "feature_version": 2,
-        "source": "summary",
-        "active_minutes": 80.57,
-        "effective_active_minutes": 80.57,
-        "strength_minutes": 80.57,
-        "strength_block_minutes": 80.57,
+        "source": "streams",
+        "active_minutes": 69.98,
+        "effective_active_minutes": 69.98,
+        "strength_minutes": 69.98,
+        "strength_block_minutes": 69.98,
         "cardio_zone_minutes": [
           0.0,
           0.0,
@@ -541,11 +541,11 @@
           0.0
         ],
         "cardio_block_minutes": 0.0,
-        "strength_density": 0.0,
+        "strength_density": 0.943,
         "strength_factor": 1.0,
-        "work_recovery_cycles": 0,
+        "work_recovery_cycles": 1,
         "hr_max_reference": 190.0,
-        "stream_status": "deferred"
+        "stream_status": "complete"
       }
     },
     {
@@ -567,24 +567,24 @@
       "score_features": {
         "version": 2,
         "feature_version": 2,
-        "source": "summary",
-        "active_minutes": 61.35,
-        "effective_active_minutes": 61.35,
-        "strength_minutes": 46.01,
-        "strength_block_minutes": 46.01,
+        "source": "streams",
+        "active_minutes": 60.17,
+        "effective_active_minutes": 60.17,
+        "strength_minutes": 60.17,
+        "strength_block_minutes": 60.17,
         "cardio_zone_minutes": [
-          15.34,
+          0.0,
           0.0,
           0.0,
           0.0,
           0.0
         ],
-        "cardio_block_minutes": 15.34,
-        "strength_density": 0.25,
+        "cardio_block_minutes": 0.0,
+        "strength_density": 0.363,
         "strength_factor": 1.0,
-        "work_recovery_cycles": 0,
+        "work_recovery_cycles": 2,
         "hr_max_reference": 190.0,
-        "stream_status": "deferred"
+        "stream_status": "complete"
       }
     },
     {
@@ -606,11 +606,11 @@
       "score_features": {
         "version": 2,
         "feature_version": 2,
-        "source": "summary",
-        "active_minutes": 75.97,
-        "effective_active_minutes": 75.97,
-        "strength_minutes": 75.97,
-        "strength_block_minutes": 75.97,
+        "source": "streams",
+        "active_minutes": 65.55,
+        "effective_active_minutes": 65.55,
+        "strength_minutes": 65.55,
+        "strength_block_minutes": 65.55,
         "cardio_zone_minutes": [
           0.0,
           0.0,
@@ -619,11 +619,11 @@
           0.0
         ],
         "cardio_block_minutes": 0.0,
-        "strength_density": 0.0,
+        "strength_density": 0.867,
         "strength_factor": 1.0,
-        "work_recovery_cycles": 0,
+        "work_recovery_cycles": 3,
         "hr_max_reference": 190.0,
-        "stream_status": "deferred"
+        "stream_status": "complete"
       }
     },
     {
@@ -645,11 +645,11 @@
       "score_features": {
         "version": 2,
         "feature_version": 2,
-        "source": "summary",
-        "active_minutes": 83.12,
-        "effective_active_minutes": 83.12,
-        "strength_minutes": 83.12,
-        "strength_block_minutes": 83.12,
+        "source": "streams",
+        "active_minutes": 75.3,
+        "effective_active_minutes": 75.3,
+        "strength_minutes": 75.3,
+        "strength_block_minutes": 75.3,
         "cardio_zone_minutes": [
           0.0,
           0.0,
@@ -658,11 +658,11 @@
           0.0
         ],
         "cardio_block_minutes": 0.0,
-        "strength_density": 0.0,
+        "strength_density": 0.843,
         "strength_factor": 1.0,
-        "work_recovery_cycles": 0,
+        "work_recovery_cycles": 1,
         "hr_max_reference": 190.0,
-        "stream_status": "deferred"
+        "stream_status": "complete"
       }
     },
     {
@@ -684,24 +684,24 @@
       "score_features": {
         "version": 2,
         "feature_version": 2,
-        "source": "summary",
-        "active_minutes": 37.25,
-        "effective_active_minutes": 37.25,
+        "source": "streams",
+        "active_minutes": 25.83,
+        "effective_active_minutes": 25.83,
         "strength_minutes": 0.0,
         "strength_block_minutes": 0.0,
         "cardio_zone_minutes": [
-          37.25,
-          0.0,
-          0.0,
+          17.73,
+          6.43,
+          1.67,
           0.0,
           0.0
         ],
-        "cardio_block_minutes": 37.25,
+        "cardio_block_minutes": 25.83,
         "strength_density": 0.0,
         "strength_factor": 1.0,
         "work_recovery_cycles": 0,
         "hr_max_reference": 190.0,
-        "stream_status": "deferred"
+        "stream_status": "complete"
       }
     },
     {
@@ -723,11 +723,11 @@
       "score_features": {
         "version": 2,
         "feature_version": 2,
-        "source": "summary",
-        "active_minutes": 71.08,
-        "effective_active_minutes": 71.08,
-        "strength_minutes": 71.08,
-        "strength_block_minutes": 71.08,
+        "source": "streams",
+        "active_minutes": 62.27,
+        "effective_active_minutes": 62.27,
+        "strength_minutes": 62.27,
+        "strength_block_minutes": 62.27,
         "cardio_zone_minutes": [
           0.0,
           0.0,
@@ -736,11 +736,11 @@
           0.0
         ],
         "cardio_block_minutes": 0.0,
-        "strength_density": 0.0,
+        "strength_density": 0.916,
         "strength_factor": 1.0,
-        "work_recovery_cycles": 0,
+        "work_recovery_cycles": 1,
         "hr_max_reference": 190.0,
-        "stream_status": "deferred"
+        "stream_status": "complete"
       }
     },
     {
@@ -762,24 +762,24 @@
       "score_features": {
         "version": 2,
         "feature_version": 2,
-        "source": "summary",
-        "active_minutes": 0.5,
-        "effective_active_minutes": 0.5,
-        "strength_minutes": 0.0,
-        "strength_block_minutes": 0.0,
+        "source": "streams",
+        "active_minutes": 72.8,
+        "effective_active_minutes": 72.8,
+        "strength_minutes": 72.33,
+        "strength_block_minutes": 72.33,
         "cardio_zone_minutes": [
-          0.5,
+          0.47,
           0.0,
           0.0,
           0.0,
           0.0
         ],
-        "cardio_block_minutes": 0.5,
-        "strength_density": 0.0,
+        "cardio_block_minutes": 0.47,
+        "strength_density": 0.579,
         "strength_factor": 1.0,
-        "work_recovery_cycles": 0,
+        "work_recovery_cycles": 2,
         "hr_max_reference": 190.0,
-        "stream_status": "deferred"
+        "stream_status": "complete"
       }
     },
     {
@@ -801,7 +801,7 @@
       "score_features": {
         "version": 2,
         "feature_version": 2,
-        "source": "summary",
+        "source": "streams",
         "active_minutes": 29.15,
         "effective_active_minutes": 29.15,
         "strength_minutes": 29.15,
@@ -814,11 +814,11 @@
           0.0
         ],
         "cardio_block_minutes": 0.0,
-        "strength_density": 0.0,
+        "strength_density": 0.997,
         "strength_factor": 1.0,
-        "work_recovery_cycles": 0,
+        "work_recovery_cycles": 1,
         "hr_max_reference": 190.0,
-        "stream_status": "deferred"
+        "stream_status": "complete"
       }
     },
     {
@@ -840,11 +840,11 @@
       "score_features": {
         "version": 2,
         "feature_version": 2,
-        "source": "summary",
-        "active_minutes": 68.77,
-        "effective_active_minutes": 68.77,
-        "strength_minutes": 68.77,
-        "strength_block_minutes": 68.77,
+        "source": "streams",
+        "active_minutes": 59.7,
+        "effective_active_minutes": 59.7,
+        "strength_minutes": 59.7,
+        "strength_block_minutes": 59.7,
         "cardio_zone_minutes": [
           0.0,
           0.0,
@@ -853,11 +853,11 @@
           0.0
         ],
         "cardio_block_minutes": 0.0,
-        "strength_density": 0.0,
+        "strength_density": 0.957,
         "strength_factor": 1.0,
-        "work_recovery_cycles": 0,
+        "work_recovery_cycles": 1,
         "hr_max_reference": 190.0,
-        "stream_status": "deferred"
+        "stream_status": "complete"
       }
     },
     {
@@ -879,11 +879,11 @@
       "score_features": {
         "version": 2,
         "feature_version": 2,
-        "source": "summary",
-        "active_minutes": 62.87,
-        "effective_active_minutes": 62.87,
-        "strength_minutes": 62.87,
-        "strength_block_minutes": 62.87,
+        "source": "streams",
+        "active_minutes": 51.87,
+        "effective_active_minutes": 51.87,
+        "strength_minutes": 51.87,
+        "strength_block_minutes": 51.87,
         "cardio_zone_minutes": [
           0.0,
           0.0,
@@ -892,11 +892,11 @@
           0.0
         ],
         "cardio_block_minutes": 0.0,
-        "strength_density": 0.0,
+        "strength_density": 0.952,
         "strength_factor": 1.0,
-        "work_recovery_cycles": 0,
+        "work_recovery_cycles": 1,
         "hr_max_reference": 190.0,
-        "stream_status": "deferred"
+        "stream_status": "complete"
       }
     },
     {
@@ -918,11 +918,11 @@
       "score_features": {
         "version": 2,
         "feature_version": 2,
-        "source": "summary",
-        "active_minutes": 82.0,
-        "effective_active_minutes": 82.0,
-        "strength_minutes": 82.0,
-        "strength_block_minutes": 82.0,
+        "source": "streams",
+        "active_minutes": 67.18,
+        "effective_active_minutes": 67.18,
+        "strength_minutes": 67.18,
+        "strength_block_minutes": 67.18,
         "cardio_zone_minutes": [
           0.0,
           0.0,
@@ -931,11 +931,11 @@
           0.0
         ],
         "cardio_block_minutes": 0.0,
-        "strength_density": 0.0,
+        "strength_density": 0.854,
         "strength_factor": 1.0,
-        "work_recovery_cycles": 0,
+        "work_recovery_cycles": 4,
         "hr_max_reference": 190.0,
-        "stream_status": "deferred"
+        "stream_status": "complete"
       }
     },
     {
@@ -957,15 +957,15 @@
       "score_features": {
         "version": 2,
         "feature_version": 2,
-        "source": "summary",
+        "source": "streams",
         "active_minutes": 53.02,
         "effective_active_minutes": 53.02,
         "strength_minutes": 0.0,
         "strength_block_minutes": 0.0,
         "cardio_zone_minutes": [
-          53.02,
-          0.0,
-          0.0,
+          33.12,
+          19.52,
+          0.38,
           0.0,
           0.0
         ],
@@ -974,7 +974,7 @@
         "strength_factor": 1.0,
         "work_recovery_cycles": 0,
         "hr_max_reference": 190.0,
-        "stream_status": "deferred"
+        "stream_status": "complete"
       }
     },
     {

--- a/assets/timekeeper-codex-usage-history.json
+++ b/assets/timekeeper-codex-usage-history.json
@@ -1,0 +1,20 @@
+{
+  "version": 1,
+  "generatedAt": "2026-08-13T10:13:03.830Z",
+  "retentionDays": 90,
+  "heartbeatMinutes": 60,
+  "source": "timekeeper-codex-inbox-sampler",
+  "samples": [
+    {
+      "observedAt": "2026-08-13T10:13:03.830Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 18,
+        "remainingPercent": 82,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-20T03:48:07.000Z"
+      },
+      "secondary": null
+    }
+  ]
+}

--- a/assets/timekeeper-codex-usage-history.json
+++ b/assets/timekeeper-codex-usage-history.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedAt": "2026-08-13T12:02:32.000Z",
+  "generatedAt": "2026-08-13T12:15:01.000Z",
   "retentionDays": 90,
   "heartbeatMinutes": 60,
   "source": "timekeeper-codex-inbox-sampler",
@@ -7432,6 +7432,17 @@
       "primary": {
         "usedPercent": 23,
         "remainingPercent": 77,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-20T03:48:07.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-13T12:08:03.889Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 24,
+        "remainingPercent": 76,
         "windowMinutes": 10080,
         "resetsAt": "2026-08-20T03:48:07.000Z"
       },

--- a/assets/timekeeper-codex-usage-history.json
+++ b/assets/timekeeper-codex-usage-history.json
@@ -1,16 +1,7437 @@
 {
   "version": 1,
-  "generatedAt": "2026-08-13T10:13:03.830Z",
+  "generatedAt": "2026-08-13T12:02:32.000Z",
   "retentionDays": 90,
   "heartbeatMinutes": 60,
   "source": "timekeeper-codex-inbox-sampler",
+  "backfill": {
+    "source": "git history of assets/timekeeper-codex-inbox/*.json",
+    "requestedDays": 30,
+    "candidateCount": 4697,
+    "recoveredFrom": "2026-07-23T20:03:45.324Z",
+    "recoveredThrough": "2026-08-13T10:58:03.798Z"
+  },
   "samples": [
+    {
+      "observedAt": "2026-07-23T20:03:45.324Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 96,
+        "remainingPercent": 4,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-07-28T17:02:53.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-23T20:33:26.753Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 97,
+        "remainingPercent": 3,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-07-28T17:02:53.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-23T20:52:23.027Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 98,
+        "remainingPercent": 2,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-07-28T17:02:53.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-23T21:00:36.075Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 99,
+        "remainingPercent": 1,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-07-28T17:02:53.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-23T21:15:19.872Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 100,
+        "remainingPercent": 0,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-07-28T17:02:53.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-23T22:17:57.282Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 100,
+        "remainingPercent": 0,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-07-28T17:02:53.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-23T23:19:49.526Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 100,
+        "remainingPercent": 0,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-07-28T17:02:53.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-24T00:23:53.571Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 100,
+        "remainingPercent": 0,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-07-28T17:02:53.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-24T01:28:05.499Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 100,
+        "remainingPercent": 0,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-07-28T17:02:53.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-24T02:28:15.576Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 100,
+        "remainingPercent": 0,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-07-28T17:02:53.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-24T03:32:57.442Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 100,
+        "remainingPercent": 0,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-07-28T17:02:53.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-25T19:32:33.880Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-01T19:29:22.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-25T19:42:40.156Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 1,
+        "remainingPercent": 99,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-01T19:29:22.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-25T19:48:12.340Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 2,
+        "remainingPercent": 98,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-01T19:29:22.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-25T20:29:26.032Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 3,
+        "remainingPercent": 97,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-01T19:29:22.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-26T06:03:38.108Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 3,
+        "remainingPercent": 97,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-01T19:29:22.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-26T06:34:26.326Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 4,
+        "remainingPercent": 96,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-01T19:29:22.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-26T07:42:25.429Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 5,
+        "remainingPercent": 95,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-01T19:29:22.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-26T08:42:30.252Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 5,
+        "remainingPercent": 95,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-01T19:29:22.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-26T09:04:37.691Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 6,
+        "remainingPercent": 94,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-01T19:29:22.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-26T09:45:07.428Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 7,
+        "remainingPercent": 93,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-01T19:29:22.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-26T10:42:37.123Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-02T10:42:31.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-26T11:12:29.333Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-02T11:12:24.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-26T11:42:37.850Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-02T11:42:27.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-26T12:12:34.871Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-02T12:12:27.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-26T12:42:33.504Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-02T12:42:27.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-26T13:12:31.284Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-02T13:12:25.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-26T13:42:34.401Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-02T13:42:30.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-26T13:52:50.626Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 9,
+        "remainingPercent": 91,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-01T19:29:22.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-26T14:12:36.215Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-02T14:12:29.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-26T14:42:27.519Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-02T14:42:17.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-26T15:12:39.083Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-02T15:12:30.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-26T15:42:36.641Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-02T15:42:30.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-26T16:12:34.765Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-02T16:12:31.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-26T16:43:04.879Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-02T16:42:55.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-26T17:13:04.190Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-02T17:12:53.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-26T17:42:36.062Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-02T17:42:29.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-26T18:12:36.269Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-02T18:12:30.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-26T19:54:24.343Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-02T19:54:18.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-26T20:32:50.059Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 18,
+        "remainingPercent": 82,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-01T19:29:22.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-26T20:59:28.486Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 19,
+        "remainingPercent": 81,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-01T19:29:22.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-26T21:33:18.610Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-02T21:33:14.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-26T22:03:13.811Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-02T22:03:06.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-26T22:33:34.976Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-02T22:33:24.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-26T23:03:19.453Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-02T23:03:15.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-26T23:33:24.337Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-02T23:33:19.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-27T00:03:22.961Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-03T00:03:16.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-27T00:33:28.554Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-03T00:33:23.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-27T01:03:25.196Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-03T01:03:19.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-27T01:37:33.991Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-03T01:37:25.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-27T02:08:07.093Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-03T02:07:51.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-27T02:17:53.279Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-03T02:17:32.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-27T02:28:07.141Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-03T02:27:58.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-27T02:33:07.199Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-03T02:32:59.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-27T06:23:11.462Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-03T06:21:04.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-27T06:32:50.458Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-03T06:32:10.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-27T06:37:45.076Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-03T06:37:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-27T06:47:53.396Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-03T06:47:33.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-27T06:53:09.581Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-03T06:52:44.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-27T06:57:53.987Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 24,
+        "remainingPercent": 76,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-01T19:29:22.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-27T11:42:52.422Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 31,
+        "remainingPercent": 69,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-01T19:29:22.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-27T11:47:55.363Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 32,
+        "remainingPercent": 68,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-01T19:29:22.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-27T13:52:42.121Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 37,
+        "remainingPercent": 63,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-01T19:29:22.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-27T13:58:03.819Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 38,
+        "remainingPercent": 62,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-01T19:29:22.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-28T13:03:03.567Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 6,
+        "remainingPercent": 94,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-04T06:20:32.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-28T13:38:04.469Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 7,
+        "remainingPercent": 93,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-04T06:20:33.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-28T14:28:03.639Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 8,
+        "remainingPercent": 92,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-04T06:20:33.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-28T15:18:03.014Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 9,
+        "remainingPercent": 91,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-04T06:20:32.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-28T16:08:02.899Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 10,
+        "remainingPercent": 90,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-04T06:20:33.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-28T16:38:03.280Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 11,
+        "remainingPercent": 89,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-04T06:20:33.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-28T16:48:02.836Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 12,
+        "remainingPercent": 88,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-04T06:20:33.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-28T17:03:02.915Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 13,
+        "remainingPercent": 87,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-04T06:20:32.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-28T17:18:03.305Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 14,
+        "remainingPercent": 86,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-04T06:20:33.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-28T17:43:02.888Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 15,
+        "remainingPercent": 85,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-04T06:20:32.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-28T18:43:02.913Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 15,
+        "remainingPercent": 85,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-04T06:20:32.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-28T19:13:02.919Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 16,
+        "remainingPercent": 84,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-04T06:20:33.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-28T19:38:03.036Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 17,
+        "remainingPercent": 83,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-04T06:20:33.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-28T19:48:03.101Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 18,
+        "remainingPercent": 82,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-04T06:20:33.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-28T20:08:03.113Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 19,
+        "remainingPercent": 81,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-04T06:20:33.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-28T20:26:07.432Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 20,
+        "remainingPercent": 80,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-04T06:20:33.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-28T20:53:03.363Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 21,
+        "remainingPercent": 79,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-04T06:20:32.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-28T21:08:55.527Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 22,
+        "remainingPercent": 78,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-04T06:20:33.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-28T21:28:03.883Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 23,
+        "remainingPercent": 77,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-04T06:20:33.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-28T21:53:03.421Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 24,
+        "remainingPercent": 76,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-04T06:20:32.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-28T22:13:03.893Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 25,
+        "remainingPercent": 75,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-04T06:20:33.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-28T22:28:03.239Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 26,
+        "remainingPercent": 74,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-04T06:20:32.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-28T23:28:03.687Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 26,
+        "remainingPercent": 74,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-04T06:20:33.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-29T00:33:02.393Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 27,
+        "remainingPercent": 73,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-04T06:20:33.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-29T01:33:04.676Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 27,
+        "remainingPercent": 73,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-04T06:20:33.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-29T06:28:09.453Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:28:10.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-29T06:38:03.814Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:04.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-29T07:43:06.536Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:37.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-29T08:23:03.039Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 1,
+        "remainingPercent": 99,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-29T08:33:03.218Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 2,
+        "remainingPercent": 98,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-29T08:43:05.535Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 3,
+        "remainingPercent": 97,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-29T09:08:03.019Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 4,
+        "remainingPercent": 96,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-29T09:18:03.147Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 5,
+        "remainingPercent": 95,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-29T09:28:04.744Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 6,
+        "remainingPercent": 94,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-29T10:28:03.453Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 7,
+        "remainingPercent": 93,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-29T11:13:03.191Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 8,
+        "remainingPercent": 92,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-29T12:18:03.268Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 8,
+        "remainingPercent": 92,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-29T12:43:03.744Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 9,
+        "remainingPercent": 91,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-29T13:48:03.281Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 9,
+        "remainingPercent": 91,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-29T14:53:02.856Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 9,
+        "remainingPercent": 91,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-29T15:53:03.001Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 9,
+        "remainingPercent": 91,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-29T16:58:02.937Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 9,
+        "remainingPercent": 91,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-29T17:58:02.961Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 9,
+        "remainingPercent": 91,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-29T18:58:03.304Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 9,
+        "remainingPercent": 91,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-29T19:33:03.139Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 10,
+        "remainingPercent": 90,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-29T20:33:03.306Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 10,
+        "remainingPercent": 90,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-29T21:38:02.899Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 10,
+        "remainingPercent": 90,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-29T22:38:02.952Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 10,
+        "remainingPercent": 90,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-29T23:38:03.000Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 10,
+        "remainingPercent": 90,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-30T00:38:03.061Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 10,
+        "remainingPercent": 90,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-30T01:38:03.301Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 10,
+        "remainingPercent": 90,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-30T02:38:03.304Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 10,
+        "remainingPercent": 90,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-30T03:43:03.451Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 10,
+        "remainingPercent": 90,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-30T04:43:03.598Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 10,
+        "remainingPercent": 90,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-30T05:48:03.801Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 10,
+        "remainingPercent": 90,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-30T06:53:03.215Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 10,
+        "remainingPercent": 90,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-30T07:58:03.328Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 10,
+        "remainingPercent": 90,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-30T08:08:03.756Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 11,
+        "remainingPercent": 89,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-30T08:58:03.254Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 12,
+        "remainingPercent": 88,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-30T09:18:03.334Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 13,
+        "remainingPercent": 87,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-30T09:38:03.487Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 14,
+        "remainingPercent": 86,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-30T09:43:03.651Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 15,
+        "remainingPercent": 85,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-30T09:53:03.212Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 16,
+        "remainingPercent": 84,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-30T10:53:03.473Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 16,
+        "remainingPercent": 84,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-30T11:33:03.516Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 17,
+        "remainingPercent": 83,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-30T12:33:03.756Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 17,
+        "remainingPercent": 83,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-30T13:33:03.951Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 17,
+        "remainingPercent": 83,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-30T14:38:03.752Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 17,
+        "remainingPercent": 83,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-30T15:43:03.514Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 17,
+        "remainingPercent": 83,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-30T16:48:02.762Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 17,
+        "remainingPercent": 83,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-30T17:18:02.816Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 18,
+        "remainingPercent": 82,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-30T17:23:02.777Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 19,
+        "remainingPercent": 81,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-30T17:28:02.986Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 20,
+        "remainingPercent": 80,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-30T17:38:03.433Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 21,
+        "remainingPercent": 79,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-30T17:43:02.732Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 22,
+        "remainingPercent": 78,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-30T17:48:07.816Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 23,
+        "remainingPercent": 77,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-30T18:03:02.823Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 24,
+        "remainingPercent": 76,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-30T18:13:02.897Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 25,
+        "remainingPercent": 75,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-30T18:18:02.950Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 26,
+        "remainingPercent": 74,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-30T18:28:03.007Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 27,
+        "remainingPercent": 73,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-30T18:33:03.044Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 28,
+        "remainingPercent": 72,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-30T18:38:03.302Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 29,
+        "remainingPercent": 71,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-30T18:53:03.391Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 30,
+        "remainingPercent": 70,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-30T19:23:03.150Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 31,
+        "remainingPercent": 69,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-30T19:43:03.037Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 32,
+        "remainingPercent": 68,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-30T19:58:03.621Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 33,
+        "remainingPercent": 67,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-30T20:13:03.077Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 34,
+        "remainingPercent": 66,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-30T21:03:03.087Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 35,
+        "remainingPercent": 65,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-30T21:33:03.184Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 36,
+        "remainingPercent": 64,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-30T21:53:03.078Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 37,
+        "remainingPercent": 63,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-30T22:53:03.444Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 37,
+        "remainingPercent": 63,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-30T23:58:03.193Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 37,
+        "remainingPercent": 63,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-31T00:58:03.471Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 37,
+        "remainingPercent": 63,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-31T01:58:03.477Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 37,
+        "remainingPercent": 63,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-31T02:58:03.891Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 37,
+        "remainingPercent": 63,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-31T04:03:02.676Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 37,
+        "remainingPercent": 63,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-31T05:03:02.764Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 37,
+        "remainingPercent": 63,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-31T06:03:02.964Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 37,
+        "remainingPercent": 63,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-31T07:03:03.053Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 37,
+        "remainingPercent": 63,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-31T07:38:03.193Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 38,
+        "remainingPercent": 62,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-31T08:38:03.256Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 38,
+        "remainingPercent": 62,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-31T09:38:03.371Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 38,
+        "remainingPercent": 62,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-31T10:03:03.299Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 39,
+        "remainingPercent": 61,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-31T10:23:03.743Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 40,
+        "remainingPercent": 60,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-31T11:28:03.431Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 40,
+        "remainingPercent": 60,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-31T12:28:03.458Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 40,
+        "remainingPercent": 60,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-31T13:28:03.567Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 40,
+        "remainingPercent": 60,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-31T14:18:03.788Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 41,
+        "remainingPercent": 59,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-31T14:33:03.453Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 42,
+        "remainingPercent": 58,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-31T15:38:03.181Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 42,
+        "remainingPercent": 58,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-31T16:43:09.014Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 42,
+        "remainingPercent": 58,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-31T17:48:03.187Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 42,
+        "remainingPercent": 58,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-31T18:48:03.428Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 42,
+        "remainingPercent": 58,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-31T19:43:02.873Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 43,
+        "remainingPercent": 57,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-31T20:43:02.887Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 43,
+        "remainingPercent": 57,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-31T21:43:03.048Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 43,
+        "remainingPercent": 57,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-31T22:43:03.194Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 43,
+        "remainingPercent": 57,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-07-31T23:48:03.287Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 43,
+        "remainingPercent": 57,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-01T00:53:02.481Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 43,
+        "remainingPercent": 57,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-01T01:53:03.386Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 43,
+        "remainingPercent": 57,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-01T02:58:02.866Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 43,
+        "remainingPercent": 57,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-05T06:38:35.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-01T03:38:02.497Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:38:02.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-01T04:38:02.720Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-01T05:38:02.815Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-01T06:38:03.472Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-01T07:23:02.964Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 1,
+        "remainingPercent": 99,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-01T07:43:03.268Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 2,
+        "remainingPercent": 98,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-01T07:53:03.029Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 3,
+        "remainingPercent": 97,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-01T08:53:03.118Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 3,
+        "remainingPercent": 97,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-01T09:58:03.308Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 4,
+        "remainingPercent": 96,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-01T10:33:03.430Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 5,
+        "remainingPercent": 95,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-01T10:58:02.250Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 6,
+        "remainingPercent": 94,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-01T11:23:02.240Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 7,
+        "remainingPercent": 93,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-01T12:23:02.369Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 7,
+        "remainingPercent": 93,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-01T12:53:02.430Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 8,
+        "remainingPercent": 92,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-01T13:13:02.954Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 9,
+        "remainingPercent": 91,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-01T13:43:02.774Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 10,
+        "remainingPercent": 90,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-01T14:43:03.117Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 10,
+        "remainingPercent": 90,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-01T15:48:03.085Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 10,
+        "remainingPercent": 90,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-01T16:53:02.815Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 10,
+        "remainingPercent": 90,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-01T17:08:02.762Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 11,
+        "remainingPercent": 89,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-01T17:33:03.092Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 12,
+        "remainingPercent": 88,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-01T17:58:02.915Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 13,
+        "remainingPercent": 87,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-01T18:33:03.206Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 14,
+        "remainingPercent": 86,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-01T19:38:03.240Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 15,
+        "remainingPercent": 85,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-01T20:18:03.579Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 16,
+        "remainingPercent": 84,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-01T20:53:03.621Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 17,
+        "remainingPercent": 83,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-01T21:33:02.212Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 18,
+        "remainingPercent": 82,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-01T22:28:02.432Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 19,
+        "remainingPercent": 81,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-01T22:58:02.356Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 20,
+        "remainingPercent": 80,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-01T23:58:02.480Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 20,
+        "remainingPercent": 80,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-02T01:03:02.485Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 20,
+        "remainingPercent": 80,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-02T02:03:02.761Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 20,
+        "remainingPercent": 80,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-02T03:03:02.964Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 20,
+        "remainingPercent": 80,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-02T04:03:02.965Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 20,
+        "remainingPercent": 80,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-02T05:08:02.919Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 20,
+        "remainingPercent": 80,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-02T05:38:03.034Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 21,
+        "remainingPercent": 79,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-02T06:08:03.218Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 22,
+        "remainingPercent": 78,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-02T06:18:03.355Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 23,
+        "remainingPercent": 77,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-02T06:28:03.215Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 24,
+        "remainingPercent": 76,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-02T06:38:03.143Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 25,
+        "remainingPercent": 75,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-02T07:03:05.473Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 26,
+        "remainingPercent": 74,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:38.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-02T07:28:03.106Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 27,
+        "remainingPercent": 73,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-02T07:43:03.841Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 28,
+        "remainingPercent": 72,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-02T08:08:03.307Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 29,
+        "remainingPercent": 71,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-02T08:23:03.560Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 30,
+        "remainingPercent": 70,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-02T08:38:02.364Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 31,
+        "remainingPercent": 69,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-02T09:38:02.864Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 31,
+        "remainingPercent": 69,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-02T09:48:02.571Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 32,
+        "remainingPercent": 68,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-02T10:03:02.575Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 33,
+        "remainingPercent": 67,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-02T10:13:02.849Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 34,
+        "remainingPercent": 66,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-02T10:33:02.563Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 35,
+        "remainingPercent": 65,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-02T11:33:02.862Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 35,
+        "remainingPercent": 65,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-02T11:43:02.617Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 36,
+        "remainingPercent": 64,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-02T11:58:02.783Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 37,
+        "remainingPercent": 63,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-02T12:58:02.874Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 37,
+        "remainingPercent": 63,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-02T13:38:02.776Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 38,
+        "remainingPercent": 62,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-02T14:38:02.797Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 38,
+        "remainingPercent": 62,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-02T14:58:03.035Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 39,
+        "remainingPercent": 61,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-02T15:08:02.925Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 40,
+        "remainingPercent": 60,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-02T15:13:02.913Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 41,
+        "remainingPercent": 59,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-02T15:18:03.026Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 42,
+        "remainingPercent": 58,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-02T15:28:06.450Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 43,
+        "remainingPercent": 57,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-02T15:38:03.169Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 44,
+        "remainingPercent": 56,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-02T15:43:02.940Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 45,
+        "remainingPercent": 55,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-02T15:48:02.915Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 46,
+        "remainingPercent": 54,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-02T15:58:02.999Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 47,
+        "remainingPercent": 53,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-02T16:08:03.023Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 48,
+        "remainingPercent": 52,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-02T16:18:02.987Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 49,
+        "remainingPercent": 51,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-02T16:48:03.093Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 50,
+        "remainingPercent": 50,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-02T17:08:03.147Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 51,
+        "remainingPercent": 49,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-02T18:08:03.202Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 51,
+        "remainingPercent": 49,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-02T19:08:03.500Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 51,
+        "remainingPercent": 49,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-02T20:03:02.347Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 52,
+        "remainingPercent": 48,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-02T21:03:02.486Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 52,
+        "remainingPercent": 48,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-02T22:03:02.544Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 52,
+        "remainingPercent": 48,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-02T23:03:02.709Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 52,
+        "remainingPercent": 48,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-03T00:08:02.791Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 52,
+        "remainingPercent": 48,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-03T01:08:02.826Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 52,
+        "remainingPercent": 48,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-03T02:08:02.962Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 52,
+        "remainingPercent": 48,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-03T03:08:03.038Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 52,
+        "remainingPercent": 48,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-03T04:08:03.149Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 52,
+        "remainingPercent": 48,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-03T05:08:03.315Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 52,
+        "remainingPercent": 48,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-03T06:13:02.510Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 52,
+        "remainingPercent": 48,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-03T07:13:02.604Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 52,
+        "remainingPercent": 48,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-03T07:18:03.197Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 53,
+        "remainingPercent": 47,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-03T07:33:02.758Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 54,
+        "remainingPercent": 46,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-03T07:48:02.863Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 55,
+        "remainingPercent": 45,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-03T08:08:02.739Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 56,
+        "remainingPercent": 44,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-03T09:08:02.886Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 56,
+        "remainingPercent": 44,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-03T10:13:02.882Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 56,
+        "remainingPercent": 44,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-03T11:18:02.927Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 56,
+        "remainingPercent": 44,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-03T12:18:02.990Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 56,
+        "remainingPercent": 44,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-03T12:33:03.219Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 57,
+        "remainingPercent": 43,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-03T12:53:05.346Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 58,
+        "remainingPercent": 42,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-03T13:48:03.159Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 59,
+        "remainingPercent": 41,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-03T14:03:03.114Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 60,
+        "remainingPercent": 40,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-03T14:18:03.384Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 61,
+        "remainingPercent": 39,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-03T15:23:03.319Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 61,
+        "remainingPercent": 39,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-03T15:38:03.517Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 62,
+        "remainingPercent": 38,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-03T16:43:02.626Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 62,
+        "remainingPercent": 38,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-03T17:48:02.422Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 63,
+        "remainingPercent": 37,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-03T18:48:03.032Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 63,
+        "remainingPercent": 37,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-03T19:53:02.609Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 63,
+        "remainingPercent": 37,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-03T20:53:02.964Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 63,
+        "remainingPercent": 37,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-03T21:58:03.269Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 63,
+        "remainingPercent": 37,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-03T22:18:03.064Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 64,
+        "remainingPercent": 36,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-03T22:33:03.220Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 65,
+        "remainingPercent": 35,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-03T23:38:02.923Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 65,
+        "remainingPercent": 35,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-04T00:38:02.973Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 65,
+        "remainingPercent": 35,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-04T01:38:03.175Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 65,
+        "remainingPercent": 35,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-04T02:43:03.028Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 65,
+        "remainingPercent": 35,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-04T03:43:03.112Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 65,
+        "remainingPercent": 35,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-04T04:43:05.211Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 65,
+        "remainingPercent": 35,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-04T05:48:02.607Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 65,
+        "remainingPercent": 35,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-04T06:53:02.746Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 65,
+        "remainingPercent": 35,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-04T07:28:02.558Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 66,
+        "remainingPercent": 34,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-04T08:28:02.892Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 66,
+        "remainingPercent": 34,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-04T08:33:02.929Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 67,
+        "remainingPercent": 33,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-04T09:33:02.952Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 67,
+        "remainingPercent": 33,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-04T10:33:03.189Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 67,
+        "remainingPercent": 33,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-04T10:48:03.520Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 68,
+        "remainingPercent": 32,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-04T11:03:05.246Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 69,
+        "remainingPercent": 31,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-04T11:18:02.895Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 70,
+        "remainingPercent": 30,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-04T12:08:03.270Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 71,
+        "remainingPercent": 29,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-04T13:13:03.339Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 71,
+        "remainingPercent": 29,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-04T14:03:03.646Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 72,
+        "remainingPercent": 28,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-04T15:08:03.651Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 72,
+        "remainingPercent": 28,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-04T15:28:02.694Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 73,
+        "remainingPercent": 27,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-04T16:33:02.540Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 73,
+        "remainingPercent": 27,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-04T17:33:02.651Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 73,
+        "remainingPercent": 27,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-04T18:33:02.658Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 73,
+        "remainingPercent": 27,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-04T19:33:03.170Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 73,
+        "remainingPercent": 27,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-04T19:38:02.927Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 74,
+        "remainingPercent": 26,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-04T20:38:03.128Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 74,
+        "remainingPercent": 26,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-04T21:38:03.219Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 74,
+        "remainingPercent": 26,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-04T22:38:06.145Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 74,
+        "remainingPercent": 26,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-04T23:43:03.029Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 74,
+        "remainingPercent": 26,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-05T00:43:03.360Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 74,
+        "remainingPercent": 26,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-05T01:48:03.224Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 74,
+        "remainingPercent": 26,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-05T02:53:02.311Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 74,
+        "remainingPercent": 26,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-05T03:53:02.389Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 74,
+        "remainingPercent": 26,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-05T04:53:02.548Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 74,
+        "remainingPercent": 26,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-05T05:48:02.619Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 75,
+        "remainingPercent": 25,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-05T06:48:02.749Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 75,
+        "remainingPercent": 25,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-05T07:48:02.876Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 75,
+        "remainingPercent": 25,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-05T08:48:03.040Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 75,
+        "remainingPercent": 25,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-05T09:48:03.204Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 75,
+        "remainingPercent": 25,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-05T10:53:03.190Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 75,
+        "remainingPercent": 25,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-05T11:53:03.472Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 75,
+        "remainingPercent": 25,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-05T12:58:02.304Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 75,
+        "remainingPercent": 25,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-05T13:28:02.437Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 76,
+        "remainingPercent": 24,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-05T14:28:02.916Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 76,
+        "remainingPercent": 24,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-05T15:33:02.873Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 76,
+        "remainingPercent": 24,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-05T16:33:03.103Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 76,
+        "remainingPercent": 24,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-05T17:33:04.176Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 76,
+        "remainingPercent": 24,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-05T18:38:03.125Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 76,
+        "remainingPercent": 24,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-05T19:38:03.359Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 76,
+        "remainingPercent": 24,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-05T20:38:03.464Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 76,
+        "remainingPercent": 24,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-05T21:43:03.215Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 76,
+        "remainingPercent": 24,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-05T22:48:03.328Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 76,
+        "remainingPercent": 24,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-05T23:53:02.425Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 76,
+        "remainingPercent": 24,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-06T00:53:02.445Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 76,
+        "remainingPercent": 24,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-06T01:53:03.508Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 76,
+        "remainingPercent": 24,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-06T02:58:02.868Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 76,
+        "remainingPercent": 24,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-06T04:03:03.431Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 76,
+        "remainingPercent": 24,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-06T05:08:03.406Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 76,
+        "remainingPercent": 24,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-06T06:13:03.285Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 76,
+        "remainingPercent": 24,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-06T07:18:03.111Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 76,
+        "remainingPercent": 24,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-06T08:18:03.292Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 76,
+        "remainingPercent": 24,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-06T09:23:03.753Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 76,
+        "remainingPercent": 24,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-06T10:28:03.822Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 76,
+        "remainingPercent": 24,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-06T10:53:03.317Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 77,
+        "remainingPercent": 23,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-06T11:08:03.332Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 78,
+        "remainingPercent": 22,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-06T11:28:03.390Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 79,
+        "remainingPercent": 21,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-06T12:28:02.458Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 78,
+        "remainingPercent": 22,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-06T13:28:02.694Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 79,
+        "remainingPercent": 21,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-06T14:28:02.704Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 79,
+        "remainingPercent": 21,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-06T15:03:02.700Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 80,
+        "remainingPercent": 20,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-06T16:03:02.989Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 80,
+        "remainingPercent": 20,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-06T17:08:03.137Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 80,
+        "remainingPercent": 20,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-06T18:13:03.057Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 80,
+        "remainingPercent": 20,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-06T19:13:03.176Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 80,
+        "remainingPercent": 20,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-06T20:13:03.307Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 80,
+        "remainingPercent": 20,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-06T21:18:02.449Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 80,
+        "remainingPercent": 20,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-06T22:23:02.341Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 80,
+        "remainingPercent": 20,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-06T23:23:02.405Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 80,
+        "remainingPercent": 20,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-07T00:23:02.624Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 80,
+        "remainingPercent": 20,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-07T01:28:02.592Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 80,
+        "remainingPercent": 20,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-07T02:33:02.614Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 80,
+        "remainingPercent": 20,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-07T03:33:02.715Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 80,
+        "remainingPercent": 20,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-07T04:33:02.732Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 80,
+        "remainingPercent": 20,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-07T05:33:02.847Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 80,
+        "remainingPercent": 20,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-07T06:33:03.049Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 80,
+        "remainingPercent": 20,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-07T07:33:03.283Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 80,
+        "remainingPercent": 20,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-07T08:33:03.329Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 80,
+        "remainingPercent": 20,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-07T09:13:02.452Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 81,
+        "remainingPercent": 19,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-07T09:38:02.391Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 82,
+        "remainingPercent": 18,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-07T10:08:03.398Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 81,
+        "remainingPercent": 19,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-07T11:13:02.946Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 81,
+        "remainingPercent": 19,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-07T11:18:02.561Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 82,
+        "remainingPercent": 18,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-07T12:08:02.854Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 83,
+        "remainingPercent": 17,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-07T12:18:02.855Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 84,
+        "remainingPercent": 16,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-07T12:33:02.740Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 85,
+        "remainingPercent": 15,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-07T12:48:03.015Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 86,
+        "remainingPercent": 14,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-07T13:08:02.990Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 87,
+        "remainingPercent": 13,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-07T13:23:03.093Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 88,
+        "remainingPercent": 12,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-07T14:28:02.847Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 88,
+        "remainingPercent": 12,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-07T15:28:03.204Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 88,
+        "remainingPercent": 12,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-07T16:28:03.210Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 88,
+        "remainingPercent": 12,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-07T17:13:03.921Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 90,
+        "remainingPercent": 10,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-07T17:18:03.358Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 91,
+        "remainingPercent": 9,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-07T17:33:03.067Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 92,
+        "remainingPercent": 8,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-07T17:38:03.086Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 93,
+        "remainingPercent": 7,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-07T17:48:04.993Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 94,
+        "remainingPercent": 6,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-07T18:07:58.315Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 95,
+        "remainingPercent": 5,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-07T18:23:04.168Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 96,
+        "remainingPercent": 4,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-07T18:33:04.086Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 97,
+        "remainingPercent": 3,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-07T18:48:04.482Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 98,
+        "remainingPercent": 2,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-07T19:08:04.006Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 99,
+        "remainingPercent": 1,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-07T19:28:04.586Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 100,
+        "remainingPercent": 0,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-07T20:33:03.436Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 100,
+        "remainingPercent": 0,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-08T03:42:36.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-08T06:38:06.440Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T06:34:12.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-08T06:43:05.862Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 1,
+        "remainingPercent": 99,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T06:34:12.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-08T07:08:03.849Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 2,
+        "remainingPercent": 98,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T06:34:11.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-08T07:28:03.972Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 3,
+        "remainingPercent": 97,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T06:34:12.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-08T08:28:06.059Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 3,
+        "remainingPercent": 97,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T06:34:11.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-08T08:33:04.167Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 4,
+        "remainingPercent": 96,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T06:34:12.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-08T08:48:04.255Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 5,
+        "remainingPercent": 95,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T06:34:12.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-08T08:58:03.874Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 6,
+        "remainingPercent": 94,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T06:34:11.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-08T09:08:04.608Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 7,
+        "remainingPercent": 93,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T06:34:12.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-08T09:18:04.005Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 8,
+        "remainingPercent": 92,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T06:34:12.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-08T09:53:04.535Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 9,
+        "remainingPercent": 91,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T06:34:12.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-08T10:18:03.304Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 10,
+        "remainingPercent": 90,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T06:34:12.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-08T11:08:03.258Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 11,
+        "remainingPercent": 89,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T06:34:12.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-08T12:13:02.343Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 11,
+        "remainingPercent": 89,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T06:34:12.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-08T13:13:02.438Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 11,
+        "remainingPercent": 89,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T06:34:11.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-08T13:28:03.457Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 12,
+        "remainingPercent": 88,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T06:34:11.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-08T14:33:02.893Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 12,
+        "remainingPercent": 88,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T06:34:12.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-08T14:53:02.557Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 13,
+        "remainingPercent": 87,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T06:34:12.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-08T15:53:02.673Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 13,
+        "remainingPercent": 87,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T06:34:12.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-08T16:53:02.810Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 13,
+        "remainingPercent": 87,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T06:34:12.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-08T17:53:02.936Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 13,
+        "remainingPercent": 87,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T06:34:12.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-08T18:03:02.923Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 14,
+        "remainingPercent": 86,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T06:34:12.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-08T18:28:02.809Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 15,
+        "remainingPercent": 85,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T06:34:12.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-08T18:43:02.717Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 16,
+        "remainingPercent": 84,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T06:34:11.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-08T18:53:03.540Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 17,
+        "remainingPercent": 83,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T06:34:12.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-08T19:08:03.530Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 18,
+        "remainingPercent": 82,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T06:34:12.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-08T19:23:02.847Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 19,
+        "remainingPercent": 81,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T06:34:12.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-08T19:43:02.953Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 20,
+        "remainingPercent": 80,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T06:34:12.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-08T20:23:03.288Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 21,
+        "remainingPercent": 79,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T06:34:12.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-08T20:33:03.117Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-08T20:41:57.956Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 1,
+        "remainingPercent": 99,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-08T21:03:03.313Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 2,
+        "remainingPercent": 98,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-08T22:08:03.099Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 2,
+        "remainingPercent": 98,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-08T23:08:03.115Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 2,
+        "remainingPercent": 98,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T00:08:03.228Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 2,
+        "remainingPercent": 98,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T01:08:03.286Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 2,
+        "remainingPercent": 98,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T02:08:04.695Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 2,
+        "remainingPercent": 98,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T03:13:02.250Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 2,
+        "remainingPercent": 98,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T04:13:02.411Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 2,
+        "remainingPercent": 98,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T05:13:02.477Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 2,
+        "remainingPercent": 98,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T06:13:02.624Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 2,
+        "remainingPercent": 98,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T07:03:02.692Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 3,
+        "remainingPercent": 97,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T07:08:02.774Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 5,
+        "remainingPercent": 95,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T07:13:02.854Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 6,
+        "remainingPercent": 94,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T07:18:02.874Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 8,
+        "remainingPercent": 92,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T07:23:02.702Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 9,
+        "remainingPercent": 91,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T07:28:02.850Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 10,
+        "remainingPercent": 90,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T07:33:03.063Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 12,
+        "remainingPercent": 88,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T07:38:02.975Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 13,
+        "remainingPercent": 87,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T07:48:02.898Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 14,
+        "remainingPercent": 86,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T07:58:02.840Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 15,
+        "remainingPercent": 85,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T08:13:02.822Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 16,
+        "remainingPercent": 84,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T08:23:03.547Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 17,
+        "remainingPercent": 83,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T08:33:03.202Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 18,
+        "remainingPercent": 82,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T08:43:02.981Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 19,
+        "remainingPercent": 81,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T08:53:03.129Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 20,
+        "remainingPercent": 80,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T09:08:03.255Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 21,
+        "remainingPercent": 79,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T09:28:03.044Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 22,
+        "remainingPercent": 78,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T09:38:02.904Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 23,
+        "remainingPercent": 77,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T09:58:02.918Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 24,
+        "remainingPercent": 76,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T10:23:03.426Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 25,
+        "remainingPercent": 75,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T10:43:07.739Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 26,
+        "remainingPercent": 74,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T10:58:03.614Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 27,
+        "remainingPercent": 73,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T11:08:03.245Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 28,
+        "remainingPercent": 72,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T11:23:03.244Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 29,
+        "remainingPercent": 71,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T11:33:03.258Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 30,
+        "remainingPercent": 70,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T11:38:03.276Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 31,
+        "remainingPercent": 69,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T11:48:03.088Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 32,
+        "remainingPercent": 68,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T11:58:03.267Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 33,
+        "remainingPercent": 67,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T12:03:03.201Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 34,
+        "remainingPercent": 66,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T12:23:03.355Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 35,
+        "remainingPercent": 65,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T13:23:03.771Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 35,
+        "remainingPercent": 65,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T13:38:03.830Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 36,
+        "remainingPercent": 64,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T14:28:03.362Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 37,
+        "remainingPercent": 63,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T14:38:02.821Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 38,
+        "remainingPercent": 62,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T14:53:02.955Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 39,
+        "remainingPercent": 61,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T14:58:03.037Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 40,
+        "remainingPercent": 60,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T15:08:02.801Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 41,
+        "remainingPercent": 59,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T15:18:02.955Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 42,
+        "remainingPercent": 58,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T15:23:03.234Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 43,
+        "remainingPercent": 57,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T15:28:03.128Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 44,
+        "remainingPercent": 56,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T15:38:02.891Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 45,
+        "remainingPercent": 55,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T15:48:03.009Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 46,
+        "remainingPercent": 54,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T15:58:03.544Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 47,
+        "remainingPercent": 53,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T16:08:03.029Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 48,
+        "remainingPercent": 52,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T16:48:03.329Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 49,
+        "remainingPercent": 51,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T17:08:06.234Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 50,
+        "remainingPercent": 50,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T17:28:03.233Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 51,
+        "remainingPercent": 49,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T18:03:03.401Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 52,
+        "remainingPercent": 48,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T18:13:02.986Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 53,
+        "remainingPercent": 47,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T18:18:03.611Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 54,
+        "remainingPercent": 46,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T18:28:04.908Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 55,
+        "remainingPercent": 45,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T18:33:03.216Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 56,
+        "remainingPercent": 44,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T18:38:03.094Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 57,
+        "remainingPercent": 43,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T18:48:03.028Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 58,
+        "remainingPercent": 42,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T18:58:03.117Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 59,
+        "remainingPercent": 41,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T19:03:03.099Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 60,
+        "remainingPercent": 40,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T19:18:03.453Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 61,
+        "remainingPercent": 39,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T19:28:03.299Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 62,
+        "remainingPercent": 38,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T19:38:03.013Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 63,
+        "remainingPercent": 37,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T19:43:03.025Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 64,
+        "remainingPercent": 36,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T19:48:03.055Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 65,
+        "remainingPercent": 35,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T19:58:03.446Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 66,
+        "remainingPercent": 34,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T20:08:03.112Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 67,
+        "remainingPercent": 33,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T20:33:03.070Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 68,
+        "remainingPercent": 32,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T20:53:03.418Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 69,
+        "remainingPercent": 31,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T21:03:03.707Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 70,
+        "remainingPercent": 30,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T21:28:03.693Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 71,
+        "remainingPercent": 29,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T21:48:04.038Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 72,
+        "remainingPercent": 28,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T22:53:03.205Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 72,
+        "remainingPercent": 28,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-09T23:53:03.210Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 72,
+        "remainingPercent": 28,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-10T00:53:03.415Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 72,
+        "remainingPercent": 28,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-10T01:53:03.607Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 72,
+        "remainingPercent": 28,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-10T02:58:03.557Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 72,
+        "remainingPercent": 28,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-10T04:03:04.440Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 72,
+        "remainingPercent": 28,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-10T05:03:07.034Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 72,
+        "remainingPercent": 28,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-10T05:48:08.970Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 73,
+        "remainingPercent": 27,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-10T06:08:03.860Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 74,
+        "remainingPercent": 26,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-10T07:08:04.696Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 75,
+        "remainingPercent": 25,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-10T07:23:04.132Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 76,
+        "remainingPercent": 24,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-10T07:38:04.685Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 77,
+        "remainingPercent": 23,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:48.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-10T07:53:03.487Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 78,
+        "remainingPercent": 22,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-10T08:08:03.365Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 79,
+        "remainingPercent": 21,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-10T08:23:03.692Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 80,
+        "remainingPercent": 20,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-10T08:38:03.642Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 81,
+        "remainingPercent": 19,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-10T09:43:02.936Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 81,
+        "remainingPercent": 19,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-10T10:18:07.800Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 82,
+        "remainingPercent": 18,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-10T10:38:03.493Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 83,
+        "remainingPercent": 17,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-10T10:58:16.021Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 84,
+        "remainingPercent": 16,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-10T11:23:03.432Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 85,
+        "remainingPercent": 15,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-10T11:43:03.714Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 86,
+        "remainingPercent": 14,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-10T12:23:05.203Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 87,
+        "remainingPercent": 13,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-10T12:38:03.638Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 88,
+        "remainingPercent": 12,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-10T12:53:03.860Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 89,
+        "remainingPercent": 11,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-10T13:03:03.849Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 90,
+        "remainingPercent": 10,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-10T13:23:03.544Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 91,
+        "remainingPercent": 9,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-10T13:43:03.502Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 92,
+        "remainingPercent": 8,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-10T13:58:03.579Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 93,
+        "remainingPercent": 7,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-10T14:58:03.764Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 93,
+        "remainingPercent": 7,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-10T16:03:03.691Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 93,
+        "remainingPercent": 7,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-10T17:03:04.316Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 93,
+        "remainingPercent": 7,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-10T18:08:04.045Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 93,
+        "remainingPercent": 7,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-10T18:43:04.224Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 94,
+        "remainingPercent": 6,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-10T19:48:03.786Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 94,
+        "remainingPercent": 6,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-10T20:48:04.159Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 94,
+        "remainingPercent": 6,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-10T21:53:03.446Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 94,
+        "remainingPercent": 6,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-10T22:58:03.426Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 94,
+        "remainingPercent": 6,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-15T20:29:47.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-11T00:03:04.422Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T00:03:04.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-11T00:13:03.483Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T00:13:03.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-11T00:23:03.454Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T00:23:03.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-11T00:33:03.639Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T00:33:03.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-11T00:43:03.510Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T00:43:03.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-11T00:53:03.573Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T00:53:03.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-11T01:03:03.602Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T01:03:03.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-11T01:13:03.445Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T01:13:03.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-11T01:23:03.502Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T01:23:03.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-11T01:33:03.453Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T01:33:03.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-11T01:43:03.434Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T01:43:03.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-11T01:53:03.515Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T01:53:03.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-11T02:03:03.477Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T02:03:03.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-11T02:13:03.491Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T02:13:03.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-11T02:23:03.418Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T02:23:03.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-11T02:33:03.530Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T02:33:03.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-11T02:38:07.070Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T02:38:07.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-11T02:48:03.416Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T02:48:03.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-11T02:58:03.534Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T02:58:03.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-11T03:08:03.677Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T03:08:03.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-11T03:18:03.379Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T03:18:03.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-11T03:28:03.682Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T03:28:03.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-11T03:38:03.621Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T03:38:03.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-11T03:48:03.967Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T03:48:03.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-11T03:58:03.552Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T03:58:03.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-11T04:08:03.753Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T04:08:03.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-11T04:18:04.089Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T04:18:03.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-11T04:28:03.631Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T04:28:03.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-11T04:33:04.397Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T04:33:04.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-11T04:43:03.719Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T04:43:03.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-11T04:53:03.654Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T04:53:03.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-11T05:03:03.739Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T05:03:03.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-11T05:13:03.894Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T05:13:03.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-11T05:23:03.949Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T05:23:03.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-11T05:33:04.180Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T05:33:03.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-11T05:43:04.044Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T05:43:03.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-11T06:48:03.839Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T05:45:32.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-11T07:48:03.943Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T05:45:32.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-11T08:53:03.407Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T05:45:32.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-11T09:03:03.554Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 1,
+        "remainingPercent": 99,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T05:45:32.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-11T10:08:03.373Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 1,
+        "remainingPercent": 99,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T05:45:32.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-11T10:28:03.176Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 2,
+        "remainingPercent": 98,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T05:45:32.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-11T10:48:02.881Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 3,
+        "remainingPercent": 97,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T05:45:32.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-11T11:33:03.256Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 4,
+        "remainingPercent": 96,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T05:45:32.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-11T12:38:03.085Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 4,
+        "remainingPercent": 96,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T05:45:32.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-11T12:48:03.100Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 5,
+        "remainingPercent": 95,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T05:45:32.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-11T13:48:03.199Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 5,
+        "remainingPercent": 95,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T05:45:32.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-11T14:48:03.371Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 5,
+        "remainingPercent": 95,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T05:45:32.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-11T15:38:03.971Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 6,
+        "remainingPercent": 94,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T05:45:32.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-11T15:58:03.357Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 7,
+        "remainingPercent": 93,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T05:45:32.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-11T16:38:03.450Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 8,
+        "remainingPercent": 92,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T05:45:32.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-11T16:53:03.568Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 9,
+        "remainingPercent": 91,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T05:45:32.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-11T17:23:03.656Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 10,
+        "remainingPercent": 90,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T05:45:32.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-11T18:23:03.453Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 11,
+        "remainingPercent": 89,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T05:45:32.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-11T18:43:04.220Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 12,
+        "remainingPercent": 88,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T05:45:32.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-11T19:03:03.751Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 13,
+        "remainingPercent": 87,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T05:45:33.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-11T19:33:04.245Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 14,
+        "remainingPercent": 86,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T05:45:32.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-11T20:43:03.972Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 14,
+        "remainingPercent": 86,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T05:45:32.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-11T21:48:04.635Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 14,
+        "remainingPercent": 86,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T05:45:32.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-11T22:53:02.912Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 14,
+        "remainingPercent": 86,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T05:45:32.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-11T23:53:03.078Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 14,
+        "remainingPercent": 86,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T05:45:32.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-12T00:58:03.147Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 14,
+        "remainingPercent": 86,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T05:45:32.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-12T02:03:03.338Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 14,
+        "remainingPercent": 86,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T05:45:32.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-12T03:08:03.352Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 14,
+        "remainingPercent": 86,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T05:45:32.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-12T04:08:03.364Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 14,
+        "remainingPercent": 86,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T05:45:32.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-12T05:08:03.466Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 14,
+        "remainingPercent": 86,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T05:45:32.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-12T05:33:03.330Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 15,
+        "remainingPercent": 85,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T05:45:32.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-12T06:33:03.505Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 15,
+        "remainingPercent": 85,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T05:45:32.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-12T07:33:03.565Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 15,
+        "remainingPercent": 85,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T05:45:32.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-12T08:33:04.372Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 15,
+        "remainingPercent": 85,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T05:45:32.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-12T09:38:04.221Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 15,
+        "remainingPercent": 85,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T05:45:32.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-12T10:38:04.258Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 15,
+        "remainingPercent": 85,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T05:45:32.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-12T10:48:04.475Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 16,
+        "remainingPercent": 84,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T05:45:32.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-12T11:53:05.266Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 16,
+        "remainingPercent": 84,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T05:45:32.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-12T12:28:05.550Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 17,
+        "remainingPercent": 83,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T05:45:32.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-12T12:53:05.805Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 18,
+        "remainingPercent": 82,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T05:45:32.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-12T13:23:03.807Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 19,
+        "remainingPercent": 81,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T05:45:32.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-12T14:03:03.927Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 20,
+        "remainingPercent": 80,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T05:45:32.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-12T14:48:03.938Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 21,
+        "remainingPercent": 79,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T05:45:32.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-12T15:23:03.926Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 22,
+        "remainingPercent": 78,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T05:45:32.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-12T15:48:04.221Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 23,
+        "remainingPercent": 77,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T05:45:32.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-12T16:13:04.233Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 24,
+        "remainingPercent": 76,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T05:45:33.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-12T16:58:04.547Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 25,
+        "remainingPercent": 75,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T05:45:33.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-12T17:08:04.394Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 26,
+        "remainingPercent": 74,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T05:45:32.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-12T17:28:04.012Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 27,
+        "remainingPercent": 73,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T05:45:32.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-12T18:13:03.890Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 28,
+        "remainingPercent": 72,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T05:45:32.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-12T18:58:04.054Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 29,
+        "remainingPercent": 71,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T05:45:32.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-12T19:28:04.008Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 30,
+        "remainingPercent": 70,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T05:45:32.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-12T19:53:04.719Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 31,
+        "remainingPercent": 69,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T05:45:32.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-12T20:13:05.559Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 32,
+        "remainingPercent": 68,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T05:45:32.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-12T21:18:05.867Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 32,
+        "remainingPercent": 68,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T05:45:32.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-12T22:23:04.450Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 32,
+        "remainingPercent": 68,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T05:45:32.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-12T23:28:03.462Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 32,
+        "remainingPercent": 68,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T05:45:32.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-13T00:28:03.645Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 32,
+        "remainingPercent": 68,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T05:45:32.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-13T01:28:03.937Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 32,
+        "remainingPercent": 68,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T05:45:32.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-13T02:28:04.633Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 32,
+        "remainingPercent": 68,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-18T05:45:33.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-13T03:33:03.956Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-20T03:33:03.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-13T03:38:08.461Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-20T03:38:07.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-13T03:48:04.126Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 0,
+        "remainingPercent": 100,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-20T03:48:03.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-13T04:18:04.462Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 1,
+        "remainingPercent": 99,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-20T03:48:07.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-13T05:08:04.135Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 2,
+        "remainingPercent": 98,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-20T03:48:07.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-13T05:58:04.069Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 3,
+        "remainingPercent": 97,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-20T03:48:07.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-13T06:13:04.092Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 4,
+        "remainingPercent": 96,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-20T03:48:07.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-13T06:23:04.654Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 5,
+        "remainingPercent": 95,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-20T03:48:07.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-13T06:38:04.307Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 6,
+        "remainingPercent": 94,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-20T03:48:07.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-13T07:03:04.467Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 7,
+        "remainingPercent": 93,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-20T03:48:07.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-13T07:13:04.584Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 8,
+        "remainingPercent": 92,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-20T03:48:07.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-13T07:28:04.647Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 9,
+        "remainingPercent": 91,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-20T03:48:07.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-13T07:48:03.685Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 10,
+        "remainingPercent": 90,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-20T03:48:07.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-13T08:08:03.824Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 11,
+        "remainingPercent": 89,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-20T03:48:07.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-13T08:23:03.656Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 12,
+        "remainingPercent": 88,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-20T03:48:07.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-13T08:38:03.663Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 13,
+        "remainingPercent": 87,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-20T03:48:07.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-13T08:48:03.880Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 14,
+        "remainingPercent": 86,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-20T03:48:07.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-13T09:08:05.186Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 15,
+        "remainingPercent": 85,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-20T03:48:07.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-13T09:23:03.835Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 16,
+        "remainingPercent": 84,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-20T03:48:07.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-13T09:48:04.476Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 17,
+        "remainingPercent": 83,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-20T03:48:07.000Z"
+      },
+      "secondary": null
+    },
     {
       "observedAt": "2026-08-13T10:13:03.830Z",
       "sourceMachineId": "hkm-ccx55",
       "primary": {
         "usedPercent": 18,
         "remainingPercent": 82,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-20T03:48:07.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-13T10:18:03.859Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 19,
+        "remainingPercent": 81,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-20T03:48:07.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-13T10:28:04.000Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 20,
+        "remainingPercent": 80,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-20T03:48:07.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-13T10:33:05.041Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 21,
+        "remainingPercent": 79,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-20T03:48:07.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-13T10:38:04.477Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 22,
+        "remainingPercent": 78,
+        "windowMinutes": 10080,
+        "resetsAt": "2026-08-20T03:48:07.000Z"
+      },
+      "secondary": null
+    },
+    {
+      "observedAt": "2026-08-13T10:58:03.798Z",
+      "sourceMachineId": "hkm-ccx55",
+      "primary": {
+        "usedPercent": 23,
+        "remainingPercent": 77,
         "windowMinutes": 10080,
         "resetsAt": "2026-08-20T03:48:07.000Z"
       },

--- a/codex-analysis.html
+++ b/codex-analysis.html
@@ -1,0 +1,481 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#0f172a" />
+    <title>Codex Analysis · TimeKeeper</title>
+    <style>
+      :root {
+        color-scheme: light;
+        font-family:
+          Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+          "Segoe UI", sans-serif;
+        --ink: #0f172a;
+        --muted: #64748b;
+        --line: #dbe4ef;
+        --surface: #ffffff;
+        --canvas: #f3f6fa;
+        --primary: #2563eb;
+        --primary-soft: #dbeafe;
+        --positive: #047857;
+        --positive-soft: #d1fae5;
+        --warning: #b45309;
+        --warning-soft: #fef3c7;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--canvas);
+        color: var(--ink);
+      }
+      button,
+      a {
+        font: inherit;
+      }
+      .shell {
+        width: min(1500px, calc(100% - 32px));
+        margin: 0 auto;
+        padding: 28px 0 56px;
+      }
+      .page-header {
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        gap: 24px;
+        margin-bottom: 20px;
+      }
+      .eyebrow {
+        margin: 0 0 6px;
+        color: var(--primary);
+        font-size: 0.78rem;
+        font-weight: 750;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+      h1 {
+        margin: 0;
+        font-size: clamp(1.8rem, 4vw, 3rem);
+        letter-spacing: -0.04em;
+      }
+      .subtitle {
+        max-width: 760px;
+        margin: 10px 0 0;
+        color: var(--muted);
+        line-height: 1.5;
+      }
+      .header-actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+        justify-content: flex-end;
+      }
+      .button,
+      .range-button {
+        border: 1px solid var(--line);
+        border-radius: 10px;
+        background: var(--surface);
+        color: var(--ink);
+        padding: 9px 13px;
+        cursor: pointer;
+        text-decoration: none;
+        font-weight: 650;
+      }
+      .button:hover,
+      .range-button:hover {
+        border-color: #94a3b8;
+      }
+      .button.primary {
+        background: var(--ink);
+        color: white;
+        border-color: var(--ink);
+      }
+      .toolbar {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: 16px;
+        margin: 18px 0;
+      }
+      .range-controls {
+        display: flex;
+        gap: 6px;
+      }
+      .range-button {
+        padding: 7px 11px;
+      }
+      .range-button.active {
+        background: var(--primary);
+        border-color: var(--primary);
+        color: white;
+      }
+      .toolbar-meta {
+        text-align: right;
+        color: var(--muted);
+        font-size: 0.86rem;
+      }
+      .toolbar-meta strong {
+        display: block;
+        color: var(--ink);
+      }
+      .measurement-banner {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        border: 1px solid var(--line);
+        border-radius: 14px;
+        padding: 14px 16px;
+        margin-bottom: 16px;
+        background: var(--surface);
+      }
+      .measurement-banner.ready {
+        background: var(--positive-soft);
+        border-color: #86efac;
+      }
+      .measurement-banner.partial {
+        background: var(--warning-soft);
+        border-color: #fcd34d;
+      }
+      .measurement-banner.collecting {
+        background: var(--primary-soft);
+        border-color: #93c5fd;
+      }
+      .measurement-banner span {
+        color: #334155;
+        line-height: 1.45;
+      }
+      .metric-grid {
+        display: grid;
+        grid-template-columns: repeat(6, minmax(0, 1fr));
+        gap: 12px;
+        margin-bottom: 18px;
+      }
+      .metric-card,
+      .section-card {
+        background: var(--surface);
+        border: 1px solid var(--line);
+        border-radius: 16px;
+        box-shadow: 0 8px 30px rgba(15, 23, 42, 0.04);
+      }
+      .metric-card {
+        padding: 15px;
+        min-height: 132px;
+        display: flex;
+        flex-direction: column;
+      }
+      .metric-label {
+        color: var(--muted);
+        font-size: 0.78rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+      }
+      .metric-value {
+        margin-top: auto;
+        font-size: 1.45rem;
+        letter-spacing: -0.03em;
+      }
+      .metric-detail {
+        color: var(--muted);
+        line-height: 1.35;
+        margin-top: 5px;
+      }
+      .section-card {
+        padding: 20px;
+        margin-top: 14px;
+      }
+      .section-header {
+        display: flex;
+        justify-content: space-between;
+        gap: 16px;
+        align-items: baseline;
+        margin-bottom: 14px;
+      }
+      .section-header h2 {
+        margin: 0;
+        font-size: 1.12rem;
+      }
+      .section-header p {
+        margin: 0;
+        color: var(--muted);
+        font-size: 0.84rem;
+      }
+      .insight-grid {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: 10px;
+      }
+      .insight {
+        border-left: 4px solid #94a3b8;
+        border-radius: 10px;
+        background: #f8fafc;
+        padding: 13px;
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+      }
+      .insight.positive {
+        border-color: var(--positive);
+        background: var(--positive-soft);
+      }
+      .insight.warning {
+        border-color: var(--warning);
+        background: var(--warning-soft);
+      }
+      .insight span {
+        color: #475569;
+        line-height: 1.42;
+        font-size: 0.9rem;
+      }
+      .table-scroll {
+        overflow-x: auto;
+      }
+      .analysis-table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 0.88rem;
+      }
+      .analysis-table th,
+      .analysis-table td {
+        padding: 11px 10px;
+        border-bottom: 1px solid #e8eef5;
+        text-align: left;
+        white-space: nowrap;
+      }
+      .analysis-table th {
+        color: #475569;
+        font-size: 0.73rem;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        background: #f8fafc;
+      }
+      .analysis-table tr:last-child td {
+        border-bottom: 0;
+      }
+      .analysis-table td:first-child {
+        font-weight: 700;
+      }
+      .analysis-table .numeric {
+        font-variant-numeric: tabular-nums;
+      }
+      .confidence {
+        display: inline-flex;
+        border-radius: 999px;
+        padding: 3px 8px;
+        font-size: 0.72rem;
+        font-weight: 750;
+      }
+      .confidence.high {
+        color: #065f46;
+        background: #d1fae5;
+      }
+      .confidence.medium {
+        color: #92400e;
+        background: #fef3c7;
+      }
+      .confidence.low {
+        color: #475569;
+        background: #e2e8f0;
+      }
+      .two-column {
+        display: grid;
+        grid-template-columns: 1.15fr 0.85fr;
+        gap: 14px;
+      }
+      .quality-list {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: 8px;
+      }
+      .quality-row {
+        background: #f8fafc;
+        border-radius: 10px;
+        padding: 10px;
+        display: flex;
+        justify-content: space-between;
+        gap: 12px;
+      }
+      .quality-row span {
+        color: var(--muted);
+      }
+      .empty-state,
+      #loadingState,
+      .fatal-state {
+        color: var(--muted);
+        padding: 28px 4px;
+        line-height: 1.5;
+      }
+      .fatal-state {
+        color: #991b1b;
+        background: #fee2e2;
+        border: 1px solid #fecaca;
+        border-radius: 12px;
+        padding: 16px;
+      }
+      .definition-note {
+        margin: 18px 0 0;
+        color: var(--muted);
+        font-size: 0.8rem;
+        line-height: 1.5;
+      }
+      @media (max-width: 1150px) {
+        .metric-grid {
+          grid-template-columns: repeat(3, minmax(0, 1fr));
+        }
+        .insight-grid {
+          grid-template-columns: 1fr;
+        }
+        .quality-list {
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+        }
+      }
+      @media (max-width: 760px) {
+        .shell {
+          width: min(100% - 20px, 1500px);
+          padding-top: 18px;
+        }
+        .page-header,
+        .toolbar {
+          align-items: stretch;
+          flex-direction: column;
+        }
+        .header-actions {
+          justify-content: flex-start;
+        }
+        .toolbar-meta {
+          text-align: left;
+        }
+        .metric-grid,
+        .two-column,
+        .quality-list {
+          grid-template-columns: 1fr;
+        }
+        .metric-card {
+          min-height: 110px;
+        }
+        .section-card {
+          padding: 14px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main class="shell">
+      <header class="page-header">
+        <div>
+          <p class="eyebrow">TimeKeeper · Codex intelligence</p>
+          <h1>Codex Analysis</h1>
+          <p class="subtitle">
+            Model and effort efficiency, quota burn, effective-time yield,
+            delegation leverage, project economics, and measurement quality.
+            Quota metrics use percentage points of the measured Codex limit
+            window—not estimated tokens.
+          </p>
+        </div>
+        <div class="header-actions">
+          <a class="button" href="index.html">Back to TimeKeeper</a>
+          <button id="refreshAnalysis" class="button" type="button">
+            Refresh
+          </button>
+          <button id="exportCsv" class="button primary" type="button">
+            Export model CSV
+          </button>
+        </div>
+      </header>
+
+      <div id="loadingState">
+        Loading local TimeKeeper activity and measured Codex usage history…
+      </div>
+
+      <div id="analysisContent" hidden>
+        <div class="toolbar">
+          <div
+            id="rangeControls"
+            class="range-controls"
+            aria-label="Analysis range"
+          ></div>
+          <div class="toolbar-meta">
+            <strong id="rangeLabel">Last 7 days</strong>
+            <span id="updatedAt"></span>
+          </div>
+        </div>
+
+        <div id="measurementBanner" class="measurement-banner"></div>
+        <section id="metricCards" class="metric-grid"></section>
+
+        <section class="section-card">
+          <div class="section-header">
+            <h2>Useful findings</h2>
+            <p>
+              Only measured claims are promoted; low-confidence model rows stay
+              directional.
+            </p>
+          </div>
+          <div id="insights" class="insight-grid"></div>
+        </section>
+
+        <section class="section-card">
+          <div class="section-header">
+            <h2>Model efficiency</h2>
+            <p>
+              Quota burn is lower-is-better; effective hours per usage point is
+              higher-is-better.
+            </p>
+          </div>
+          <div id="modelTable"></div>
+        </section>
+
+        <section class="section-card">
+          <div class="section-header">
+            <h2>Model × effort</h2>
+            <p>
+              Separates the same model at different reasoning-effort settings.
+            </p>
+          </div>
+          <div id="modelEffortTable"></div>
+        </section>
+
+        <section class="section-card">
+          <div class="section-header">
+            <h2>Project efficiency</h2>
+            <p>Shows where quota is converted into the most credited work.</p>
+          </div>
+          <div id="projectTable"></div>
+        </section>
+
+        <div class="two-column">
+          <section class="section-card">
+            <div class="section-header">
+              <h2>Recent daily trend</h2>
+              <p>Latest 14 measured days in the selected range.</p>
+            </div>
+            <div id="dailyTable"></div>
+          </section>
+
+          <section class="section-card">
+            <div class="section-header">
+              <h2>Measurement quality</h2>
+              <p>Use this before trusting small differences.</p>
+            </div>
+            <div id="dataQuality" class="quality-list"></div>
+          </section>
+        </div>
+
+        <p class="definition-note">
+          Attribution method: each positive quota change is assigned to
+          overlapping imported Codex activity in proportion to model active
+          time. Reset transitions, negative deltas, anomalous jumps, and large
+          history gaps are excluded. Model segments do not carry exact
+          timestamps, so mixed-model sessions are proportionally allocated and
+          marked with confidence levels.
+        </p>
+      </div>
+    </main>
+    <script
+      type="module"
+      src="src/features/codex/analysis-page.mjs?v=1"
+    ></script>
+  </body>
+</html>

--- a/codex-analysis.html
+++ b/codex-analysis.html
@@ -40,6 +40,17 @@
       a {
         font: inherit;
       }
+      .sr-only {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+        white-space: nowrap;
+        border: 0;
+      }
       .shell {
         width: min(1500px, calc(100% - 32px));
         margin: 0 auto;
@@ -62,8 +73,7 @@
       }
       h1 {
         margin: 0;
-        font-size: clamp(1.8rem, 4vw, 3rem);
-        letter-spacing: -0.04em;
+        font-size: 2.4rem;
       }
       .subtitle {
         max-width: 760px;
@@ -104,6 +114,12 @@
         gap: 16px;
         margin: 18px 0;
       }
+      .toolbar-group {
+        display: flex;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: 10px;
+      }
       .range-controls {
         display: flex;
         gap: 6px;
@@ -115,6 +131,61 @@
         background: var(--primary);
         border-color: var(--primary);
         color: white;
+      }
+      .select-control,
+      .number-control {
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        background: var(--surface);
+        color: var(--ink);
+        min-height: 38px;
+        padding: 7px 10px;
+      }
+      .number-control {
+        width: 96px;
+      }
+      .filter-panel {
+        display: grid;
+        grid-template-columns: repeat(5, minmax(0, 1fr));
+        gap: 10px;
+        align-items: end;
+        margin-bottom: 16px;
+        padding: 14px;
+        border: 1px solid var(--line);
+        border-radius: 10px;
+        background: #f8fafc;
+      }
+      .filter-field {
+        display: flex;
+        flex-direction: column;
+        gap: 5px;
+        min-width: 0;
+      }
+      .filter-field label,
+      .checkbox-field {
+        color: var(--muted);
+        font-size: 0.76rem;
+        font-weight: 750;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+      }
+      .checkbox-field {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        min-height: 38px;
+        cursor: pointer;
+      }
+      .checkbox-field input {
+        width: 16px;
+        height: 16px;
+        accent-color: var(--primary);
+      }
+      .filter-summary {
+        grid-column: 1 / -1;
+        margin: 0;
+        color: var(--muted);
+        font-size: 0.82rem;
       }
       .toolbar-meta {
         text-align: right;
@@ -159,6 +230,7 @@
       }
       .metric-card,
       .section-card {
+        min-width: 0;
         background: var(--surface);
         border: 1px solid var(--line);
         border-radius: 16px;
@@ -190,6 +262,32 @@
       .section-card {
         padding: 20px;
         margin-top: 14px;
+      }
+      .chart-grid {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 14px;
+        margin-top: 14px;
+      }
+      .chart-card {
+        min-width: 0;
+      }
+      .chart-card.wide {
+        grid-column: 1 / -1;
+      }
+      .chart-canvas {
+        display: block;
+        width: 100%;
+        height: 230px;
+        border: 1px solid #e8eef5;
+        border-radius: 8px;
+        background: #f8fafc;
+      }
+      .chart-caption {
+        margin: 8px 0 0;
+        color: var(--muted);
+        font-size: 0.78rem;
+        line-height: 1.4;
       }
       .section-header {
         display: flex;
@@ -235,6 +333,8 @@
         font-size: 0.9rem;
       }
       .table-scroll {
+        min-width: 0;
+        max-width: 100%;
         overflow-x: auto;
       }
       .analysis-table {
@@ -255,6 +355,22 @@
         text-transform: uppercase;
         letter-spacing: 0.04em;
         background: #f8fafc;
+      }
+      .table-sort-button {
+        border: 0;
+        padding: 0;
+        background: transparent;
+        color: inherit;
+        font: inherit;
+        font-weight: inherit;
+        letter-spacing: inherit;
+        text-transform: inherit;
+        cursor: pointer;
+      }
+      .table-sort-button:hover,
+      .table-sort-button:focus-visible {
+        color: var(--primary);
+        text-decoration: underline;
       }
       .analysis-table tr:last-child td {
         border-bottom: 0;
@@ -285,6 +401,7 @@
         background: #e2e8f0;
       }
       .two-column {
+        min-width: 0;
         display: grid;
         grid-template-columns: 1.15fr 0.85fr;
         gap: 14px;
@@ -329,6 +446,9 @@
         .metric-grid {
           grid-template-columns: repeat(3, minmax(0, 1fr));
         }
+        .filter-panel {
+          grid-template-columns: repeat(3, minmax(0, 1fr));
+        }
         .insight-grid {
           grid-template-columns: 1fr;
         }
@@ -353,15 +473,33 @@
           text-align: left;
         }
         .metric-grid,
+        .chart-grid,
         .two-column,
         .quality-list {
           grid-template-columns: 1fr;
+        }
+        .chart-card.wide {
+          grid-column: auto;
+        }
+        .filter-panel {
+          grid-template-columns: 1fr 1fr;
+        }
+        .filter-summary {
+          grid-column: 1 / -1;
         }
         .metric-card {
           min-height: 110px;
         }
         .section-card {
           padding: 14px;
+        }
+        h1 {
+          font-size: 1.9rem;
+        }
+      }
+      @media (max-width: 440px) {
+        .filter-panel {
+          grid-template-columns: 1fr;
         }
       }
     </style>
@@ -396,16 +534,68 @@
 
       <div id="analysisContent" hidden>
         <div class="toolbar">
-          <div
-            id="rangeControls"
-            class="range-controls"
-            aria-label="Analysis range"
-          ></div>
+          <div class="toolbar-group">
+            <div
+              id="rangeControls"
+              class="range-controls"
+              aria-label="Analysis range"
+            ></div>
+            <label>
+              <span class="sr-only">Quota window</span>
+              <select
+                id="windowSelect"
+                class="select-control"
+                aria-label="Quota window"
+              ></select>
+            </label>
+          </div>
           <div class="toolbar-meta">
             <strong id="rangeLabel">Last 7 days</strong>
             <span id="updatedAt"></span>
           </div>
         </div>
+
+        <section class="filter-panel" aria-label="Analysis filters">
+          <div class="filter-field">
+            <label for="filterModel">Model</label>
+            <select id="filterModel" class="select-control"></select>
+          </div>
+          <div class="filter-field">
+            <label for="filterEffort">Effort</label>
+            <select id="filterEffort" class="select-control"></select>
+          </div>
+          <div class="filter-field">
+            <label for="filterProject">Project</label>
+            <select id="filterProject" class="select-control"></select>
+          </div>
+          <div class="filter-field">
+            <label for="minMeasuredHours">Minimum measured hours</label>
+            <input
+              id="minMeasuredHours"
+              class="number-control"
+              type="number"
+              min="0"
+              step="0.25"
+              inputmode="decimal"
+            />
+          </div>
+          <div class="filter-field">
+            <label for="minUsagePoints">Minimum quota points</label>
+            <input
+              id="minUsagePoints"
+              class="number-control"
+              type="number"
+              min="0"
+              step="0.5"
+              inputmode="decimal"
+            />
+          </div>
+          <label class="checkbox-field" for="hideUnknown">
+            <input id="hideUnknown" type="checkbox" />
+            Hide unknown rows
+          </label>
+          <p id="filterSummary" class="filter-summary"></p>
+        </section>
 
         <div id="measurementBanner" class="measurement-banner"></div>
         <section id="metricCards" class="metric-grid"></section>
@@ -419,6 +609,90 @@
             </p>
           </div>
           <div id="insights" class="insight-grid"></div>
+        </section>
+
+        <section class="chart-grid" aria-label="Codex charts">
+          <article class="section-card chart-card wide">
+            <div class="section-header">
+              <h2>Quota burn over time</h2>
+              <p>
+                Observed percentage points consumed between quota snapshots.
+              </p>
+            </div>
+            <canvas
+              id="quotaBurnChart"
+              class="chart-canvas"
+              role="img"
+              aria-label="Quota burn over time"
+            ></canvas>
+            <p class="chart-caption">
+              Quota points are observed limit-window percentage points, not
+              tokens or cost.
+            </p>
+          </article>
+          <article class="section-card chart-card">
+            <div class="section-header">
+              <h2>Model burn and yield</h2>
+              <p>Compare measured quota burn with credited-time yield.</p>
+            </div>
+            <canvas
+              id="modelYieldChart"
+              class="chart-canvas"
+              role="img"
+              aria-label="Model quota burn and effective-time yield"
+            ></canvas>
+            <p class="chart-caption">
+              Each point is a filtered model. Differences with low confidence
+              remain directional.
+            </p>
+          </article>
+          <article class="section-card chart-card">
+            <div class="section-header">
+              <h2>Effective time by model and effort</h2>
+              <p>Total credited hours in the selected range.</p>
+            </div>
+            <canvas
+              id="modelEffortChart"
+              class="chart-canvas"
+              role="img"
+              aria-label="Effective time by model and effort"
+            ></canvas>
+            <p class="chart-caption">
+              This includes full-range effective time; measured values are shown
+              in the tables.
+            </p>
+          </article>
+          <article class="section-card chart-card">
+            <div class="section-header">
+              <h2>Project quota efficiency</h2>
+              <p>Measured effective hours produced per quota point.</p>
+            </div>
+            <canvas
+              id="projectEfficiencyChart"
+              class="chart-canvas"
+              role="img"
+              aria-label="Project quota efficiency"
+            ></canvas>
+            <p class="chart-caption">
+              Projects without overlapping quota history are omitted from this
+              chart.
+            </p>
+          </article>
+          <article class="section-card chart-card">
+            <div class="section-header">
+              <h2>Quota trajectory</h2>
+              <p>Current used percentage across the selected window.</p>
+            </div>
+            <canvas
+              id="quotaTrajectoryChart"
+              class="chart-canvas"
+              role="img"
+              aria-label="Quota trajectory toward reset"
+            ></canvas>
+            <p class="chart-caption">
+              The trajectory is reset-safe; a reset starts a new line.
+            </p>
+          </article>
         </section>
 
         <section class="section-card">

--- a/codex-analysis.html
+++ b/codex-analysis.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -9,8 +9,13 @@
       :root {
         color-scheme: light;
         font-family:
-          Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
-          "Segoe UI", sans-serif;
+          Inter,
+          ui-sans-serif,
+          system-ui,
+          -apple-system,
+          BlinkMacSystemFont,
+          'Segoe UI',
+          sans-serif;
         --ink: #0f172a;
         --muted: #64748b;
         --line: #dbe4ef;

--- a/docs/codex-analysis.md
+++ b/docs/codex-analysis.md
@@ -1,0 +1,35 @@
+# Codex analysis measurement model
+
+The Codex analysis page separates three quantities that were previously mixed together:
+
+1. **Active time**: wall-clock seconds attributed to Codex model activity.
+2. **Effective time**: TimeKeeper's credited time after model, effort, repository and delegation policy weights.
+3. **Quota usage**: percentage-point changes in the observed Codex limit window.
+
+The first implementation deliberately labels quota use as percentage points rather than tokens. Codex currently exposes a limit-window percentage in the local session/status data, while exact billable token consumption is not consistently available in the TimeKeeper import records.
+
+## Metrics
+
+- **Usage / active hour**: quota percentage points divided by model active hours. Lower is better.
+- **Effective hours / usage point**: credited hours divided by quota percentage points. Higher is better.
+- **Focus conversion**: effective seconds divided by active seconds.
+- **Usage share**: the model's attributed percentage of measured quota change.
+- **Subagent share**: the portion of model active time classified as delegated/subagent work.
+
+## Attribution
+
+The sampler records the current primary and secondary limit windows every ten minutes, while compressing unchanged samples to an hourly heartbeat. The analytics engine then:
+
+1. sorts snapshots chronologically;
+2. rejects reset transitions, negative deltas, anomalous jumps and gaps longer than three hours;
+3. finds imported Codex sessions overlapping each positive quota delta;
+4. allocates the delta in proportion to overlapping model active time;
+5. aggregates the result by model, model × effort, effort, project and role.
+
+A mixed-model session contains aggregate model durations but no exact per-model timestamps. Its quota is therefore allocated proportionally within the session. The page exposes low, medium and high confidence labels so small or weakly measured differences are not presented as established rankings.
+
+## Current integration state
+
+The initial page is available at `codex-analysis.html`. It reads imported Codex entries from the same browser's `timekeeperDataPro` localStorage and quota history from `assets/timekeeper-codex-usage-history.json`.
+
+The next integration step is to add a clear **Deep analysis** action to the existing Codex page and decide whether the analysis should remain a dedicated route or become embedded tabs inside the current page.

--- a/docs/codex-analysis.md
+++ b/docs/codex-analysis.md
@@ -1,35 +1,94 @@
 # Codex analysis measurement model
 
-The Codex analysis page separates three quantities that were previously mixed together:
+The deep Codex analysis page is available from the Codex section in
+TimeKeeper and directly at `codex-analysis.html`. It reads the same browser
+local `timekeeperDataPro` data as the main app and does not create a second
+entry store.
+
+## Measurement definitions
+
+The page keeps three quantities separate:
 
 1. **Active time**: wall-clock seconds attributed to Codex model activity.
-2. **Effective time**: TimeKeeper's credited time after model, effort, repository and delegation policy weights.
-3. **Quota usage**: percentage-point changes in the observed Codex limit window.
+2. **Effective time**: TimeKeeper credited time after model, effort,
+   repository, and delegation policy weights.
+3. **Quota usage**: positive percentage-point changes in an observed Codex
+   limit window.
 
-The first implementation deliberately labels quota use as percentage points rather than tokens. Codex currently exposes a limit-window percentage in the local session/status data, while exact billable token consumption is not consistently available in the TimeKeeper import records.
+Quota usage is not tokens, cost, or billing. The imported records do not
+consistently expose exact billable token consumption, so the page never
+estimates it from elapsed time or model names.
 
-## Metrics
+The selected range's full active and effective totals are independent from
+quota-history coverage. Efficiency denominators use only activity overlapping
+actual quota snapshots. A session can therefore contribute to full-range time
+without contributing to measured efficiency.
 
-- **Usage / active hour**: quota percentage points divided by model active hours. Lower is better.
-- **Effective hours / usage point**: credited hours divided by quota percentage points. Higher is better.
+## Metrics and controls
+
+- **Usage / active hour**: quota percentage points divided by measured active
+  hours. Lower is better.
+- **Effective hours / usage point**: measured credited hours divided by quota
+  percentage points. Higher is better.
 - **Focus conversion**: effective seconds divided by active seconds.
-- **Usage share**: the model's attributed percentage of measured quota change.
-- **Subagent share**: the portion of model active time classified as delegated/subagent work.
+- **Usage share**: a model's attributed share of measured quota change.
+- **Subagent share**: the portion of model active time classified as delegated
+  work.
+
+The page supports 24-hour, 7-day, 30-day, and 90-day ranges. Where the data
+exists, the quota-window selector supports both primary and secondary windows.
+Model, effort, and project filters, minimum measured-time and quota-point
+thresholds, unknown-row visibility, sortable tables, charts, and CSV export
+all operate on the displayed breakdowns without changing the overall totals.
 
 ## Attribution
 
-The sampler records the current primary and secondary limit windows every ten minutes, while compressing unchanged samples to an hourly heartbeat. The analytics engine then:
+The scheduled sampler records primary and secondary limit windows every ten
+minutes. Unchanged states are compressed to hourly heartbeats, while state
+changes are retained immediately. The history is bounded to 90 days.
+
+The analytics engine:
 
 1. sorts snapshots chronologically;
-2. rejects reset transitions, negative deltas, anomalous jumps and gaps longer than three hours;
-3. finds imported Codex sessions overlapping each positive quota delta;
-4. allocates the delta in proportion to overlapping model active time;
-5. aggregates the result by model, model × effort, effort, project and role.
+2. treats small reset-time timestamp jitter as the same quota window;
+3. rejects reset transitions, negative deltas, anomalous jumps, and gaps
+   longer than three hours;
+4. finds imported Codex sessions overlapping each positive quota delta;
+5. allocates the delta in proportion to overlapping model active time;
+6. aggregates the result by model, model and effort, effort, project, and
+   parent/subagent role.
 
-A mixed-model session contains aggregate model durations but no exact per-model timestamps. Its quota is therefore allocated proportionally within the session. The page exposes low, medium and high confidence labels so small or weakly measured differences are not presented as established rankings.
+Allocation is conserved: the model breakdown sums to the attributed quota
+points. Quota with no overlapping activity remains explicitly unattributed.
+Mixed-model sessions contain aggregate model durations without exact per-model
+timestamps, so their allocation is proportional and receives a lower
+confidence qualification.
 
-## Current integration state
+## Historical backfill
 
-The initial page is available at `codex-analysis.html`. It reads imported Codex entries from the same browser's `timekeeperDataPro` localStorage and quota history from `assets/timekeeper-codex-usage-history.json`.
+The one-time backfill command can inspect bounded Git history of
+`assets/timekeeper-codex-inbox/*.json`:
 
-The next integration step is to add a clear **Deep analysis** action to the existing Codex page and decide whether the analysis should remain a dedicated route or become embedded tabs inside the current page.
+```text
+node scripts/codex-usage-history.mjs --backfill-days=30
+```
+
+It reads actual historical `usageLimits` snapshots, compresses them through the
+same merge path, preserves reset boundaries, and records a `backfill` metadata
+object in the published history. Normal scheduled runs do not scan Git
+history; they only sample the current inbox files.
+
+The current one-time recovery found 4,697 usable candidates and compressed them
+to 675 samples covering 23 July 2026 through 13 August 2026. Earlier inbox
+commits did not contain usable `usageLimits` data, so the backfill must not
+claim more than that recovered interval. A future run should preserve the
+recorded recovery metadata rather than silently invent older values.
+
+## Confidence and limitations
+
+Confidence considers measured active time, quota points, and the number of
+attributed intervals. Sparse history displays collecting or partial language.
+Low-confidence differences must not be treated as established model rankings.
+The page also reports skipped gaps, anomalous deltas, reset transitions,
+unknown-model share, mixed-model share, and quota attribution coverage so that
+small comparisons can be judged in context.

--- a/index.html
+++ b/index.html
@@ -499,7 +499,10 @@
       <section id="codex" class="section" style="display:none;">
         <div class="codex-page-header">
           <h2>Codex</h2>
-          <button id="codexPageRefreshBtn" type="button" class="btn secondary">Refresh</button>
+          <div class="codex-page-actions">
+            <a href="codex-analysis.html" class="btn secondary">Deep analysis</a>
+            <button id="codexPageRefreshBtn" type="button" class="btn secondary">Refresh</button>
+          </div>
         </div>
         <div id="codexPageContent" class="codex-page-content" aria-live="polite"></div>
       </section>

--- a/scripts/codex-usage-history.mjs
+++ b/scripts/codex-usage-history.mjs
@@ -1,6 +1,8 @@
+import { execFile } from 'node:child_process';
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
+import { promisify } from 'node:util';
 import { fileURLToPath } from 'node:url';
 
 export const DEFAULT_INBOX_DIR = 'assets/timekeeper-codex-inbox';
@@ -8,6 +10,9 @@ export const DEFAULT_OUTPUT_FILE = 'assets/timekeeper-codex-usage-history.json';
 export const DEFAULT_RETENTION_DAYS = 90;
 export const DEFAULT_HEARTBEAT_MINUTES = 60;
 export const DEFAULT_MAX_SAMPLES = 5000;
+export const DEFAULT_BACKFILL_MAX_COMMITS = 5000;
+
+const execFileAsync = promisify(execFile);
 
 function parseTimestamp(value) {
   const timestamp = Date.parse(String(value || ''));
@@ -15,6 +20,7 @@ function parseTimestamp(value) {
 }
 
 function finiteNumber(value) {
+  if (value === null || value === undefined || value === '') return null;
   const number = Number(value);
   return Number.isFinite(number) ? number : null;
 }
@@ -72,6 +78,36 @@ function stateKey(sample) {
   });
 }
 
+function sameWindowState(left, right) {
+  if (!left && !right) return true;
+  if (!left || !right) return false;
+  if (left.usedPercent !== right.usedPercent) return false;
+  if (
+    left.windowMinutes > 0 &&
+    right.windowMinutes > 0 &&
+    left.windowMinutes !== right.windowMinutes
+  ) {
+    return false;
+  }
+  if (!left.resetsAt || !right.resetsAt) {
+    return left.resetsAt === right.resetsAt;
+  }
+  const leftResetMs = parseTimestamp(left.resetsAt);
+  const rightResetMs = parseTimestamp(right.resetsAt);
+  return (
+    leftResetMs !== null &&
+    rightResetMs !== null &&
+    Math.abs(leftResetMs - rightResetMs) <= 5 * 60 * 1000
+  );
+}
+
+function sameSampleState(left, right) {
+  return (
+    sameWindowState(left?.primary, right?.primary) &&
+    sameWindowState(left?.secondary, right?.secondary)
+  );
+}
+
 function sampleKey(sample) {
   return `${sample.observedAt}|${stateKey(sample)}`;
 }
@@ -108,37 +144,41 @@ export function mergeUsageHistory(
     now = new Date(),
     retentionDays = DEFAULT_RETENTION_DAYS,
     heartbeatMinutes = DEFAULT_HEARTBEAT_MINUTES,
-    maxSamples = DEFAULT_MAX_SAMPLES
+    maxSamples = DEFAULT_MAX_SAMPLES,
+    includeAllCandidates = false
   } = {}
 ) {
   const nowMs = parseTimestamp(now) ?? Date.now();
   const cutoffMs = nowMs - Math.max(1, retentionDays) * 24 * 60 * 60 * 1000;
-  const normalized = (Array.isArray(existingHistory) ? existingHistory : [])
+  const existing = (Array.isArray(existingHistory) ? existingHistory : [])
     .map(normalizeExistingSample)
     .filter((sample) => parseTimestamp(sample.observedAt) >= cutoffMs);
-  const current = chooseCurrentCandidate(candidates);
-  if (current) {
-    const currentMs = parseTimestamp(current.observedAt);
-    const last = normalized
-      .slice()
-      .sort(
-        (left, right) =>
-          parseTimestamp(left.observedAt) - parseTimestamp(right.observedAt)
-      )
-      .slice(-1)[0];
+  const normalizedCandidates = (Array.isArray(candidates) ? candidates : [])
+    .map(normalizeExistingSample)
+    .filter((sample) => parseTimestamp(sample.observedAt) >= cutoffMs);
+  const selectedCandidates = includeAllCandidates
+    ? normalizedCandidates
+    : [chooseCurrentCandidate(normalizedCandidates)].filter(Boolean);
+  const byTimestamp = new Map();
+  [...existing, ...selectedCandidates]
+    .sort(
+      (left, right) =>
+        parseTimestamp(left.observedAt) - parseTimestamp(right.observedAt)
+    )
+    .forEach((sample) => {
+      byTimestamp.set(sample.observedAt, sample);
+    });
+  const normalized = [];
+  byTimestamp.forEach((sample) => {
+    const sampleMs = parseTimestamp(sample.observedAt);
+    const last = normalized[normalized.length - 1];
     const lastMs = last ? parseTimestamp(last.observedAt) : null;
-    const stateChanged = !last || stateKey(last) !== stateKey(current);
+    const stateChanged = !last || !sameSampleState(last, sample);
     const heartbeatDue =
       lastMs === null ||
-      currentMs - lastMs >= Math.max(1, heartbeatMinutes) * 60 * 1000;
-    if (
-      currentMs !== null &&
-      currentMs >= cutoffMs &&
-      (stateChanged || heartbeatDue)
-    ) {
-      normalized.push(current);
-    }
-  }
+      sampleMs - lastMs >= Math.max(1, heartbeatMinutes) * 60 * 1000;
+    if (stateChanged || heartbeatDue) normalized.push(sample);
+  });
   const deduped = new Map();
   normalized.forEach((sample) => {
     deduped.set(sampleKey(sample), sample);
@@ -150,6 +190,75 @@ export function mergeUsageHistory(
     )
     .slice(-Math.max(2, maxSamples));
   return samples;
+}
+
+async function runGit(args, gitDirectory) {
+  const result = await execFileAsync('git', args, {
+    cwd: gitDirectory,
+    maxBuffer: 20 * 1024 * 1024
+  });
+  return result.stdout;
+}
+
+export async function readHistoricalUsageCandidatesFromGit({
+  gitDirectory = process.cwd(),
+  since = null,
+  until = new Date(),
+  maxCommits = DEFAULT_BACKFILL_MAX_COMMITS
+} = {}) {
+  const untilMs = parseTimestamp(until) ?? Date.now();
+  const sinceMs = parseTimestamp(since);
+  if (sinceMs === null || sinceMs >= untilMs) return [];
+  const commits = [
+    ...new Set(
+      (
+        await runGit(
+          [
+            'log',
+            '--format=%H',
+            `--since=${new Date(sinceMs).toISOString()}`,
+            `--until=${new Date(untilMs).toISOString()}`,
+            '--',
+            'assets/timekeeper-codex-inbox'
+          ],
+          gitDirectory
+        )
+      ).split(/\r?\n/)
+    )
+  ]
+    .map((commit) => commit.trim())
+    .filter(Boolean)
+    .slice(0, Math.max(1, maxCommits));
+  if (!commits.length) return [];
+  const files = (
+    await runGit(
+      [
+        'ls-tree',
+        '-r',
+        '--name-only',
+        'HEAD',
+        '--',
+        'assets/timekeeper-codex-inbox'
+      ],
+      gitDirectory
+    )
+  )
+    .split(/\r?\n/)
+    .map((file) => file.trim())
+    .filter((file) => file.toLowerCase().endsWith('.json'));
+  const candidates = [];
+  for (const commit of commits) {
+    for (const file of files) {
+      try {
+        const text = await runGit(['show', `${commit}:${file}`], gitDirectory);
+        const candidate = normalizeUsageCandidate(JSON.parse(text), file);
+        if (candidate) candidates.push(candidate);
+      } catch {
+        // The file may not exist yet in an older commit or may be malformed.
+      }
+    }
+  }
+  return candidates;
 }
 
 export async function readInboxCandidates(inboxDir = DEFAULT_INBOX_DIR) {
@@ -182,9 +291,12 @@ export async function readInboxCandidates(inboxDir = DEFAULT_INBOX_DIR) {
 async function readHistoryFile(outputFile) {
   try {
     const parsed = JSON.parse(await fs.readFile(outputFile, 'utf8'));
-    return Array.isArray(parsed?.samples) ? parsed.samples : [];
+    return {
+      samples: Array.isArray(parsed?.samples) ? parsed.samples : [],
+      backfill: parsed?.backfill || null
+    };
   } catch (error) {
-    if (error?.code === 'ENOENT') return [];
+    if (error?.code === 'ENOENT') return { samples: [], backfill: null };
     throw error;
   }
 }
@@ -195,22 +307,49 @@ export async function updateCodexUsageHistory({
   now = new Date(),
   retentionDays = DEFAULT_RETENTION_DAYS,
   heartbeatMinutes = DEFAULT_HEARTBEAT_MINUTES,
-  maxSamples = DEFAULT_MAX_SAMPLES
+  maxSamples = DEFAULT_MAX_SAMPLES,
+  backfillDays = 0,
+  backfillMaxCommits = DEFAULT_BACKFILL_MAX_COMMITS,
+  gitDirectory = process.cwd()
 } = {}) {
-  const existing = await readHistoryFile(outputFile);
+  const existingPayload = await readHistoryFile(outputFile);
   const candidates = await readInboxCandidates(inboxDir);
-  const samples = mergeUsageHistory(existing, candidates, {
+  const backfillCandidates =
+    Number(backfillDays) > 0
+      ? await readHistoricalUsageCandidatesFromGit({
+          gitDirectory,
+          since: new Date(
+            (parseTimestamp(now) ?? Date.now()) -
+              Number(backfillDays) * 24 * 60 * 60 * 1000
+          ),
+          until: now,
+          maxCommits: backfillMaxCommits
+        })
+      : [];
+  const allCandidates = [...backfillCandidates, ...candidates];
+  const samples = mergeUsageHistory(existingPayload.samples, allCandidates, {
     now,
     retentionDays,
     heartbeatMinutes,
-    maxSamples
+    maxSamples,
+    includeAllCandidates: backfillCandidates.length > 0
   });
+  const backfill = backfillCandidates.length
+    ? {
+        source: 'git history of assets/timekeeper-codex-inbox/*.json',
+        requestedDays: Number(backfillDays),
+        candidateCount: backfillCandidates.length,
+        recoveredFrom: samples[0]?.observedAt || null,
+        recoveredThrough: samples.at(-1)?.observedAt || null
+      }
+    : existingPayload.backfill;
   const payload = {
     version: 1,
     generatedAt: new Date(parseTimestamp(now) ?? Date.now()).toISOString(),
     retentionDays,
     heartbeatMinutes,
     source: 'timekeeper-codex-inbox-sampler',
+    ...(backfill ? { backfill } : {}),
     samples
   };
   const nextText = `${JSON.stringify(payload, null, 2)}\n`;
@@ -258,7 +397,11 @@ if (isCli) {
     retentionDays: Number(args.retentionDays) || DEFAULT_RETENTION_DAYS,
     heartbeatMinutes:
       Number(args.heartbeatMinutes) || DEFAULT_HEARTBEAT_MINUTES,
-    maxSamples: Number(args.maxSamples) || DEFAULT_MAX_SAMPLES
+    maxSamples: Number(args.maxSamples) || DEFAULT_MAX_SAMPLES,
+    backfillDays: Number(args.backfillDays) || 0,
+    backfillMaxCommits:
+      Number(args.backfillMaxCommits) || DEFAULT_BACKFILL_MAX_COMMITS,
+    gitDirectory: args.gitDirectory || process.cwd()
   })
     .then(({ changed, payload }) => {
       process.stdout.write(

--- a/scripts/codex-usage-history.mjs
+++ b/scripts/codex-usage-history.mjs
@@ -1,0 +1,274 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+export const DEFAULT_INBOX_DIR = 'assets/timekeeper-codex-inbox';
+export const DEFAULT_OUTPUT_FILE = 'assets/timekeeper-codex-usage-history.json';
+export const DEFAULT_RETENTION_DAYS = 90;
+export const DEFAULT_HEARTBEAT_MINUTES = 60;
+export const DEFAULT_MAX_SAMPLES = 5000;
+
+function parseTimestamp(value) {
+  const timestamp = Date.parse(String(value || ''));
+  return Number.isFinite(timestamp) ? timestamp : null;
+}
+
+function finiteNumber(value) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : null;
+}
+
+function normalizeWindow(window) {
+  if (!window || typeof window !== 'object') return null;
+  let usedPercent = finiteNumber(window.usedPercent);
+  let remainingPercent = finiteNumber(window.remainingPercent);
+  if (usedPercent === null && remainingPercent !== null) {
+    usedPercent = 100 - remainingPercent;
+  }
+  if (remainingPercent === null && usedPercent !== null) {
+    remainingPercent = 100 - usedPercent;
+  }
+  if (usedPercent === null) return null;
+  return {
+    usedPercent: Math.min(100, Math.max(0, usedPercent)),
+    remainingPercent: Math.min(
+      100,
+      Math.max(0, remainingPercent ?? 100 - usedPercent)
+    ),
+    windowMinutes: Math.max(0, finiteNumber(window.windowMinutes) ?? 0),
+    resetsAt: parseTimestamp(window.resetsAt)
+      ? new Date(parseTimestamp(window.resetsAt)).toISOString()
+      : null
+  };
+}
+
+export function normalizeUsageCandidate(payload, sourceFile = '') {
+  if (!payload || typeof payload !== 'object') return null;
+  const usageLimits = payload.usageLimits;
+  if (!usageLimits || typeof usageLimits !== 'object') return null;
+  const observedMs =
+    parseTimestamp(usageLimits.observedAt) ??
+    parseTimestamp(payload.updatedAt) ??
+    parseTimestamp(payload.generatedAt);
+  if (observedMs === null) return null;
+  const primary = normalizeWindow(usageLimits.primary);
+  const secondary = normalizeWindow(usageLimits.secondary);
+  if (!primary && !secondary) return null;
+  return {
+    observedAt: new Date(observedMs).toISOString(),
+    sourceMachineId: String(
+      payload.machineId || path.basename(sourceFile, '.json')
+    ),
+    primary,
+    secondary
+  };
+}
+
+function stateKey(sample) {
+  return JSON.stringify({
+    primary: sample?.primary || null,
+    secondary: sample?.secondary || null
+  });
+}
+
+function sampleKey(sample) {
+  return `${sample.observedAt}|${stateKey(sample)}`;
+}
+
+function normalizeExistingSample(sample) {
+  if (!sample || typeof sample !== 'object') return null;
+  const observedMs = parseTimestamp(sample.observedAt || sample.capturedAt);
+  if (observedMs === null) return null;
+  const primary = normalizeWindow(sample.primary);
+  const secondary = normalizeWindow(sample.secondary);
+  if (!primary && !secondary) return null;
+  return {
+    observedAt: new Date(observedMs).toISOString(),
+    sourceMachineId: String(sample.sourceMachineId || sample.machineId || ''),
+    primary,
+    secondary
+  };
+}
+
+function chooseCurrentCandidate(candidates) {
+  return candidates
+    .filter(Boolean)
+    .slice()
+    .sort(
+      (left, right) =>
+        parseTimestamp(right.observedAt) - parseTimestamp(left.observedAt)
+    )[0];
+}
+
+export function mergeUsageHistory(
+  existingHistory,
+  candidates,
+  {
+    now = new Date(),
+    retentionDays = DEFAULT_RETENTION_DAYS,
+    heartbeatMinutes = DEFAULT_HEARTBEAT_MINUTES,
+    maxSamples = DEFAULT_MAX_SAMPLES
+  } = {}
+) {
+  const nowMs = parseTimestamp(now) ?? Date.now();
+  const cutoffMs = nowMs - Math.max(1, retentionDays) * 24 * 60 * 60 * 1000;
+  const normalized = (Array.isArray(existingHistory) ? existingHistory : [])
+    .map(normalizeExistingSample)
+    .filter((sample) => parseTimestamp(sample.observedAt) >= cutoffMs);
+  const current = chooseCurrentCandidate(candidates);
+  if (current) {
+    const currentMs = parseTimestamp(current.observedAt);
+    const last = normalized
+      .slice()
+      .sort(
+        (left, right) =>
+          parseTimestamp(left.observedAt) - parseTimestamp(right.observedAt)
+      )
+      .slice(-1)[0];
+    const lastMs = last ? parseTimestamp(last.observedAt) : null;
+    const stateChanged = !last || stateKey(last) !== stateKey(current);
+    const heartbeatDue =
+      lastMs === null ||
+      currentMs - lastMs >= Math.max(1, heartbeatMinutes) * 60 * 1000;
+    if (
+      currentMs !== null &&
+      currentMs >= cutoffMs &&
+      (stateChanged || heartbeatDue)
+    ) {
+      normalized.push(current);
+    }
+  }
+  const deduped = new Map();
+  normalized.forEach((sample) => {
+    deduped.set(sampleKey(sample), sample);
+  });
+  const samples = [...deduped.values()]
+    .sort(
+      (left, right) =>
+        parseTimestamp(left.observedAt) - parseTimestamp(right.observedAt)
+    )
+    .slice(-Math.max(2, maxSamples));
+  return samples;
+}
+
+export async function readInboxCandidates(inboxDir = DEFAULT_INBOX_DIR) {
+  let entries = [];
+  try {
+    entries = await fs.readdir(inboxDir, { withFileTypes: true });
+  } catch (error) {
+    if (error?.code === 'ENOENT') return [];
+    throw error;
+  }
+  const candidates = [];
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.toLowerCase().endsWith('.json')) {
+      continue;
+    }
+    const filePath = path.join(inboxDir, entry.name);
+    try {
+      const payload = JSON.parse(await fs.readFile(filePath, 'utf8'));
+      const candidate = normalizeUsageCandidate(payload, filePath);
+      if (candidate) candidates.push(candidate);
+    } catch (error) {
+      process.stderr.write(
+        `Skipping unreadable Codex inbox file ${filePath}: ${error.message}\n`
+      );
+    }
+  }
+  return candidates;
+}
+
+async function readHistoryFile(outputFile) {
+  try {
+    const parsed = JSON.parse(await fs.readFile(outputFile, 'utf8'));
+    return Array.isArray(parsed?.samples) ? parsed.samples : [];
+  } catch (error) {
+    if (error?.code === 'ENOENT') return [];
+    throw error;
+  }
+}
+
+export async function updateCodexUsageHistory({
+  inboxDir = DEFAULT_INBOX_DIR,
+  outputFile = DEFAULT_OUTPUT_FILE,
+  now = new Date(),
+  retentionDays = DEFAULT_RETENTION_DAYS,
+  heartbeatMinutes = DEFAULT_HEARTBEAT_MINUTES,
+  maxSamples = DEFAULT_MAX_SAMPLES
+} = {}) {
+  const existing = await readHistoryFile(outputFile);
+  const candidates = await readInboxCandidates(inboxDir);
+  const samples = mergeUsageHistory(existing, candidates, {
+    now,
+    retentionDays,
+    heartbeatMinutes,
+    maxSamples
+  });
+  const payload = {
+    version: 1,
+    generatedAt: new Date(parseTimestamp(now) ?? Date.now()).toISOString(),
+    retentionDays,
+    heartbeatMinutes,
+    source: 'timekeeper-codex-inbox-sampler',
+    samples
+  };
+  const nextText = `${JSON.stringify(payload, null, 2)}\n`;
+  let previousText = '';
+  try {
+    previousText = await fs.readFile(outputFile, 'utf8');
+  } catch (error) {
+    if (error?.code !== 'ENOENT') throw error;
+  }
+  const previousComparable = previousText
+    ? JSON.stringify({
+        ...(JSON.parse(previousText) || {}),
+        generatedAt: null
+      })
+    : '';
+  const nextComparable = JSON.stringify({ ...payload, generatedAt: null });
+  if (previousComparable === nextComparable) {
+    return { changed: false, payload };
+  }
+  await fs.mkdir(path.dirname(outputFile), { recursive: true });
+  await fs.writeFile(outputFile, nextText, 'utf8');
+  return { changed: true, payload };
+}
+
+function parseArgs(argv = process.argv.slice(2)) {
+  const options = {};
+  argv.forEach((arg) => {
+    const match = /^--([^=]+)=(.*)$/.exec(arg);
+    if (!match) return;
+    const key = match[1].replace(/-([a-z])/g, (_, char) => char.toUpperCase());
+    options[key] = match[2];
+  });
+  return options;
+}
+
+const isCli =
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (isCli) {
+  const args = parseArgs();
+  updateCodexUsageHistory({
+    inboxDir: args.inbox || DEFAULT_INBOX_DIR,
+    outputFile: args.output || DEFAULT_OUTPUT_FILE,
+    retentionDays: Number(args.retentionDays) || DEFAULT_RETENTION_DAYS,
+    heartbeatMinutes:
+      Number(args.heartbeatMinutes) || DEFAULT_HEARTBEAT_MINUTES,
+    maxSamples: Number(args.maxSamples) || DEFAULT_MAX_SAMPLES
+  })
+    .then(({ changed, payload }) => {
+      process.stdout.write(
+        `${changed ? 'Updated' : 'No change to'} Codex usage history (${payload.samples.length} samples).\n`
+      );
+    })
+    .catch((error) => {
+      process.stderr.write(
+        `Codex usage history update failed: ${error.message || error}\n`
+      );
+      process.exitCode = 1;
+    });
+}

--- a/service-worker.js
+++ b/service-worker.js
@@ -3,12 +3,15 @@
 const sw = /** @type {ServiceWorkerGlobalScope} */ (
   /** @type {unknown} */ (self)
 );
-const CACHE_NAME = 'timekeeper-app-v19';
+const CACHE_NAME = 'timekeeper-app-v20';
 const APP_SHELL = [
   './',
   './index.html',
+  './codex-analysis.html',
   './style.css',
   './src/main.mjs?v=16',
+  './src/features/codex/analysis-page.mjs?v=1',
+  './src/features/codex/analytics.mjs',
   './src/shared/runtime-helpers.mjs',
   './src/shared/id.mjs',
   './src/shared/ui.mjs',
@@ -29,6 +32,7 @@ const APP_SHELL = [
   './src/styles/layout.css',
   './assets/strava.json',
   './assets/strava_overrides.json',
+  './assets/timekeeper-codex-usage-history.json',
   './assets/timekeeper-icon.svg',
   './manifest.webmanifest'
 ];
@@ -68,8 +72,8 @@ sw.addEventListener('activate', (event) => {
         if (!refreshExistingClients) return;
         clients.forEach((client) => {
           const url = new URL(client.url);
-          if (url.searchParams.get('timekeeper-update') === '17') return;
-          url.searchParams.set('timekeeper-update', '17');
+          if (url.searchParams.get('timekeeper-update') === '18') return;
+          url.searchParams.set('timekeeper-update', '18');
           client.navigate(url.href).catch(() => undefined);
         });
       })
@@ -96,7 +100,7 @@ sw.addEventListener('fetch', (event) => {
         return response;
       })
       .catch(() =>
-        caches.match(event.request).then((cached) => {
+        caches.match(event.request, { ignoreSearch: true }).then((cached) => {
           if (cached) return cached;
           if (event.request.mode === 'navigate') {
             return caches.match('./index.html');

--- a/src/features/codex/analysis-page.mjs
+++ b/src/features/codex/analysis-page.mjs
@@ -79,6 +79,10 @@ function formatPercent(value, decimals = 0) {
   return Number.isFinite(value) ? `${(value * 100).toFixed(decimals)}%` : '—';
 }
 
+function formatQuotaPercent(value, decimals = 0) {
+  return Number.isFinite(value) ? `${value.toFixed(decimals)}%` : '—';
+}
+
 function formatHours(value, decimals = 1) {
   return Number.isFinite(value) ? `${value.toFixed(decimals)} h` : '—';
 }
@@ -159,7 +163,9 @@ function renderMetricCards(analytics) {
       value: Number.isFinite(analytics.overall.effectiveHoursPerUsagePoint)
         ? `${analytics.overall.effectiveHoursPerUsagePoint.toFixed(2)} h/pt`
         : 'Collecting',
-      detail: 'Effective hours per quota percentage point'
+      detail: `${formatHours(
+        analytics.overall.measuredEffectiveHours
+      )} measured effective time`
     },
     {
       label: 'Attributed usage',
@@ -281,6 +287,21 @@ const efficiencyColumns = [
   {
     key: 'wallHours',
     label: 'Active',
+    title: 'Total active time in the selected range',
+    numeric: true,
+    format: (value) => formatHours(value)
+  },
+  {
+    key: 'measuredWallHours',
+    label: 'Measured active',
+    title: 'Active time overlapping quota-history coverage',
+    numeric: true,
+    format: (value) => formatHours(value)
+  },
+  {
+    key: 'measuredEffectiveHours',
+    label: 'Measured effective',
+    title: 'Effective time overlapping quota-history coverage',
     numeric: true,
     format: (value) => formatHours(value)
   },
@@ -382,6 +403,12 @@ function renderTables(analytics) {
         format: (value) => formatHours(value)
       },
       {
+        key: 'measuredWallHours',
+        label: 'Measured active',
+        numeric: true,
+        format: (value) => formatHours(value)
+      },
+      {
         key: 'usagePoints',
         label: 'Quota used',
         numeric: true,
@@ -428,10 +455,7 @@ function renderDataQuality(analytics) {
   ];
   rows.forEach(([label, value]) => {
     const row = makeElement('div', 'quality-row');
-    row.append(
-      makeElement('span', '', label),
-      makeElement('strong', '', value)
-    );
+    row.append(makeElement('span', '', label), makeElement('strong', '', value));
     container.appendChild(row);
   });
 }
@@ -460,6 +484,8 @@ function buildCsv(analytics) {
     'model',
     'effective_hours',
     'active_hours',
+    'measured_active_hours',
+    'measured_effective_hours',
     'quota_points',
     'quota_points_per_active_hour',
     'effective_hours_per_quota_point',
@@ -471,6 +497,8 @@ function buildCsv(analytics) {
     row.label,
     row.effectiveHours,
     row.wallHours,
+    row.measuredWallHours,
+    row.measuredEffectiveHours,
     row.usagePoints,
     row.usagePerWallHour ?? '',
     row.effectiveHoursPerUsagePoint ?? '',
@@ -545,6 +573,5 @@ async function initialize() {
 initialize().catch((error) => {
   console.error(error);
   byId('loadingState').className = 'fatal-state';
-  byId('loadingState').textContent =
-    `Codex analysis failed: ${error.message || error}`;
+  byId('loadingState').textContent = `Codex analysis failed: ${error.message || error}`;
 });

--- a/src/features/codex/analysis-page.mjs
+++ b/src/features/codex/analysis-page.mjs
@@ -1,0 +1,550 @@
+import { buildCodexAnalytics } from './analytics.mjs';
+
+const TIMEKEEPER_DATA_KEY = 'timekeeperDataPro';
+const USAGE_HISTORY_URL = new URL(
+  '../../../assets/timekeeper-codex-usage-history.json',
+  import.meta.url
+);
+const RANGE_OPTIONS = [1, 7, 30, 90];
+
+const state = {
+  rangeDays: 7,
+  analytics: null,
+  data: null,
+  usageHistory: []
+};
+
+function byId(id) {
+  return document.getElementById(id);
+}
+
+function readTimekeeperData() {
+  try {
+    const raw = localStorage.getItem(TIMEKEEPER_DATA_KEY);
+    const parsed = raw ? JSON.parse(raw) : null;
+    return parsed && typeof parsed === 'object' ? parsed : null;
+  } catch (error) {
+    console.warn('Unable to read TimeKeeper data:', error);
+    return null;
+  }
+}
+
+function normalizeUsageHistoryPayload(payload) {
+  if (Array.isArray(payload)) return payload;
+  if (Array.isArray(payload?.samples)) return payload.samples;
+  return [];
+}
+
+function getCurrentUsageSample(data) {
+  const integration = data?.codexIntegration;
+  const usageLimits =
+    integration?.usageLimits ||
+    integration?.lastUsageLimits ||
+    data?.codexUsageLimits;
+  if (!usageLimits || typeof usageLimits !== 'object') return null;
+  return {
+    observedAt:
+      usageLimits.observedAt ||
+      integration.lastUsageAt ||
+      integration.lastImportAt ||
+      new Date().toISOString(),
+    primary: usageLimits.primary || null,
+    secondary: usageLimits.secondary || null,
+    sourceMachineId: 'browser-cache'
+  };
+}
+
+async function loadUsageHistory(data) {
+  let samples = [];
+  try {
+    const response = await fetch(`${USAGE_HISTORY_URL}?v=${Date.now()}`, {
+      cache: 'no-store'
+    });
+    if (response.ok) {
+      samples = normalizeUsageHistoryPayload(await response.json());
+    }
+  } catch (error) {
+    console.warn('Unable to load Codex usage history:', error);
+  }
+  const current = getCurrentUsageSample(data);
+  if (current) samples.push(current);
+  return samples;
+}
+
+function formatNumber(value, decimals = 1) {
+  return Number.isFinite(value) ? value.toFixed(decimals) : '—';
+}
+
+function formatPercent(value, decimals = 0) {
+  return Number.isFinite(value) ? `${(value * 100).toFixed(decimals)}%` : '—';
+}
+
+function formatHours(value, decimals = 1) {
+  return Number.isFinite(value) ? `${value.toFixed(decimals)} h` : '—';
+}
+
+function formatDateTime(value) {
+  if (!value) return '—';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '—';
+  return date.toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit'
+  });
+}
+
+function titleCase(value) {
+  return String(value || '')
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+function makeElement(tag, className = '', text = '') {
+  const element = document.createElement(tag);
+  if (className) element.className = className;
+  if (text !== '') element.textContent = text;
+  return element;
+}
+
+function renderMeasurementBanner(analytics) {
+  const banner = byId('measurementBanner');
+  banner.className = `measurement-banner ${analytics.measurementState}`;
+  banner.replaceChildren();
+  const title = makeElement('strong');
+  const detail = makeElement('span');
+  if (analytics.measurementState === 'ready') {
+    title.textContent = 'Measured quota efficiency';
+    detail.textContent =
+      'Usage rates are based on reset-safe quota changes aligned with imported Codex activity.';
+  } else if (analytics.measurementState === 'partial') {
+    title.textContent = 'Preliminary quota efficiency';
+    detail.textContent =
+      'The model rankings are usable, but history or activity attribution is still incomplete. Treat low-confidence rows as directional.';
+  } else {
+    title.textContent = 'Collecting usage history';
+    detail.textContent =
+      'Time and focus metrics are available now. Usage-per-hour and effective-time-per-usage will appear after at least two quota snapshots have been collected.';
+  }
+  banner.append(title, detail);
+}
+
+function renderMetricCards(analytics) {
+  const cards = byId('metricCards');
+  cards.replaceChildren();
+  const metrics = [
+    {
+      label: 'Primary quota',
+      value: Number.isFinite(analytics.overall.latestUsedPercent)
+        ? `${analytics.overall.latestUsedPercent.toFixed(0)}% used`
+        : 'Unavailable',
+      detail: analytics.overall.resetsAt
+        ? `Resets ${formatDateTime(analytics.overall.resetsAt)}`
+        : 'Waiting for a quota snapshot'
+    },
+    {
+      label: 'Quota burn',
+      value: Number.isFinite(analytics.overall.burnPerDay)
+        ? `${analytics.overall.burnPerDay.toFixed(2)} pts/day`
+        : 'Collecting',
+      detail: Number.isFinite(analytics.overall.projectedUsedAtReset)
+        ? `${analytics.overall.projectedUsedAtReset.toFixed(0)}% projected at reset`
+        : 'Needs a measured interval'
+    },
+    {
+      label: 'Effective yield',
+      value: Number.isFinite(analytics.overall.effectiveHoursPerUsagePoint)
+        ? `${analytics.overall.effectiveHoursPerUsagePoint.toFixed(2)} h/pt`
+        : 'Collecting',
+      detail: 'Effective hours per quota percentage point'
+    },
+    {
+      label: 'Attributed usage',
+      value: formatPercent(analytics.overall.attributionRate),
+      detail: `${formatNumber(analytics.overall.attributedUsagePoints, 2)} of ${formatNumber(
+        analytics.overall.totalUsagePoints,
+        2
+      )} quota points`
+    },
+    {
+      label: 'Effective time',
+      value: formatHours(analytics.overall.totalEffectiveHours),
+      detail: `${formatHours(analytics.overall.totalWallHours)} active · ${formatPercent(
+        analytics.overall.focusConversion
+      )} credited`
+    },
+    {
+      label: 'Session shape',
+      value: Number.isFinite(analytics.overall.medianSessionMinutes)
+        ? `${analytics.overall.medianSessionMinutes.toFixed(0)} min median`
+        : 'No sessions',
+      detail: `${formatNumber(
+        analytics.overall.sessionsPerEffectiveHour,
+        2
+      )} sessions/effective hour`
+    }
+  ];
+  metrics.forEach((metric) => {
+    const card = makeElement('article', 'metric-card');
+    card.append(
+      makeElement('span', 'metric-label', metric.label),
+      makeElement('strong', 'metric-value', metric.value),
+      makeElement('small', 'metric-detail', metric.detail)
+    );
+    cards.appendChild(card);
+  });
+}
+
+function renderInsights(analytics) {
+  const container = byId('insights');
+  container.replaceChildren();
+  if (!analytics.insights.length) {
+    container.appendChild(
+      makeElement(
+        'p',
+        'empty-state',
+        'No measured efficiency findings yet. The page will populate as quota history accumulates.'
+      )
+    );
+    return;
+  }
+  analytics.insights.forEach((insight) => {
+    const card = makeElement('article', `insight ${insight.tone}`);
+    card.append(
+      makeElement('strong', '', insight.title),
+      makeElement('span', '', insight.detail)
+    );
+    container.appendChild(card);
+  });
+}
+
+function confidenceBadge(confidence) {
+  return `<span class="confidence ${confidence}">${titleCase(confidence)}</span>`;
+}
+
+function formatCell(column, row) {
+  const value = row[column.key];
+  if (column.format) return column.format(value, row);
+  return value ?? '—';
+}
+
+function renderTable(containerId, rows, columns, emptyMessage) {
+  const container = byId(containerId);
+  container.replaceChildren();
+  if (!rows.length) {
+    container.appendChild(makeElement('p', 'empty-state', emptyMessage));
+    return;
+  }
+  const wrapper = makeElement('div', 'table-scroll');
+  const table = makeElement('table', 'analysis-table');
+  const head = document.createElement('thead');
+  const headRow = document.createElement('tr');
+  columns.forEach((column) => {
+    const header = document.createElement('th');
+    header.textContent = column.label;
+    if (column.title) header.title = column.title;
+    headRow.appendChild(header);
+  });
+  head.appendChild(headRow);
+  const body = document.createElement('tbody');
+  rows.forEach((row) => {
+    const tr = document.createElement('tr');
+    columns.forEach((column) => {
+      const cell = document.createElement('td');
+      const formatted = formatCell(column, row);
+      if (column.html) {
+        cell.innerHTML = String(formatted);
+      } else {
+        cell.textContent = String(formatted);
+      }
+      if (column.numeric) cell.className = 'numeric';
+      tr.appendChild(cell);
+    });
+    body.appendChild(tr);
+  });
+  table.append(head, body);
+  wrapper.appendChild(table);
+  container.appendChild(wrapper);
+}
+
+const efficiencyColumns = [
+  { key: 'label', label: 'Model' },
+  {
+    key: 'effectiveHours',
+    label: 'Effective',
+    numeric: true,
+    format: (value) => formatHours(value)
+  },
+  {
+    key: 'wallHours',
+    label: 'Active',
+    numeric: true,
+    format: (value) => formatHours(value)
+  },
+  {
+    key: 'usagePoints',
+    label: 'Quota used',
+    title: 'Percentage points consumed in the measured primary limit window',
+    numeric: true,
+    format: (value) =>
+      Number.isFinite(value) ? `${value.toFixed(2)} pts` : '—'
+  },
+  {
+    key: 'usagePerWallHour',
+    label: 'Usage / active h',
+    title: 'Lower is more quota-efficient',
+    numeric: true,
+    format: (value) =>
+      Number.isFinite(value) ? `${value.toFixed(2)} pts/h` : '—'
+  },
+  {
+    key: 'effectiveHoursPerUsagePoint',
+    label: 'Effective h / usage',
+    title: 'Higher is more quota-efficient',
+    numeric: true,
+    format: (value) =>
+      Number.isFinite(value) ? `${value.toFixed(2)} h/pt` : '—'
+  },
+  {
+    key: 'focusConversion',
+    label: 'Focus conversion',
+    numeric: true,
+    format: (value) => formatPercent(value)
+  },
+  {
+    key: 'sessions',
+    label: 'Sessions',
+    numeric: true,
+    format: (value) => String(value)
+  },
+  {
+    key: 'confidence',
+    label: 'Confidence',
+    html: true,
+    format: (value) => confidenceBadge(value)
+  }
+];
+
+function renderTables(analytics) {
+  const modelRows = analytics.byModel
+    .slice()
+    .sort((left, right) => {
+      if (
+        Number.isFinite(left.usagePerWallHour) &&
+        Number.isFinite(right.usagePerWallHour)
+      ) {
+        return right.usagePerWallHour - left.usagePerWallHour;
+      }
+      return right.effectiveHours - left.effectiveHours;
+    });
+  renderTable(
+    'modelTable',
+    modelRows,
+    efficiencyColumns,
+    'No imported Codex model activity exists in this range.'
+  );
+  renderTable(
+    'modelEffortTable',
+    analytics.byModelEffort,
+    [
+      { ...efficiencyColumns[0], label: 'Model · effort' },
+      ...efficiencyColumns.slice(1)
+    ],
+    'No model-and-effort breakdown is available.'
+  );
+  renderTable(
+    'projectTable',
+    analytics.byProject,
+    [
+      { ...efficiencyColumns[0], label: 'Project' },
+      ...efficiencyColumns.slice(1)
+    ],
+    'No project-level Codex activity exists in this range.'
+  );
+  renderTable(
+    'dailyTable',
+    analytics.daily.slice(-14).reverse(),
+    [
+      { key: 'date', label: 'Date' },
+      {
+        key: 'effectiveHours',
+        label: 'Effective',
+        numeric: true,
+        format: (value) => formatHours(value)
+      },
+      {
+        key: 'wallHours',
+        label: 'Active',
+        numeric: true,
+        format: (value) => formatHours(value)
+      },
+      {
+        key: 'usagePoints',
+        label: 'Quota used',
+        numeric: true,
+        format: (value) =>
+          Number.isFinite(value) ? `${value.toFixed(2)} pts` : '—'
+      },
+      {
+        key: 'usagePerWallHour',
+        label: 'Usage / active h',
+        numeric: true,
+        format: (value) =>
+          Number.isFinite(value) ? `${value.toFixed(2)} pts/h` : '—'
+      }
+    ],
+    'Daily measurements will appear once usage history accumulates.'
+  );
+}
+
+function renderDataQuality(analytics) {
+  const container = byId('dataQuality');
+  container.replaceChildren();
+  const rows = [
+    ['Quota snapshots', String(analytics.coverage.sampleCount)],
+    ['Measured intervals', String(analytics.coverage.intervalCount)],
+    ['Measurement coverage', formatPercent(analytics.coverage.timeCoverage)],
+    ['Quota attribution', formatPercent(analytics.overall.attributionRate)],
+    ['Unknown model time', formatPercent(analytics.overall.unknownModelShare)],
+    [
+      'Mixed-model sessions',
+      formatPercent(analytics.overall.mixedModelSessionShare)
+    ],
+    [
+      'Subagent active-time share',
+      formatPercent(analytics.overall.subagentWallShare)
+    ],
+    [
+      'Skipped large snapshot gaps',
+      String(analytics.coverage.skippedLargeGaps)
+    ],
+    [
+      'Detected reset transitions',
+      String(analytics.coverage.resetTransitions)
+    ]
+  ];
+  rows.forEach(([label, value]) => {
+    const row = makeElement('div', 'quality-row');
+    row.append(
+      makeElement('span', '', label),
+      makeElement('strong', '', value)
+    );
+    container.appendChild(row);
+  });
+}
+
+function updateRangeControls() {
+  const container = byId('rangeControls');
+  container.replaceChildren();
+  RANGE_OPTIONS.forEach((rangeDays) => {
+    const button = makeElement(
+      'button',
+      rangeDays === state.rangeDays ? 'range-button active' : 'range-button',
+      rangeDays === 1 ? '24h' : `${rangeDays}d`
+    );
+    button.type = 'button';
+    button.addEventListener('click', () => {
+      state.rangeDays = rangeDays;
+      updateRangeControls();
+      render();
+    });
+    container.appendChild(button);
+  });
+}
+
+function buildCsv(analytics) {
+  const headers = [
+    'model',
+    'effective_hours',
+    'active_hours',
+    'quota_points',
+    'quota_points_per_active_hour',
+    'effective_hours_per_quota_point',
+    'focus_conversion',
+    'sessions',
+    'confidence'
+  ];
+  const rows = analytics.byModel.map((row) => [
+    row.label,
+    row.effectiveHours,
+    row.wallHours,
+    row.usagePoints,
+    row.usagePerWallHour ?? '',
+    row.effectiveHoursPerUsagePoint ?? '',
+    row.focusConversion ?? '',
+    row.sessions,
+    row.confidence
+  ]);
+  return [headers, ...rows]
+    .map((row) =>
+      row
+        .map((value) => `"${String(value ?? '').replaceAll('"', '""')}"`)
+        .join(',')
+    )
+    .join('\n');
+}
+
+function exportCsv() {
+  if (!state.analytics) return;
+  const blob = new Blob([buildCsv(state.analytics)], { type: 'text/csv' });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = `timekeeper-codex-analysis-${state.rangeDays}d.csv`;
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  URL.revokeObjectURL(url);
+}
+
+function render() {
+  if (!state.data) return;
+  const analytics = buildCodexAnalytics({
+    entries: state.data.entries || [],
+    projects: state.data.projects || [],
+    usageHistory: state.usageHistory,
+    rangeDays: state.rangeDays,
+    now: new Date()
+  });
+  state.analytics = analytics;
+  byId('rangeLabel').textContent =
+    state.rangeDays === 1 ? 'Last 24 hours' : `Last ${state.rangeDays} days`;
+  byId('updatedAt').textContent = `Calculated ${formatDateTime(
+    analytics.generatedAt
+  )}`;
+  renderMeasurementBanner(analytics);
+  renderMetricCards(analytics);
+  renderInsights(analytics);
+  renderTables(analytics);
+  renderDataQuality(analytics);
+}
+
+async function initialize() {
+  updateRangeControls();
+  byId('exportCsv').addEventListener('click', exportCsv);
+  byId('refreshAnalysis').addEventListener('click', () =>
+    window.location.reload()
+  );
+  state.data = readTimekeeperData();
+  if (!state.data) {
+    byId('loadingState').className = 'fatal-state';
+    byId('loadingState').textContent =
+      'No TimeKeeper browser data was found. Open TimeKeeper on this same origin and import Codex activity first.';
+    byId('analysisContent').hidden = true;
+    return;
+  }
+  state.usageHistory = await loadUsageHistory(state.data);
+  byId('loadingState').hidden = true;
+  byId('analysisContent').hidden = false;
+  render();
+}
+
+initialize().catch((error) => {
+  console.error(error);
+  byId('loadingState').className = 'fatal-state';
+  byId('loadingState').textContent =
+    `Codex analysis failed: ${error.message || error}`;
+});

--- a/src/features/codex/analysis-page.mjs
+++ b/src/features/codex/analysis-page.mjs
@@ -6,12 +6,35 @@ const USAGE_HISTORY_URL = new URL(
   import.meta.url
 );
 const RANGE_OPTIONS = [1, 7, 30, 90];
+const CHART_COLORS = [
+  '#2563eb',
+  '#047857',
+  '#b45309',
+  '#7c3aed',
+  '#be123c',
+  '#0891b2'
+];
 
 const state = {
   rangeDays: 7,
+  windowKey: 'primary',
   analytics: null,
   data: null,
-  usageHistory: []
+  usageHistory: [],
+  filters: {
+    model: 'all',
+    effort: 'all',
+    project: 'all',
+    minMeasuredHours: 0,
+    minUsagePoints: 0,
+    hideUnknown: true
+  },
+  sort: {
+    model: { key: 'usagePerWallHour', direction: 'desc' },
+    modelEffort: { key: 'effectiveHours', direction: 'desc' },
+    project: { key: 'effectiveHoursPerUsagePoint', direction: 'desc' },
+    daily: { key: 'date', direction: 'desc' }
+  }
 };
 
 function byId(id) {
@@ -45,8 +68,8 @@ function getCurrentUsageSample(data) {
   return {
     observedAt:
       usageLimits.observedAt ||
-      integration.lastUsageAt ||
-      integration.lastImportAt ||
+      integration?.lastUsageAt ||
+      integration?.lastImportAt ||
       new Date().toISOString(),
     primary: usageLimits.primary || null,
     secondary: usageLimits.secondary || null,
@@ -72,25 +95,25 @@ async function loadUsageHistory(data) {
 }
 
 function formatNumber(value, decimals = 1) {
-  return Number.isFinite(value) ? value.toFixed(decimals) : '—';
+  return Number.isFinite(value) ? value.toFixed(decimals) : '-';
 }
 
 function formatPercent(value, decimals = 0) {
-  return Number.isFinite(value) ? `${(value * 100).toFixed(decimals)}%` : '—';
+  return Number.isFinite(value) ? `${(value * 100).toFixed(decimals)}%` : '-';
 }
 
 function formatQuotaPercent(value, decimals = 0) {
-  return Number.isFinite(value) ? `${value.toFixed(decimals)}%` : '—';
+  return Number.isFinite(value) ? `${value.toFixed(decimals)}%` : '-';
 }
 
 function formatHours(value, decimals = 1) {
-  return Number.isFinite(value) ? `${value.toFixed(decimals)} h` : '—';
+  return Number.isFinite(value) ? `${value.toFixed(decimals)} h` : '-';
 }
 
 function formatDateTime(value) {
-  if (!value) return '—';
+  if (!value) return '-';
   const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return '—';
+  if (Number.isNaN(date.getTime())) return '-';
   return date.toLocaleString(undefined, {
     month: 'short',
     day: 'numeric',
@@ -114,6 +137,31 @@ function makeElement(tag, className = '', text = '') {
   return element;
 }
 
+function windowHasData(samples, windowKey) {
+  return samples.some((sample) => {
+    const window = sample?.[windowKey];
+    const hasNumber = (value) =>
+      value !== null &&
+      value !== undefined &&
+      value !== '' &&
+      Number.isFinite(Number(value));
+    return (
+      window &&
+      (hasNumber(window.usedPercent) || hasNumber(window.remainingPercent))
+    );
+  });
+}
+
+function windowLabel(windowKey) {
+  return windowKey === 'secondary'
+    ? 'Secondary quota window'
+    : 'Primary quota window';
+}
+
+function rangeLabel(rangeDays) {
+  return rangeDays === 1 ? 'Last 24 hours' : `Last ${rangeDays} days`;
+}
+
 function renderMeasurementBanner(analytics) {
   const banner = byId('measurementBanner');
   banner.className = `measurement-banner ${analytics.measurementState}`;
@@ -121,17 +169,17 @@ function renderMeasurementBanner(analytics) {
   const title = makeElement('strong');
   const detail = makeElement('span');
   if (analytics.measurementState === 'ready') {
-    title.textContent = 'Measured quota efficiency';
+    title.textContent = `Measured ${windowLabel(analytics.windowKey).toLowerCase()}`;
     detail.textContent =
-      'Usage rates are based on reset-safe quota changes aligned with imported Codex activity.';
+      'Usage rates use reset-safe quota changes aligned with imported Codex activity.';
   } else if (analytics.measurementState === 'partial') {
     title.textContent = 'Preliminary quota efficiency';
     detail.textContent =
-      'The model rankings are usable, but history or activity attribution is still incomplete. Treat low-confidence rows as directional.';
+      'History or activity attribution is incomplete. Treat low-confidence rows as directional.';
   } else {
     title.textContent = 'Collecting usage history';
     detail.textContent =
-      'Time and focus metrics are available now. Usage-per-hour and effective-time-per-usage will appear after at least two quota snapshots have been collected.';
+      'Time and focus metrics are available now. Efficiency ratios need at least two usable quota snapshots in this window.';
   }
   banner.append(title, detail);
 }
@@ -141,9 +189,9 @@ function renderMetricCards(analytics) {
   cards.replaceChildren();
   const metrics = [
     {
-      label: 'Primary quota',
+      label: `${titleCase(analytics.windowKey)} quota`,
       value: Number.isFinite(analytics.overall.latestUsedPercent)
-        ? `${analytics.overall.latestUsedPercent.toFixed(0)}% used`
+        ? `${formatQuotaPercent(analytics.overall.latestUsedPercent)} used`
         : 'Unavailable',
       detail: analytics.overall.resetsAt
         ? `Resets ${formatDateTime(analytics.overall.resetsAt)}`
@@ -163,22 +211,20 @@ function renderMetricCards(analytics) {
       value: Number.isFinite(analytics.overall.effectiveHoursPerUsagePoint)
         ? `${analytics.overall.effectiveHoursPerUsagePoint.toFixed(2)} h/pt`
         : 'Collecting',
-      detail: `${formatHours(
-        analytics.overall.measuredEffectiveHours
-      )} measured effective time`
+      detail: `${formatHours(analytics.overall.measuredEffectiveHours)} measured effective time`
     },
     {
       label: 'Attributed usage',
       value: formatPercent(analytics.overall.attributionRate),
-      detail: `${formatNumber(analytics.overall.attributedUsagePoints, 2)} of ${formatNumber(
-        analytics.overall.totalUsagePoints,
+      detail: `${formatNumber(
+        analytics.overall.attributedUsagePoints,
         2
-      )} quota points`
+      )} of ${formatNumber(analytics.overall.totalUsagePoints, 2)} quota points`
     },
     {
       label: 'Effective time',
       value: formatHours(analytics.overall.totalEffectiveHours),
-      detail: `${formatHours(analytics.overall.totalWallHours)} active · ${formatPercent(
+      detail: `${formatHours(analytics.overall.totalWallHours)} active - ${formatPercent(
         analytics.overall.focusConversion
       )} credited`
     },
@@ -228,16 +274,78 @@ function renderInsights(analytics) {
 }
 
 function confidenceBadge(confidence) {
-  return `<span class="confidence ${confidence}">${titleCase(confidence)}</span>`;
+  return makeElement('span', `confidence ${confidence}`, titleCase(confidence));
+}
+
+function isUnknownRow(row) {
+  return [row?.key, row?.label, row?.model, row?.effort]
+    .filter(Boolean)
+    .some((value) => String(value).toLowerCase().includes('unknown'));
+}
+
+function applyFilters(rows, tableKey) {
+  const filters = state.filters;
+  return rows.filter((row) => {
+    if (filters.hideUnknown && isUnknownRow(row)) return false;
+    if (tableKey === 'model' && filters.model !== 'all') {
+      if (row.key !== filters.model) return false;
+    }
+    if (tableKey === 'modelEffort') {
+      if (filters.model !== 'all' && row.model !== filters.model) return false;
+      if (filters.effort !== 'all' && row.effort !== filters.effort)
+        return false;
+    }
+    if (tableKey === 'project' && filters.project !== 'all') {
+      if (row.key !== filters.project) return false;
+    }
+    if (
+      Number.isFinite(filters.minMeasuredHours) &&
+      row.measuredWallHours < filters.minMeasuredHours
+    ) {
+      return false;
+    }
+    if (
+      Number.isFinite(filters.minUsagePoints) &&
+      row.usagePoints < filters.minUsagePoints
+    ) {
+      return false;
+    }
+    return true;
+  });
+}
+
+function sortValue(row, key) {
+  const value = row?.[key];
+  return typeof value === 'string' ? value.toLowerCase() : value;
+}
+
+function sortRows(rows, tableKey) {
+  const sort = state.sort[tableKey] || { key: 'label', direction: 'asc' };
+  return rows.slice().sort((left, right) => {
+    const leftValue = sortValue(left, sort.key);
+    const rightValue = sortValue(right, sort.key);
+    const leftMissing =
+      leftValue === null || leftValue === undefined || leftValue === '';
+    const rightMissing =
+      rightValue === null || rightValue === undefined || rightValue === '';
+    if (leftMissing || rightMissing) {
+      if (leftMissing && rightMissing) return 0;
+      return leftMissing ? 1 : -1;
+    }
+    const comparison =
+      typeof leftValue === 'number' && typeof rightValue === 'number'
+        ? leftValue - rightValue
+        : String(leftValue).localeCompare(String(rightValue));
+    return sort.direction === 'asc' ? comparison : -comparison;
+  });
 }
 
 function formatCell(column, row) {
   const value = row[column.key];
-  if (column.format) return column.format(value, row);
-  return value ?? '—';
+  return column.format ? column.format(value, row) : (value ?? '-');
 }
 
-function renderTable(containerId, rows, columns, emptyMessage) {
+function renderTable(containerId, rows, columns, emptyMessage, tableKey) {
   const container = byId(containerId);
   container.replaceChildren();
   if (!rows.length) {
@@ -248,21 +356,47 @@ function renderTable(containerId, rows, columns, emptyMessage) {
   const table = makeElement('table', 'analysis-table');
   const head = document.createElement('thead');
   const headRow = document.createElement('tr');
+  const activeSort = state.sort[tableKey];
   columns.forEach((column) => {
     const header = document.createElement('th');
-    header.textContent = column.label;
-    if (column.title) header.title = column.title;
+    const sortKey = column.sortKey || column.key;
+    const button = makeElement('button', 'table-sort-button', column.label);
+    button.type = 'button';
+    button.title = column.title || `Sort by ${column.label}`;
+    button.setAttribute(
+      'aria-sort',
+      activeSort?.key === sortKey
+        ? activeSort.direction === 'asc'
+          ? 'ascending'
+          : 'descending'
+        : 'none'
+    );
+    button.addEventListener('click', () => {
+      const current = state.sort[tableKey] || {
+        key: sortKey,
+        direction: 'asc'
+      };
+      state.sort[tableKey] = {
+        key: sortKey,
+        direction:
+          current.key === sortKey && current.direction === 'asc'
+            ? 'desc'
+            : 'asc'
+      };
+      render();
+    });
+    header.appendChild(button);
     headRow.appendChild(header);
   });
   head.appendChild(headRow);
   const body = document.createElement('tbody');
-  rows.forEach((row) => {
+  sortRows(rows, tableKey).forEach((row) => {
     const tr = document.createElement('tr');
     columns.forEach((column) => {
       const cell = document.createElement('td');
       const formatted = formatCell(column, row);
-      if (column.html) {
-        cell.innerHTML = String(formatted);
+      if (column.render) {
+        cell.appendChild(column.render(formatted, row));
       } else {
         cell.textContent = String(formatted);
       }
@@ -277,7 +411,7 @@ function renderTable(containerId, rows, columns, emptyMessage) {
 }
 
 const efficiencyColumns = [
-  { key: 'label', label: 'Model' },
+  { key: 'label', label: 'Name' },
   {
     key: 'effectiveHours',
     label: 'Effective',
@@ -308,10 +442,10 @@ const efficiencyColumns = [
   {
     key: 'usagePoints',
     label: 'Quota used',
-    title: 'Percentage points consumed in the measured primary limit window',
+    title: 'Percentage points consumed in the selected quota window',
     numeric: true,
     format: (value) =>
-      Number.isFinite(value) ? `${value.toFixed(2)} pts` : '—'
+      Number.isFinite(value) ? `${value.toFixed(2)} pts` : '-'
   },
   {
     key: 'usagePerWallHour',
@@ -319,7 +453,7 @@ const efficiencyColumns = [
     title: 'Lower is more quota-efficient',
     numeric: true,
     format: (value) =>
-      Number.isFinite(value) ? `${value.toFixed(2)} pts/h` : '—'
+      Number.isFinite(value) ? `${value.toFixed(2)} pts/h` : '-'
   },
   {
     key: 'effectiveHoursPerUsagePoint',
@@ -327,7 +461,7 @@ const efficiencyColumns = [
     title: 'Higher is more quota-efficient',
     numeric: true,
     format: (value) =>
-      Number.isFinite(value) ? `${value.toFixed(2)} h/pt` : '—'
+      Number.isFinite(value) ? `${value.toFixed(2)} h/pt` : '-'
   },
   {
     key: 'focusConversion',
@@ -344,48 +478,47 @@ const efficiencyColumns = [
   {
     key: 'confidence',
     label: 'Confidence',
-    html: true,
-    format: (value) => confidenceBadge(value)
+    title:
+      'Confidence considers measured time, quota points, and interval count',
+    format: (value) => value,
+    render: (value) => confidenceBadge(value)
   }
 ];
 
 function renderTables(analytics) {
-  const modelRows = analytics.byModel.slice().sort((left, right) => {
-    if (
-      Number.isFinite(left.usagePerWallHour) &&
-      Number.isFinite(right.usagePerWallHour)
-    ) {
-      return right.usagePerWallHour - left.usagePerWallHour;
-    }
-    return right.effectiveHours - left.effectiveHours;
-  });
+  const modelRows = applyFilters(analytics.byModel, 'model');
+  const modelEffortRows = applyFilters(analytics.byModelEffort, 'modelEffort');
+  const projectRows = applyFilters(analytics.byProject, 'project');
   renderTable(
     'modelTable',
     modelRows,
     efficiencyColumns,
-    'No imported Codex model activity exists in this range.'
+    'No imported Codex model activity exists in this range.',
+    'model'
   );
   renderTable(
     'modelEffortTable',
-    analytics.byModelEffort,
+    modelEffortRows,
     [
-      { ...efficiencyColumns[0], label: 'Model · effort' },
+      { ...efficiencyColumns[0], label: 'Model / effort' },
       ...efficiencyColumns.slice(1)
     ],
-    'No model-and-effort breakdown is available.'
+    'No model-and-effort breakdown is available.',
+    'modelEffort'
   );
   renderTable(
     'projectTable',
-    analytics.byProject,
+    projectRows,
     [
       { ...efficiencyColumns[0], label: 'Project' },
       ...efficiencyColumns.slice(1)
     ],
-    'No project-level Codex activity exists in this range.'
+    'No project-level Codex activity exists in this range.',
+    'project'
   );
   renderTable(
     'dailyTable',
-    analytics.daily.slice(-14).reverse(),
+    analytics.daily.slice(-14),
     [
       { key: 'date', label: 'Date' },
       {
@@ -403,6 +536,7 @@ function renderTables(analytics) {
       {
         key: 'measuredWallHours',
         label: 'Measured active',
+        title: 'Active time overlapping quota-history coverage',
         numeric: true,
         format: (value) => formatHours(value)
       },
@@ -411,17 +545,18 @@ function renderTables(analytics) {
         label: 'Quota used',
         numeric: true,
         format: (value) =>
-          Number.isFinite(value) ? `${value.toFixed(2)} pts` : '—'
+          Number.isFinite(value) ? `${value.toFixed(2)} pts` : '-'
       },
       {
         key: 'usagePerWallHour',
         label: 'Usage / active h',
         numeric: true,
         format: (value) =>
-          Number.isFinite(value) ? `${value.toFixed(2)} pts/h` : '—'
+          Number.isFinite(value) ? `${value.toFixed(2)} pts/h` : '-'
       }
     ],
-    'Daily measurements will appear once usage history accumulates.'
+    'Daily measurements will appear once usage history accumulates.',
+    'daily'
   );
 }
 
@@ -429,6 +564,8 @@ function renderDataQuality(analytics) {
   const container = byId('dataQuality');
   container.replaceChildren();
   const rows = [
+    ['Window', titleCase(analytics.windowKey)],
+    ['Measurement state', titleCase(analytics.measurementState)],
     ['Quota snapshots', String(analytics.coverage.sampleCount)],
     ['Measured intervals', String(analytics.coverage.intervalCount)],
     ['Measurement coverage', formatPercent(analytics.coverage.timeCoverage)],
@@ -446,6 +583,7 @@ function renderDataQuality(analytics) {
       'Skipped large snapshot gaps',
       String(analytics.coverage.skippedLargeGaps)
     ],
+    ['Skipped anomalous deltas', String(analytics.coverage.skippedAnomalies)],
     ['Detected reset transitions', String(analytics.coverage.resetTransitions)]
   ];
   rows.forEach(([label, value]) => {
@@ -468,17 +606,421 @@ function updateRangeControls() {
       rangeDays === 1 ? '24h' : `${rangeDays}d`
     );
     button.type = 'button';
+    button.setAttribute('aria-pressed', String(rangeDays === state.rangeDays));
     button.addEventListener('click', () => {
       state.rangeDays = rangeDays;
-      updateRangeControls();
       render();
     });
     container.appendChild(button);
   });
 }
 
-function buildCsv(analytics) {
+function renderWindowControls() {
+  const select = /** @type {HTMLSelectElement} */ (byId('windowSelect'));
+  const secondaryAvailable = windowHasData(state.usageHistory, 'secondary');
+  const options = [
+    {
+      key: 'primary',
+      label: 'Primary quota window',
+      available: windowHasData(state.usageHistory, 'primary')
+    }
+  ];
+  if (secondaryAvailable) {
+    options.push({
+      key: 'secondary',
+      label: 'Secondary quota window',
+      available: true
+    });
+  }
+  if (!options.some((option) => option.key === state.windowKey)) {
+    state.windowKey = options[0].key;
+  }
+  select.replaceChildren();
+  options.forEach((option) => {
+    const element = document.createElement('option');
+    element.value = option.key;
+    element.textContent = option.available
+      ? option.label
+      : `${option.label} - no snapshots`;
+    element.disabled = !option.available;
+    select.appendChild(element);
+  });
+  select.value = state.windowKey;
+  select.onchange = () => {
+    state.windowKey = select.value;
+    render();
+  };
+}
+
+function setSelectOptions(select, allLabel, rows, valueGetter, labelGetter) {
+  const values = new Map();
+  rows.forEach((row) => {
+    const value = valueGetter(row);
+    if (value && !values.has(value)) values.set(value, labelGetter(row));
+  });
+  select.replaceChildren();
+  const all = document.createElement('option');
+  all.value = 'all';
+  all.textContent = allLabel;
+  select.appendChild(all);
+  [...values.entries()]
+    .sort((left, right) => left[1].localeCompare(right[1]))
+    .forEach(([value, label]) => {
+      const option = document.createElement('option');
+      option.value = value;
+      option.textContent = label;
+      select.appendChild(option);
+    });
+}
+
+function renderFilterControls(analytics) {
+  setSelectOptions(
+    byId('filterModel'),
+    'All models',
+    analytics.byModel,
+    (row) => row.key,
+    (row) => row.label
+  );
+  setSelectOptions(
+    byId('filterEffort'),
+    'All efforts',
+    analytics.byEffort,
+    (row) => row.key,
+    (row) => titleCase(row.label)
+  );
+  setSelectOptions(
+    byId('filterProject'),
+    'All projects',
+    analytics.byProject,
+    (row) => row.key,
+    (row) => row.label
+  );
+  const modelFilter = /** @type {HTMLSelectElement} */ (byId('filterModel'));
+  const effortFilter = /** @type {HTMLSelectElement} */ (byId('filterEffort'));
+  const projectFilter = /** @type {HTMLSelectElement} */ (
+    byId('filterProject')
+  );
+  modelFilter.value = state.filters.model;
+  effortFilter.value = state.filters.effort;
+  projectFilter.value = state.filters.project;
+  modelFilter.onchange = () => {
+    state.filters.model = modelFilter.value;
+    render();
+  };
+  effortFilter.onchange = () => {
+    state.filters.effort = effortFilter.value;
+    render();
+  };
+  projectFilter.onchange = () => {
+    state.filters.project = projectFilter.value;
+    render();
+  };
+  const minMeasured = /** @type {HTMLInputElement} */ (
+    byId('minMeasuredHours')
+  );
+  const minUsage = /** @type {HTMLInputElement} */ (byId('minUsagePoints'));
+  const hideUnknown = /** @type {HTMLInputElement} */ (byId('hideUnknown'));
+  minMeasured.value = String(state.filters.minMeasuredHours || '');
+  minUsage.value = String(state.filters.minUsagePoints || '');
+  hideUnknown.checked = state.filters.hideUnknown;
+  minMeasured.onchange = () => {
+    state.filters.minMeasuredHours = Math.max(
+      0,
+      Number(minMeasured.value) || 0
+    );
+    render();
+  };
+  minUsage.onchange = () => {
+    state.filters.minUsagePoints = Math.max(0, Number(minUsage.value) || 0);
+    render();
+  };
+  hideUnknown.onchange = () => {
+    state.filters.hideUnknown = hideUnknown.checked;
+    render();
+  };
+  const visible = applyFilters(analytics.byModel, 'model').length;
+  byId('filterSummary').textContent =
+    `${visible} of ${analytics.byModel.length} model rows shown. Filters affect tables and charts, not the overall totals above.`;
+}
+
+function prepareCanvas(canvas) {
+  const rect = canvas.getBoundingClientRect();
+  const width = Math.max(280, Math.floor(rect.width || 600));
+  const height = 230;
+  const deviceScale = window.devicePixelRatio || 1;
+  canvas.width = Math.floor(width * deviceScale);
+  canvas.height = Math.floor(height * deviceScale);
+  const context = canvas.getContext('2d');
+  context.setTransform(deviceScale, 0, 0, deviceScale, 0, 0);
+  context.clearRect(0, 0, width, height);
+  context.font = '12px system-ui, sans-serif';
+  context.lineJoin = 'round';
+  return { context, width, height };
+}
+
+function drawEmptyChart(canvas, message) {
+  const { context, width, height } = prepareCanvas(canvas);
+  context.fillStyle = '#64748b';
+  context.textAlign = 'center';
+  context.fillText(message, width / 2, height / 2);
+}
+
+function drawGrid(context, left, top, plotWidth, plotHeight, maxValue, suffix) {
+  context.strokeStyle = '#dbe4ef';
+  context.fillStyle = '#64748b';
+  context.lineWidth = 1;
+  context.textAlign = 'right';
+  for (let index = 0; index <= 4; index += 1) {
+    const value = (maxValue * index) / 4;
+    const y = top + plotHeight - (plotHeight * index) / 4;
+    context.beginPath();
+    context.moveTo(left, y);
+    context.lineTo(left + plotWidth, y);
+    context.stroke();
+    context.fillText(`${value.toFixed(1)}${suffix}`, left - 7, y + 4);
+  }
+}
+
+function truncateLabel(value, maxLength = 16) {
+  const label = String(value || '-');
+  return label.length > maxLength
+    ? `${label.slice(0, maxLength - 1)}...`
+    : label;
+}
+
+function drawBarChart(canvas, items, emptyMessage, suffix = '') {
+  if (!items.length) {
+    drawEmptyChart(canvas, emptyMessage);
+    return;
+  }
+  const { context, width, height } = prepareCanvas(canvas);
+  const left = 48;
+  const top = 14;
+  const right = 12;
+  const bottom = 54;
+  const plotWidth = width - left - right;
+  const plotHeight = height - top - bottom;
+  const maxValue = Math.max(1, ...items.map((item) => item.value));
+  drawGrid(context, left, top, plotWidth, plotHeight, maxValue, suffix);
+  const slotWidth = plotWidth / items.length;
+  const barWidth = Math.max(4, Math.min(44, slotWidth * 0.68));
+  items.forEach((item, index) => {
+    const x = left + slotWidth * index + (slotWidth - barWidth) / 2;
+    const barHeight = (item.value / maxValue) * plotHeight;
+    const y = top + plotHeight - barHeight;
+    context.fillStyle = CHART_COLORS[index % CHART_COLORS.length];
+    context.fillRect(x, y, barWidth, barHeight);
+    if (items.length <= 16) {
+      context.fillStyle = '#334155';
+      context.textAlign = 'center';
+      context.fillText(
+        item.value.toFixed(1),
+        x + barWidth / 2,
+        Math.max(top + 11, y - 5)
+      );
+    }
+    context.save();
+    context.translate(x + barWidth / 2, top + plotHeight + 10);
+    context.rotate(-Math.PI / 5);
+    context.fillStyle = '#64748b';
+    context.textAlign = 'right';
+    context.fillText(truncateLabel(item.label), 0, 0);
+    context.restore();
+  });
+}
+
+function compactTimeline(intervals, maxItems = 48) {
+  if (intervals.length <= maxItems) {
+    return intervals.map((interval) => ({
+      label: formatDateTime(interval.startAt),
+      value: interval.usagePoints
+    }));
+  }
+  const bucketSize = Math.ceil(intervals.length / maxItems);
+  const buckets = [];
+  for (let index = 0; index < intervals.length; index += bucketSize) {
+    const bucket = intervals.slice(index, index + bucketSize);
+    buckets.push({
+      label: formatDateTime(bucket[0].startAt),
+      value: bucket.reduce((total, interval) => total + interval.usagePoints, 0)
+    });
+  }
+  return buckets;
+}
+
+function drawQuotaBurnChart(analytics) {
+  drawBarChart(
+    byId('quotaBurnChart'),
+    compactTimeline(analytics.quotaTimeline),
+    'Quota burn will appear after usable snapshots accumulate.',
+    ' pts'
+  );
+}
+
+function drawModelYieldChart(analytics) {
+  const rows = applyFilters(analytics.byModel, 'model').filter(
+    (row) =>
+      Number.isFinite(row.usagePerWallHour) &&
+      Number.isFinite(row.effectiveHoursPerUsagePoint)
+  );
+  if (!rows.length) {
+    drawEmptyChart(
+      byId('modelYieldChart'),
+      'Measured model yield is still collecting.'
+    );
+    return;
+  }
+  const { context, width, height } = prepareCanvas(byId('modelYieldChart'));
+  const left = 48;
+  const top = 18;
+  const right = 18;
+  const bottom = 36;
+  const plotWidth = width - left - right;
+  const plotHeight = height - top - bottom;
+  const maxX = Math.max(1, ...rows.map((row) => row.usagePerWallHour));
+  const maxY = Math.max(
+    1,
+    ...rows.map((row) => row.effectiveHoursPerUsagePoint)
+  );
+  drawGrid(context, left, top, plotWidth, plotHeight, maxY, ' h');
+  context.strokeStyle = '#94a3b8';
+  context.beginPath();
+  context.moveTo(left, top + plotHeight);
+  context.lineTo(left + plotWidth, top + plotHeight);
+  context.stroke();
+  context.fillStyle = '#64748b';
+  context.textAlign = 'center';
+  context.fillText(
+    'Quota points per measured active hour',
+    left + plotWidth / 2,
+    height - 8
+  );
+  rows.forEach((row, index) => {
+    const x = left + (row.usagePerWallHour / maxX) * plotWidth;
+    const y =
+      top + plotHeight - (row.effectiveHoursPerUsagePoint / maxY) * plotHeight;
+    context.fillStyle = CHART_COLORS[index % CHART_COLORS.length];
+    context.beginPath();
+    context.arc(x, y, 5, 0, Math.PI * 2);
+    context.fill();
+    context.fillStyle = '#334155';
+    context.textAlign = x > width - 90 ? 'right' : 'left';
+    context.fillText(
+      truncateLabel(row.label),
+      x + (x > width - 90 ? -8 : 8),
+      y - 8
+    );
+  });
+}
+
+function drawModelEffortChart(analytics) {
+  const rows = applyFilters(analytics.byModelEffort, 'modelEffort')
+    .filter(
+      (row) => Number.isFinite(row.effectiveHours) && row.effectiveHours > 0
+    )
+    .slice(0, 24)
+    .map((row) => ({ label: row.label, value: row.effectiveHours }));
+  drawBarChart(
+    byId('modelEffortChart'),
+    rows,
+    'No model-and-effort time in this range.',
+    ' h'
+  );
+}
+
+function drawProjectEfficiencyChart(analytics) {
+  const rows = applyFilters(analytics.byProject, 'project')
+    .filter(
+      (row) =>
+        Number.isFinite(row.effectiveHoursPerUsagePoint) &&
+        row.effectiveHoursPerUsagePoint > 0
+    )
+    .slice(0, 24)
+    .map((row) => ({
+      label: row.label,
+      value: row.effectiveHoursPerUsagePoint
+    }));
+  drawBarChart(
+    byId('projectEfficiencyChart'),
+    rows,
+    'Project efficiency is still collecting.',
+    ' h'
+  );
+}
+
+function resetMatches(left, right) {
+  if (!left || !right) return false;
+  const leftMs = Date.parse(left);
+  const rightMs = Date.parse(right);
+  return Number.isFinite(leftMs) && Number.isFinite(rightMs)
+    ? Math.abs(leftMs - rightMs) <= 5 * 60 * 1000
+    : left === right;
+}
+
+function drawQuotaTrajectoryChart(analytics) {
+  const points = analytics.quotaTrajectory.filter((point) =>
+    Number.isFinite(point.usedPercent)
+  );
+  if (!points.length) {
+    drawEmptyChart(
+      byId('quotaTrajectoryChart'),
+      'Quota trajectory is still collecting.'
+    );
+    return;
+  }
+  const { context, width, height } = prepareCanvas(
+    byId('quotaTrajectoryChart')
+  );
+  const left = 48;
+  const top = 14;
+  const right = 18;
+  const bottom = 30;
+  const plotWidth = width - left - right;
+  const plotHeight = height - top - bottom;
+  drawGrid(context, left, top, plotWidth, plotHeight, 100, '%');
+  context.strokeStyle = '#2563eb';
+  context.lineWidth = 2;
+  points.forEach((point, index) => {
+    const x =
+      points.length === 1
+        ? left + plotWidth / 2
+        : left + (index / (points.length - 1)) * plotWidth;
+    const y = top + plotHeight - (point.usedPercent / 100) * plotHeight;
+    const previous = points[index - 1];
+    if (!previous || !resetMatches(previous.resetsAt, point.resetsAt)) {
+      context.beginPath();
+      context.moveTo(x, y);
+    } else {
+      context.lineTo(x, y);
+    }
+    context.stroke();
+    context.fillStyle = '#2563eb';
+    context.beginPath();
+    context.arc(x, y, 3, 0, Math.PI * 2);
+    context.fill();
+  });
+  context.fillStyle = '#64748b';
+  context.textAlign = 'left';
+  context.fillText(formatDateTime(points[0].observedAt), left, height - 8);
+  context.textAlign = 'right';
+  context.fillText(
+    formatDateTime(points.at(-1).observedAt),
+    width - right,
+    height - 8
+  );
+}
+
+function drawCharts(analytics) {
+  drawQuotaBurnChart(analytics);
+  drawModelYieldChart(analytics);
+  drawModelEffortChart(analytics);
+  drawProjectEfficiencyChart(analytics);
+  drawQuotaTrajectoryChart(analytics);
+}
+
+export function buildCsv(analytics, rows = analytics?.byModel || []) {
   const headers = [
+    'window_key',
     'model',
     'effective_hours',
     'active_hours',
@@ -491,7 +1033,8 @@ function buildCsv(analytics) {
     'sessions',
     'confidence'
   ];
-  const rows = analytics.byModel.map((row) => [
+  const values = rows.map((row) => [
+    analytics?.windowKey || 'primary',
     row.label,
     row.effectiveHours,
     row.wallHours,
@@ -504,7 +1047,7 @@ function buildCsv(analytics) {
     row.sessions,
     row.confidence
   ]);
-  return [headers, ...rows]
+  return [headers, ...values]
     .map((row) =>
       row
         .map((value) => `"${String(value ?? '').replaceAll('"', '""')}"`)
@@ -515,11 +1058,14 @@ function buildCsv(analytics) {
 
 function exportCsv() {
   if (!state.analytics) return;
-  const blob = new Blob([buildCsv(state.analytics)], { type: 'text/csv' });
+  const rows = applyFilters(state.analytics.byModel, 'model');
+  const blob = new Blob([buildCsv(state.analytics, rows)], {
+    type: 'text/csv'
+  });
   const url = URL.createObjectURL(blob);
   const anchor = document.createElement('a');
   anchor.href = url;
-  anchor.download = `timekeeper-codex-analysis-${state.rangeDays}d.csv`;
+  anchor.download = `timekeeper-codex-analysis-${state.windowKey}-${state.rangeDays}d.csv`;
   document.body.appendChild(anchor);
   anchor.click();
   anchor.remove();
@@ -533,19 +1079,22 @@ function render() {
     projects: state.data.projects || [],
     usageHistory: state.usageHistory,
     rangeDays: state.rangeDays,
+    windowKey: state.windowKey,
     now: new Date()
   });
   state.analytics = analytics;
-  byId('rangeLabel').textContent =
-    state.rangeDays === 1 ? 'Last 24 hours' : `Last ${state.rangeDays} days`;
-  byId('updatedAt').textContent = `Calculated ${formatDateTime(
-    analytics.generatedAt
-  )}`;
+  updateRangeControls();
+  renderWindowControls();
+  byId('rangeLabel').textContent = rangeLabel(state.rangeDays);
+  byId('updatedAt').textContent =
+    `Calculated ${formatDateTime(analytics.generatedAt)}`;
+  renderFilterControls(analytics);
   renderMeasurementBanner(analytics);
   renderMetricCards(analytics);
   renderInsights(analytics);
   renderTables(analytics);
   renderDataQuality(analytics);
+  drawCharts(analytics);
 }
 
 async function initialize() {
@@ -554,6 +1103,9 @@ async function initialize() {
   byId('refreshAnalysis').addEventListener('click', () =>
     window.location.reload()
   );
+  window.addEventListener('resize', () => {
+    if (state.analytics) drawCharts(state.analytics);
+  });
   state.data = readTimekeeperData();
   if (!state.data) {
     byId('loadingState').className = 'fatal-state';
@@ -568,9 +1120,11 @@ async function initialize() {
   render();
 }
 
-initialize().catch((error) => {
-  console.error(error);
-  byId('loadingState').className = 'fatal-state';
-  byId('loadingState').textContent =
-    `Codex analysis failed: ${error.message || error}`;
-});
+if (typeof document !== 'undefined') {
+  initialize().catch((error) => {
+    console.error(error);
+    byId('loadingState').className = 'fatal-state';
+    byId('loadingState').textContent =
+      `Codex analysis failed: ${error.message || error}`;
+  });
+}

--- a/src/features/codex/analysis-page.mjs
+++ b/src/features/codex/analysis-page.mjs
@@ -350,17 +350,15 @@ const efficiencyColumns = [
 ];
 
 function renderTables(analytics) {
-  const modelRows = analytics.byModel
-    .slice()
-    .sort((left, right) => {
-      if (
-        Number.isFinite(left.usagePerWallHour) &&
-        Number.isFinite(right.usagePerWallHour)
-      ) {
-        return right.usagePerWallHour - left.usagePerWallHour;
-      }
-      return right.effectiveHours - left.effectiveHours;
-    });
+  const modelRows = analytics.byModel.slice().sort((left, right) => {
+    if (
+      Number.isFinite(left.usagePerWallHour) &&
+      Number.isFinite(right.usagePerWallHour)
+    ) {
+      return right.usagePerWallHour - left.usagePerWallHour;
+    }
+    return right.effectiveHours - left.effectiveHours;
+  });
   renderTable(
     'modelTable',
     modelRows,
@@ -448,14 +446,14 @@ function renderDataQuality(analytics) {
       'Skipped large snapshot gaps',
       String(analytics.coverage.skippedLargeGaps)
     ],
-    [
-      'Detected reset transitions',
-      String(analytics.coverage.resetTransitions)
-    ]
+    ['Detected reset transitions', String(analytics.coverage.resetTransitions)]
   ];
   rows.forEach(([label, value]) => {
     const row = makeElement('div', 'quality-row');
-    row.append(makeElement('span', '', label), makeElement('strong', '', value));
+    row.append(
+      makeElement('span', '', label),
+      makeElement('strong', '', value)
+    );
     container.appendChild(row);
   });
 }
@@ -573,5 +571,6 @@ async function initialize() {
 initialize().catch((error) => {
   console.error(error);
   byId('loadingState').className = 'fatal-state';
-  byId('loadingState').textContent = `Codex analysis failed: ${error.message || error}`;
+  byId('loadingState').textContent =
+    `Codex analysis failed: ${error.message || error}`;
 });

--- a/src/features/codex/analytics.mjs
+++ b/src/features/codex/analytics.mjs
@@ -2,8 +2,10 @@ const HOUR_SECONDS = 60 * 60;
 const DAY_MS = 24 * 60 * 60 * 1000;
 const DEFAULT_MAX_USAGE_GAP_HOURS = 3;
 const DEFAULT_MAX_USAGE_DELTA = 40;
+const DEFAULT_RESET_TIME_TOLERANCE_MINUTES = 5;
 
 function finiteNumber(value, fallback = 0) {
+  if (value === null || value === undefined || value === '') return fallback;
   const number = Number(value);
   return Number.isFinite(number) ? number : fallback;
 }
@@ -73,8 +75,12 @@ export function normalizeCodexUsageSample(sample, windowKey = 'primary') {
     sample.usageLimits?.observedAt;
   const observedMs = parseTime(observedAt);
   if (observedMs === null) return null;
-  let usedPercent = Number(window.usedPercent);
-  let remainingPercent = Number(window.remainingPercent);
+  const toNumber = (value) =>
+    value === null || value === undefined || value === ''
+      ? Number.NaN
+      : Number(value);
+  let usedPercent = toNumber(window.usedPercent);
+  let remainingPercent = toNumber(window.remainingPercent);
   if (!Number.isFinite(usedPercent) && Number.isFinite(remainingPercent)) {
     usedPercent = 100 - remainingPercent;
   }
@@ -116,7 +122,11 @@ function dedupeUsageSamples(samples) {
   );
 }
 
-function sameUsageWindow(previous, current) {
+function sameUsageWindow(
+  previous,
+  current,
+  resetTimeToleranceMs = DEFAULT_RESET_TIME_TOLERANCE_MINUTES * 60 * 1000
+) {
   if (!previous || !current) return false;
   if (
     previous.windowMinutes > 0 &&
@@ -126,6 +136,11 @@ function sameUsageWindow(previous, current) {
     return false;
   }
   if (previous.resetsAt && current.resetsAt) {
+    const previousResetMs = parseTime(previous.resetsAt);
+    const currentResetMs = parseTime(current.resetsAt);
+    if (previousResetMs !== null && currentResetMs !== null) {
+      return Math.abs(currentResetMs - previousResetMs) <= resetTimeToleranceMs;
+    }
     return previous.resetsAt === current.resetsAt;
   }
   return current.usedPercent >= previous.usedPercent;
@@ -136,7 +151,8 @@ export function computeCodexUsageIntervals(
   {
     windowKey = 'primary',
     maxGapHours = DEFAULT_MAX_USAGE_GAP_HOURS,
-    maxUsageDelta = DEFAULT_MAX_USAGE_DELTA
+    maxUsageDelta = DEFAULT_MAX_USAGE_DELTA,
+    resetTimeToleranceMinutes = DEFAULT_RESET_TIME_TOLERANCE_MINUTES
   } = {}
 ) {
   const rawSamples = Array.isArray(usageHistory)
@@ -158,7 +174,13 @@ export function computeCodexUsageIntervals(
     const current = samples[index];
     const durationMs = current.observedMs - previous.observedMs;
     if (durationMs <= 0) continue;
-    if (!sameUsageWindow(previous, current)) {
+    if (
+      !sameUsageWindow(
+        previous,
+        current,
+        Math.max(0, resetTimeToleranceMinutes) * 60 * 1000
+      )
+    ) {
       resetTransitions += 1;
       continue;
     }
@@ -277,9 +299,7 @@ function normalizeModelBreakdown(entry, session) {
         factor: positiveNumber(row?.creditedFactor ?? row?.factor, 0)
       };
     })
-    .filter(
-      (row) => row.wallSeconds > 0 || row.effectiveSeconds > 0 || row.factor > 0
-    );
+    .filter((row) => row.wallSeconds > 0 || row.effectiveSeconds > 0);
   if (rows.length) return rows;
   return [
     {
@@ -513,6 +533,8 @@ function rankRows(rows, selector, direction = 'desc') {
 
 function buildInsights(analytics) {
   const insights = [];
+  const selectedWindow =
+    analytics.windowKey === 'secondary' ? 'secondary' : 'primary';
   const qualified = analytics.byModel.filter(
     (row) => row.confidence !== 'low' && row.usagePoints > 0
   );
@@ -568,7 +590,7 @@ function buildInsights(analytics) {
     insights.push({
       tone: projected >= 100 ? 'warning' : 'neutral',
       title: 'Projected quota at reset',
-      detail: `At the measured burn rate, the primary window would reach approximately ${projected.toFixed(0)}% used by reset.`
+      detail: `At the measured burn rate, the ${selectedWindow} window would reach approximately ${projected.toFixed(0)}% used by reset.`
     });
   }
   return insights.slice(0, 6);
@@ -581,14 +603,16 @@ export function buildCodexAnalytics({
   rangeDays = 7,
   now = new Date(),
   windowKey = 'primary',
-  maxUsageGapHours = DEFAULT_MAX_USAGE_GAP_HOURS
+  maxUsageGapHours = DEFAULT_MAX_USAGE_GAP_HOURS,
+  resetTimeToleranceMinutes = DEFAULT_RESET_TIME_TOLERANCE_MINUTES
 } = {}) {
   const nowMs = parseTime(now) ?? Date.now();
   const requestedRangeDays = clamp(positiveNumber(rangeDays, 7), 1 / 24, 365);
   const requestedStartMs = nowMs - requestedRangeDays * DAY_MS;
   const usage = computeCodexUsageIntervals(usageHistory, {
     windowKey,
-    maxGapHours: maxUsageGapHours
+    maxGapHours: maxUsageGapHours,
+    resetTimeToleranceMinutes
   });
   const sessions = normalizeCodexSessions(entries, projects).filter(
     (session) => session.endMs > requestedStartMs && session.startMs < nowMs
@@ -617,15 +641,17 @@ export function buildCodexAnalytics({
     overlappingMeasurementEndMs > overlappingMeasurementStartMs;
   const measurementStartMs = hasMeasurementWindow
     ? overlappingMeasurementStartMs
-    : requestedStartMs;
+    : null;
   const measurementEndMs = hasMeasurementWindow
     ? overlappingMeasurementEndMs
-    : nowMs;
-  const clippedIntervals = usage.intervals
-    .map((interval) =>
-      clipInterval(interval, measurementStartMs, measurementEndMs)
-    )
-    .filter(Boolean);
+    : null;
+  const clippedIntervals = hasMeasurementWindow
+    ? usage.intervals
+        .map((interval) =>
+          clipInterval(interval, measurementStartMs, measurementEndMs)
+        )
+        .filter(Boolean)
+    : [];
 
   const maps = {
     model: new Map(),
@@ -646,11 +672,9 @@ export function buildCodexAnalytics({
   sessions.forEach((session) => {
     const rangeClip = getSessionClip(session, requestedStartMs, nowMs);
     if (!rangeClip) return;
-    const measurementClip = getSessionClip(
-      session,
-      measurementStartMs,
-      measurementEndMs
-    );
+    const measurementClip = hasMeasurementWindow
+      ? getSessionClip(session, measurementStartMs, measurementEndMs)
+      : null;
     const measurementFraction = measurementClip?.fraction ?? 0;
     totalWallSeconds += session.wallSeconds * rangeClip.fraction;
     totalEffectiveSeconds += session.effectiveSeconds * rangeClip.fraction;
@@ -794,10 +818,9 @@ export function buildCodexAnalytics({
     (total, interval) => total + interval.usagePoints,
     0
   );
-  const measurementHours = Math.max(
-    0,
-    (measurementEndMs - measurementStartMs) / (60 * 60 * 1000)
-  );
+  const measurementHours = hasMeasurementWindow
+    ? Math.max(0, (measurementEndMs - measurementStartMs) / (60 * 60 * 1000))
+    : 0;
   const latestSample = relevantSamples
     .filter((sample) => sample.observedMs <= nowMs)
     .slice(-1)[0];
@@ -844,11 +867,9 @@ export function buildCodexAnalytics({
     };
     row.wallSeconds += session.wallSeconds * clip.fraction;
     row.effectiveSeconds += session.effectiveSeconds * clip.fraction;
-    const measurementClip = getSessionClip(
-      session,
-      measurementStartMs,
-      measurementEndMs
-    );
+    const measurementClip = hasMeasurementWindow
+      ? getSessionClip(session, measurementStartMs, measurementEndMs)
+      : null;
     if (measurementClip) {
       row.measuredWallSeconds += session.wallSeconds * measurementClip.fraction;
       row.measuredEffectiveSeconds +=
@@ -891,8 +912,12 @@ export function buildCodexAnalytics({
     measurementState,
     coverage: {
       requestedStartAt: new Date(requestedStartMs).toISOString(),
-      measurementStartAt: new Date(measurementStartMs).toISOString(),
-      measurementEndAt: new Date(measurementEndMs).toISOString(),
+      measurementStartAt: measurementStartMs
+        ? new Date(measurementStartMs).toISOString()
+        : null,
+      measurementEndAt: measurementEndMs
+        ? new Date(measurementEndMs).toISOString()
+        : null,
       measurementHours: round(measurementHours),
       requestedHours: round(requestedHours),
       timeCoverage: round(timeCoverage),
@@ -950,7 +975,21 @@ export function buildCodexAnalytics({
     byEffort,
     byProject,
     byRole,
-    daily
+    daily,
+    quotaTimeline: clippedIntervals.map((interval) => ({
+      startAt: interval.startAt,
+      endAt: interval.endAt,
+      usagePoints: round(interval.usagePoints),
+      currentUsedPercent: interval.currentUsedPercent,
+      resetsAt: interval.resetsAt
+    })),
+    quotaTrajectory: relevantSamples.map((sample) => ({
+      observedAt: sample.observedAt,
+      usedPercent: sample.usedPercent,
+      remainingPercent: sample.remainingPercent,
+      resetsAt: sample.resetsAt,
+      windowKey: sample.windowKey
+    }))
   };
   analytics.insights = buildInsights(analytics);
   return analytics;

--- a/src/features/codex/analytics.mjs
+++ b/src/features/codex/analytics.mjs
@@ -1,0 +1,923 @@
+const HOUR_SECONDS = 60 * 60;
+const DAY_MS = 24 * 60 * 60 * 1000;
+const DEFAULT_MAX_USAGE_GAP_HOURS = 3;
+const DEFAULT_MAX_USAGE_DELTA = 40;
+
+function finiteNumber(value, fallback = 0) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : fallback;
+}
+
+function positiveNumber(value, fallback = 0) {
+  return Math.max(0, finiteNumber(value, fallback));
+}
+
+function parseTime(value) {
+  if (value instanceof Date) {
+    const time = value.getTime();
+    return Number.isFinite(time) ? time : null;
+  }
+  const time = Date.parse(String(value || ''));
+  return Number.isFinite(time) ? time : null;
+}
+
+function normalizeLabel(value, fallback = 'unknown') {
+  const text = String(value || '')
+    .trim()
+    .toLowerCase();
+  return text || fallback;
+}
+
+function normalizeDisplayLabel(value, fallback = 'Unknown') {
+  const text = String(value || '').trim();
+  return text || fallback;
+}
+
+function clamp(value, min, max) {
+  return Math.min(max, Math.max(min, value));
+}
+
+function safeDivide(numerator, denominator) {
+  return denominator > 0 ? numerator / denominator : null;
+}
+
+function round(value, decimals = 4) {
+  if (!Number.isFinite(value)) return null;
+  const factor = 10 ** decimals;
+  return Math.round(value * factor) / factor;
+}
+
+function getUsageWindow(sample, windowKey) {
+  if (!sample || typeof sample !== 'object') return null;
+  if (sample[windowKey] && typeof sample[windowKey] === 'object') {
+    return sample[windowKey];
+  }
+  if (
+    sample.usageLimits &&
+    typeof sample.usageLimits === 'object' &&
+    sample.usageLimits[windowKey] &&
+    typeof sample.usageLimits[windowKey] === 'object'
+  ) {
+    return sample.usageLimits[windowKey];
+  }
+  return null;
+}
+
+export function normalizeCodexUsageSample(sample, windowKey = 'primary') {
+  const window = getUsageWindow(sample, windowKey);
+  if (!window) return null;
+  const observedAt =
+    sample.observedAt ||
+    sample.capturedAt ||
+    sample.updatedAt ||
+    sample.usageLimits?.observedAt;
+  const observedMs = parseTime(observedAt);
+  if (observedMs === null) return null;
+  let usedPercent = Number(window.usedPercent);
+  let remainingPercent = Number(window.remainingPercent);
+  if (!Number.isFinite(usedPercent) && Number.isFinite(remainingPercent)) {
+    usedPercent = 100 - remainingPercent;
+  }
+  if (!Number.isFinite(remainingPercent) && Number.isFinite(usedPercent)) {
+    remainingPercent = 100 - usedPercent;
+  }
+  if (!Number.isFinite(usedPercent)) return null;
+  const windowMinutes = positiveNumber(window.windowMinutes, 0);
+  return {
+    observedAt: new Date(observedMs).toISOString(),
+    observedMs,
+    usedPercent: clamp(usedPercent, 0, 100),
+    remainingPercent: Number.isFinite(remainingPercent)
+      ? clamp(remainingPercent, 0, 100)
+      : clamp(100 - usedPercent, 0, 100),
+    windowMinutes,
+    resetsAt: parseTime(window.resetsAt)
+      ? new Date(parseTime(window.resetsAt)).toISOString()
+      : null,
+    sourceMachineId: normalizeDisplayLabel(
+      sample.sourceMachineId || sample.machineId,
+      ''
+    ),
+    windowKey
+  };
+}
+
+function dedupeUsageSamples(samples) {
+  const byTimestamp = new Map();
+  samples.forEach((sample) => {
+    const key = String(sample.observedMs);
+    const existing = byTimestamp.get(key);
+    if (!existing || sample.usedPercent !== existing.usedPercent) {
+      byTimestamp.set(key, sample);
+    }
+  });
+  return [...byTimestamp.values()].sort(
+    (left, right) => left.observedMs - right.observedMs
+  );
+}
+
+function sameUsageWindow(previous, current) {
+  if (!previous || !current) return false;
+  if (
+    previous.windowMinutes > 0 &&
+    current.windowMinutes > 0 &&
+    previous.windowMinutes !== current.windowMinutes
+  ) {
+    return false;
+  }
+  if (previous.resetsAt && current.resetsAt) {
+    return previous.resetsAt === current.resetsAt;
+  }
+  return current.usedPercent >= previous.usedPercent;
+}
+
+export function computeCodexUsageIntervals(
+  usageHistory,
+  {
+    windowKey = 'primary',
+    maxGapHours = DEFAULT_MAX_USAGE_GAP_HOURS,
+    maxUsageDelta = DEFAULT_MAX_USAGE_DELTA
+  } = {}
+) {
+  const rawSamples = Array.isArray(usageHistory)
+    ? usageHistory
+    : Array.isArray(usageHistory?.samples)
+      ? usageHistory.samples
+      : [];
+  const samples = dedupeUsageSamples(
+    rawSamples
+      .map((sample) => normalizeCodexUsageSample(sample, windowKey))
+      .filter(Boolean)
+  );
+  const intervals = [];
+  let resetTransitions = 0;
+  let skippedLargeGaps = 0;
+  let skippedAnomalies = 0;
+  for (let index = 1; index < samples.length; index += 1) {
+    const previous = samples[index - 1];
+    const current = samples[index];
+    const durationMs = current.observedMs - previous.observedMs;
+    if (durationMs <= 0) continue;
+    if (!sameUsageWindow(previous, current)) {
+      resetTransitions += 1;
+      continue;
+    }
+    const durationHours = durationMs / (60 * 60 * 1000);
+    if (durationHours > maxGapHours) {
+      skippedLargeGaps += 1;
+      continue;
+    }
+    const delta = current.usedPercent - previous.usedPercent;
+    if (delta < 0 || delta > maxUsageDelta) {
+      skippedAnomalies += 1;
+      continue;
+    }
+    intervals.push({
+      startMs: previous.observedMs,
+      endMs: current.observedMs,
+      startAt: previous.observedAt,
+      endAt: current.observedAt,
+      durationHours,
+      usagePoints: delta,
+      previousUsedPercent: previous.usedPercent,
+      currentUsedPercent: current.usedPercent,
+      windowMinutes: current.windowMinutes || previous.windowMinutes,
+      resetsAt: current.resetsAt || previous.resetsAt,
+      windowKey
+    });
+  }
+  return {
+    windowKey,
+    samples,
+    intervals,
+    resetTransitions,
+    skippedLargeGaps,
+    skippedAnomalies,
+    coverageStartMs: samples.length ? samples[0].observedMs : null,
+    coverageEndMs: samples.length
+      ? samples[samples.length - 1].observedMs
+      : null,
+    totalUsagePoints: intervals.reduce(
+      (total, interval) => total + interval.usagePoints,
+      0
+    )
+  };
+}
+
+function isCodexEntry(entry) {
+  if (!entry || typeof entry !== 'object') return false;
+  const source = String(entry.source || '').toLowerCase();
+  const externalId = String(entry.externalId || entry.id || '').toLowerCase();
+  const description = String(entry.description || '').toLowerCase();
+  return (
+    source.includes('codex') ||
+    externalId.startsWith('codex-') ||
+    externalId.startsWith('codex:') ||
+    description.startsWith('codex:')
+  );
+}
+
+function inferSessionTimes(entry) {
+  const startMs =
+    parseTime(entry.startTime) ??
+    parseTime(entry.timestamp) ??
+    parseTime(entry.createdAt);
+  if (startMs === null) return null;
+  const explicitEndMs = parseTime(entry.endTime);
+  const elapsedSeconds = positiveNumber(
+    entry.elapsedSeconds ?? entry.wallSeconds ?? entry.codexWallSeconds,
+    0
+  );
+  const focusFactor = positiveNumber(
+    entry.focusFactor ?? entry.manualFactor,
+    0
+  );
+  const effectiveSeconds = positiveNumber(
+    entry.duration ?? entry.effectiveSeconds,
+    0
+  );
+  const inferredWallSeconds =
+    elapsedSeconds > 0
+      ? elapsedSeconds
+      : focusFactor > 0
+        ? effectiveSeconds / focusFactor
+        : effectiveSeconds;
+  const endMs =
+    explicitEndMs !== null && explicitEndMs > startMs
+      ? explicitEndMs
+      : startMs + Math.max(1, inferredWallSeconds) * 1000;
+  return {
+    startMs,
+    endMs,
+    wallSeconds: inferredWallSeconds,
+    effectiveSeconds,
+    focusFactor
+  };
+}
+
+function normalizeModelBreakdown(entry, session) {
+  const raw = Array.isArray(entry.codexModelBreakdown)
+    ? entry.codexModelBreakdown
+    : Array.isArray(entry.modelBreakdown)
+      ? entry.modelBreakdown
+      : [];
+  const rows = raw
+    .map((row) => {
+      const wallSeconds = positiveNumber(
+        row?.wallSeconds ?? row?.activeSeconds,
+        0
+      );
+      const effectiveSeconds = positiveNumber(row?.effectiveSeconds, 0);
+      return {
+        model: normalizeLabel(row?.model),
+        effort: normalizeLabel(row?.effort),
+        role: normalizeLabel(row?.role, 'parent'),
+        wallSeconds,
+        effectiveSeconds,
+        factor: positiveNumber(row?.creditedFactor ?? row?.factor, 0)
+      };
+    })
+    .filter(
+      (row) => row.wallSeconds > 0 || row.effectiveSeconds > 0 || row.factor > 0
+    );
+  if (rows.length) return rows;
+  return [
+    {
+      model: normalizeLabel(entry.codexModel ?? entry.model),
+      effort: normalizeLabel(entry.codexEffort ?? entry.effort),
+      role: normalizeLabel(entry.codexRole ?? entry.role, 'parent'),
+      wallSeconds: session.wallSeconds,
+      effectiveSeconds: session.effectiveSeconds,
+      factor: session.focusFactor
+    }
+  ];
+}
+
+export function normalizeCodexSessions(entries, projects = []) {
+  const projectNames = new Map(
+    (Array.isArray(projects) ? projects : []).map((project) => [
+      String(project?.id || ''),
+      normalizeDisplayLabel(project?.name, 'Unknown project')
+    ])
+  );
+  return (Array.isArray(entries) ? entries : [])
+    .filter(isCodexEntry)
+    .map((entry) => {
+      const times = inferSessionTimes(entry);
+      if (!times) return null;
+      const projectName =
+        normalizeDisplayLabel(
+          entry.timekeeperProjectName ||
+            entry.projectName ||
+            projectNames.get(String(entry.projectId || '')),
+          'Unknown project'
+        ) || 'Unknown project';
+      const session = {
+        id: String(entry.externalId || entry.id || `${times.startMs}`),
+        startMs: times.startMs,
+        endMs: times.endMs,
+        wallSeconds: times.wallSeconds,
+        effectiveSeconds: times.effectiveSeconds,
+        focusFactor: times.focusFactor,
+        projectName,
+        repoName: normalizeDisplayLabel(
+          entry.repoName || entry.codexRepoName || entry.projectKey,
+          projectName
+        ),
+        description: normalizeDisplayLabel(entry.description, 'Codex session'),
+        delegatedSessionCount: positiveNumber(
+          entry.codexDelegatedSessionCount ?? entry.delegatedSessionCount,
+          0
+        )
+      };
+      session.modelBreakdown = normalizeModelBreakdown(entry, session);
+      return session;
+    })
+    .filter(Boolean)
+    .sort((left, right) => left.startMs - right.startMs);
+}
+
+function overlapMs(startA, endA, startB, endB) {
+  return Math.max(0, Math.min(endA, endB) - Math.max(startA, startB));
+}
+
+function clipInterval(interval, rangeStartMs, rangeEndMs) {
+  const durationMs = interval.endMs - interval.startMs;
+  const clippedMs = overlapMs(
+    interval.startMs,
+    interval.endMs,
+    rangeStartMs,
+    rangeEndMs
+  );
+  if (durationMs <= 0 || clippedMs <= 0) return null;
+  const fraction = clippedMs / durationMs;
+  return {
+    ...interval,
+    startMs: Math.max(interval.startMs, rangeStartMs),
+    endMs: Math.min(interval.endMs, rangeEndMs),
+    durationHours: clippedMs / (60 * 60 * 1000),
+    usagePoints: interval.usagePoints * fraction
+  };
+}
+
+function getSessionClip(session, rangeStartMs, rangeEndMs) {
+  const spanMs = session.endMs - session.startMs;
+  const clippedMs = overlapMs(
+    session.startMs,
+    session.endMs,
+    rangeStartMs,
+    rangeEndMs
+  );
+  if (spanMs <= 0 || clippedMs <= 0) return null;
+  return {
+    fraction: clamp(clippedMs / spanMs, 0, 1),
+    clippedMs
+  };
+}
+
+function makeAggregate(key, label, extras = {}) {
+  return {
+    key,
+    label,
+    wallSeconds: 0,
+    effectiveSeconds: 0,
+    usagePoints: 0,
+    sessions: new Set(),
+    allocatedIntervals: new Set(),
+    parentWallSeconds: 0,
+    subagentWallSeconds: 0,
+    delegatedSessions: 0,
+    ...extras
+  };
+}
+
+function ensureAggregate(map, key, label, extras) {
+  if (!map.has(key)) {
+    map.set(key, makeAggregate(key, label, extras));
+  }
+  return map.get(key);
+}
+
+function addTimeToAggregate(aggregate, segment, session, fraction) {
+  const wallSeconds = segment.wallSeconds * fraction;
+  const effectiveSeconds = segment.effectiveSeconds * fraction;
+  aggregate.wallSeconds += wallSeconds;
+  aggregate.effectiveSeconds += effectiveSeconds;
+  aggregate.sessions.add(session.id);
+  aggregate.delegatedSessions += session.delegatedSessionCount * fraction;
+  if (segment.role === 'subagent') {
+    aggregate.subagentWallSeconds += wallSeconds;
+  } else {
+    aggregate.parentWallSeconds += wallSeconds;
+  }
+}
+
+function addUsageToAggregate(aggregate, usagePoints, intervalIndex) {
+  aggregate.usagePoints += usagePoints;
+  aggregate.allocatedIntervals.add(intervalIndex);
+}
+
+function getSegmentWeight(segment) {
+  if (segment.wallSeconds > 0) return segment.wallSeconds;
+  if (segment.effectiveSeconds > 0) return segment.effectiveSeconds;
+  return Math.max(0, segment.factor);
+}
+
+function finalizeAggregate(aggregate, totalAttributedUsagePoints) {
+  const wallHours = aggregate.wallSeconds / HOUR_SECONDS;
+  const effectiveHours = aggregate.effectiveSeconds / HOUR_SECONDS;
+  const usagePoints = aggregate.usagePoints;
+  let confidence = 'low';
+  if (
+    usagePoints >= 2 &&
+    wallHours >= 2 &&
+    aggregate.allocatedIntervals.size >= 3
+  ) {
+    confidence = 'high';
+  } else if (
+    usagePoints >= 0.5 &&
+    wallHours >= 0.5 &&
+    aggregate.allocatedIntervals.size >= 1
+  ) {
+    confidence = 'medium';
+  }
+  return {
+    ...aggregate,
+    sessions: aggregate.sessions.size,
+    allocatedIntervals: aggregate.allocatedIntervals.size,
+    wallHours: round(wallHours),
+    effectiveHours: round(effectiveHours),
+    usagePoints: round(usagePoints),
+    usagePerWallHour: round(safeDivide(usagePoints, wallHours)),
+    usagePerEffectiveHour: round(safeDivide(usagePoints, effectiveHours)),
+    effectiveHoursPerUsagePoint: round(
+      safeDivide(effectiveHours, usagePoints)
+    ),
+    wallHoursPerUsagePoint: round(safeDivide(wallHours, usagePoints)),
+    focusConversion: round(
+      safeDivide(aggregate.effectiveSeconds, aggregate.wallSeconds)
+    ),
+    usageShare: round(
+      safeDivide(usagePoints, totalAttributedUsagePoints)
+    ),
+    subagentShare: round(
+      safeDivide(
+        aggregate.subagentWallSeconds,
+        aggregate.parentWallSeconds + aggregate.subagentWallSeconds
+      )
+    ),
+    confidence
+  };
+}
+
+function median(values) {
+  const sorted = values
+    .filter(Number.isFinite)
+    .slice()
+    .sort((left, right) => left - right);
+  if (!sorted.length) return null;
+  const middle = Math.floor(sorted.length / 2);
+  if (sorted.length % 2) return sorted[middle];
+  return (sorted[middle - 1] + sorted[middle]) / 2;
+}
+
+function dateKey(timestampMs) {
+  return new Date(timestampMs).toISOString().slice(0, 10);
+}
+
+function rankRows(rows, selector, direction = 'desc') {
+  return rows
+    .filter((row) => Number.isFinite(selector(row)))
+    .slice()
+    .sort((left, right) => {
+      const delta = selector(left) - selector(right);
+      return direction === 'asc' ? delta : -delta;
+    });
+}
+
+function buildInsights(analytics) {
+  const insights = [];
+  const qualified = analytics.byModel.filter(
+    (row) => row.confidence !== 'low' && row.usagePoints > 0
+  );
+  const highestBurn = rankRows(
+    qualified,
+    (row) => row.usagePerWallHour
+  )[0];
+  if (highestBurn) {
+    insights.push({
+      tone: 'warning',
+      title: 'Highest measured quota burn',
+      detail: `${highestBurn.label} used ${highestBurn.usagePerWallHour.toFixed(2)} quota points per active hour.`
+    });
+  }
+  const bestYield = rankRows(
+    qualified,
+    (row) => row.effectiveHoursPerUsagePoint
+  )[0];
+  if (bestYield) {
+    insights.push({
+      tone: 'positive',
+      title: 'Best effective-time yield',
+      detail: `${bestYield.label} produced ${bestYield.effectiveHoursPerUsagePoint.toFixed(2)} effective hours per quota point.`
+    });
+  }
+  const topEffective = rankRows(
+    analytics.byModel,
+    (row) => row.effectiveHours
+  )[0];
+  if (topEffective) {
+    insights.push({
+      tone: 'neutral',
+      title: 'Largest effective-time contribution',
+      detail: `${topEffective.label} contributed ${topEffective.effectiveHours.toFixed(1)} effective hours in the selected range.`
+    });
+  }
+  if (analytics.overall.unknownModelShare >= 0.1) {
+    insights.push({
+      tone: 'warning',
+      title: 'Model attribution needs cleanup',
+      detail: `${Math.round(analytics.overall.unknownModelShare * 100)}% of effective time is assigned to an unknown model.`
+    });
+  }
+  if (
+    analytics.overall.attributionRate < 0.7 &&
+    analytics.overall.totalUsagePoints > 0
+  ) {
+    insights.push({
+      tone: 'warning',
+      title: 'Quota attribution is incomplete',
+      detail: `${Math.round(analytics.overall.attributionRate * 100)}% of measured quota change overlapped imported Codex activity.`
+    });
+  }
+  if (analytics.overall.projectedUsedAtReset !== null) {
+    const projected = analytics.overall.projectedUsedAtReset;
+    insights.push({
+      tone: projected >= 100 ? 'warning' : 'neutral',
+      title: 'Projected quota at reset',
+      detail: `At the measured burn rate, the primary window would reach approximately ${projected.toFixed(0)}% used by reset.`
+    });
+  }
+  return insights.slice(0, 6);
+}
+
+export function buildCodexAnalytics({
+  entries = [],
+  projects = [],
+  usageHistory = [],
+  rangeDays = 7,
+  now = new Date(),
+  windowKey = 'primary',
+  maxUsageGapHours = DEFAULT_MAX_USAGE_GAP_HOURS
+} = {}) {
+  const nowMs = parseTime(now) ?? Date.now();
+  const requestedRangeDays = clamp(
+    positiveNumber(rangeDays, 7),
+    1 / 24,
+    365
+  );
+  const requestedStartMs = nowMs - requestedRangeDays * DAY_MS;
+  const usage = computeCodexUsageIntervals(usageHistory, {
+    windowKey,
+    maxGapHours: maxUsageGapHours
+  });
+  const sessions = normalizeCodexSessions(entries, projects).filter(
+    (session) => session.endMs > requestedStartMs && session.startMs < nowMs
+  );
+  const relevantSampleCutoffMs =
+    requestedStartMs - maxUsageGapHours * 60 * 60 * 1000;
+  const relevantSamples = usage.samples.filter(
+    (sample) =>
+      sample.observedMs >= relevantSampleCutoffMs && sample.observedMs <= nowMs
+  );
+  const usageCoverageStartMs = relevantSamples.length
+    ? relevantSamples[0].observedMs
+    : null;
+  const usageCoverageEndMs = relevantSamples.length
+    ? relevantSamples[relevantSamples.length - 1].observedMs
+    : null;
+  const overlappingMeasurementStartMs =
+    usageCoverageStartMs === null
+      ? null
+      : Math.max(requestedStartMs, usageCoverageStartMs);
+  const overlappingMeasurementEndMs =
+    usageCoverageEndMs === null ? null : Math.min(nowMs, usageCoverageEndMs);
+  const hasMeasurementWindow =
+    overlappingMeasurementStartMs !== null &&
+    overlappingMeasurementEndMs !== null &&
+    overlappingMeasurementEndMs > overlappingMeasurementStartMs;
+  const measurementStartMs = hasMeasurementWindow
+    ? overlappingMeasurementStartMs
+    : requestedStartMs;
+  const measurementEndMs = hasMeasurementWindow
+    ? overlappingMeasurementEndMs
+    : nowMs;
+  const clippedIntervals = usage.intervals
+    .map((interval) =>
+      clipInterval(interval, measurementStartMs, measurementEndMs)
+    )
+    .filter(Boolean);
+
+  const maps = {
+    model: new Map(),
+    modelEffort: new Map(),
+    effort: new Map(),
+    project: new Map(),
+    role: new Map()
+  };
+  let unknownModelEffectiveSeconds = 0;
+  let totalEffectiveSeconds = 0;
+  let totalWallSeconds = 0;
+  let subagentWallSeconds = 0;
+  const sessionDurationsMinutes = [];
+  let mixedModelSessions = 0;
+
+  sessions.forEach((session) => {
+    const clip = getSessionClip(
+      session,
+      measurementStartMs,
+      measurementEndMs
+    );
+    if (!clip) return;
+    totalWallSeconds += session.wallSeconds * clip.fraction;
+    totalEffectiveSeconds += session.effectiveSeconds * clip.fraction;
+    sessionDurationsMinutes.push((session.wallSeconds * clip.fraction) / 60);
+    const distinctModels = new Set(
+      session.modelBreakdown
+        .filter((segment) => getSegmentWeight(segment) > 0)
+        .map((segment) => segment.model)
+    );
+    if (distinctModels.size > 1) mixedModelSessions += 1;
+    session.modelBreakdown.forEach((segment) => {
+      const model = segment.model;
+      const effort = segment.effort;
+      const role = segment.role;
+      const modelAggregate = ensureAggregate(maps.model, model, model);
+      const modelEffortKey = `${model}::${effort}`;
+      const modelEffortAggregate = ensureAggregate(
+        maps.modelEffort,
+        modelEffortKey,
+        `${model} · ${effort}`,
+        { model, effort }
+      );
+      const effortAggregate = ensureAggregate(maps.effort, effort, effort);
+      const projectAggregate = ensureAggregate(
+        maps.project,
+        session.projectName,
+        session.projectName
+      );
+      const roleAggregate = ensureAggregate(maps.role, role, role);
+      [
+        modelAggregate,
+        modelEffortAggregate,
+        effortAggregate,
+        projectAggregate,
+        roleAggregate
+      ].forEach((aggregate) =>
+        addTimeToAggregate(aggregate, segment, session, clip.fraction)
+      );
+      if (model === 'unknown') {
+        unknownModelEffectiveSeconds +=
+          segment.effectiveSeconds * clip.fraction;
+      }
+      if (role === 'subagent') {
+        subagentWallSeconds += segment.wallSeconds * clip.fraction;
+      }
+    });
+  });
+
+  let attributedUsagePoints = 0;
+  let unattributedUsagePoints = 0;
+  clippedIntervals.forEach((interval, intervalIndex) => {
+    if (interval.usagePoints <= 0) return;
+    const candidates = [];
+    sessions.forEach((session) => {
+      const overlap = overlapMs(
+        session.startMs,
+        session.endMs,
+        interval.startMs,
+        interval.endMs
+      );
+      const spanMs = session.endMs - session.startMs;
+      if (overlap <= 0 || spanMs <= 0) return;
+      const fraction = overlap / spanMs;
+      session.modelBreakdown.forEach((segment) => {
+        const weight = getSegmentWeight(segment) * fraction;
+        if (weight <= 0) return;
+        candidates.push({ session, segment, weight });
+      });
+    });
+    const totalWeight = candidates.reduce(
+      (total, candidate) => total + candidate.weight,
+      0
+    );
+    if (totalWeight <= 0) {
+      unattributedUsagePoints += interval.usagePoints;
+      return;
+    }
+    attributedUsagePoints += interval.usagePoints;
+    candidates.forEach(({ session, segment, weight }) => {
+      const allocated = interval.usagePoints * (weight / totalWeight);
+      const modelAggregate = ensureAggregate(
+        maps.model,
+        segment.model,
+        segment.model
+      );
+      const modelEffortKey = `${segment.model}::${segment.effort}`;
+      const modelEffortAggregate = ensureAggregate(
+        maps.modelEffort,
+        modelEffortKey,
+        `${segment.model} · ${segment.effort}`,
+        { model: segment.model, effort: segment.effort }
+      );
+      const effortAggregate = ensureAggregate(
+        maps.effort,
+        segment.effort,
+        segment.effort
+      );
+      const projectAggregate = ensureAggregate(
+        maps.project,
+        session.projectName,
+        session.projectName
+      );
+      const roleAggregate = ensureAggregate(
+        maps.role,
+        segment.role,
+        segment.role
+      );
+      [
+        modelAggregate,
+        modelEffortAggregate,
+        effortAggregate,
+        projectAggregate,
+        roleAggregate
+      ].forEach((aggregate) =>
+        addUsageToAggregate(aggregate, allocated, intervalIndex)
+      );
+    });
+  });
+
+  const finalizeMap = (map) =>
+    [...map.values()]
+      .map((aggregate) =>
+        finalizeAggregate(aggregate, attributedUsagePoints)
+      )
+      .sort((left, right) => right.effectiveHours - left.effectiveHours);
+  const byModel = finalizeMap(maps.model);
+  const byModelEffort = finalizeMap(maps.modelEffort);
+  const byEffort = finalizeMap(maps.effort);
+  const byProject = finalizeMap(maps.project);
+  const byRole = finalizeMap(maps.role);
+
+  const totalUsagePoints = clippedIntervals.reduce(
+    (total, interval) => total + interval.usagePoints,
+    0
+  );
+  const measurementHours = Math.max(
+    0,
+    (measurementEndMs - measurementStartMs) / (60 * 60 * 1000)
+  );
+  const latestSample = relevantSamples
+    .filter((sample) => sample.observedMs <= nowMs)
+    .slice(-1)[0];
+  const positiveMeasurementHours = measurementHours > 0 ? measurementHours : 0;
+  const burnPerHour = safeDivide(totalUsagePoints, positiveMeasurementHours);
+  let projectedUsedAtReset = null;
+  if (latestSample?.resetsAt && burnPerHour !== null) {
+    const resetMs = parseTime(latestSample.resetsAt);
+    if (resetMs !== null && resetMs > latestSample.observedMs) {
+      projectedUsedAtReset = round(
+        latestSample.usedPercent +
+          burnPerHour *
+            ((resetMs - latestSample.observedMs) / (60 * 60 * 1000)),
+        2
+      );
+    }
+  }
+
+  const dailyMap = new Map();
+  clippedIntervals.forEach((interval) => {
+    const key = dateKey(interval.endMs);
+    const row = dailyMap.get(key) || {
+      date: key,
+      usagePoints: 0,
+      wallSeconds: 0,
+      effectiveSeconds: 0
+    };
+    row.usagePoints += interval.usagePoints;
+    dailyMap.set(key, row);
+  });
+  sessions.forEach((session) => {
+    const clip = getSessionClip(
+      session,
+      measurementStartMs,
+      measurementEndMs
+    );
+    if (!clip) return;
+    const key = dateKey(Math.max(session.startMs, measurementStartMs));
+    const row = dailyMap.get(key) || {
+      date: key,
+      usagePoints: 0,
+      wallSeconds: 0,
+      effectiveSeconds: 0
+    };
+    row.wallSeconds += session.wallSeconds * clip.fraction;
+    row.effectiveSeconds += session.effectiveSeconds * clip.fraction;
+    dailyMap.set(key, row);
+  });
+  const daily = [...dailyMap.values()]
+    .sort((left, right) => left.date.localeCompare(right.date))
+    .map((row) => ({
+      ...row,
+      usagePoints: round(row.usagePoints),
+      wallHours: round(row.wallSeconds / HOUR_SECONDS),
+      effectiveHours: round(row.effectiveSeconds / HOUR_SECONDS),
+      usagePerWallHour: round(
+        safeDivide(row.usagePoints, row.wallSeconds / HOUR_SECONDS)
+      )
+    }));
+
+  let measurementState = 'collecting';
+  const attributionRate = safeDivide(
+    attributedUsagePoints,
+    totalUsagePoints
+  );
+  const requestedHours = requestedRangeDays * 24;
+  const timeCoverage = safeDivide(measurementHours, requestedHours);
+  if (hasMeasurementWindow && relevantSamples.length >= 2) {
+    measurementState =
+      clippedIntervals.length > 0 &&
+      (attributionRate ?? 1) >= 0.7 &&
+      (timeCoverage ?? 0) >= 0.5
+        ? 'ready'
+        : 'partial';
+  }
+  const analytics = {
+    generatedAt: new Date(nowMs).toISOString(),
+    rangeDays: requestedRangeDays,
+    windowKey,
+    measurementState,
+    coverage: {
+      requestedStartAt: new Date(requestedStartMs).toISOString(),
+      measurementStartAt: new Date(measurementStartMs).toISOString(),
+      measurementEndAt: new Date(measurementEndMs).toISOString(),
+      measurementHours: round(measurementHours),
+      requestedHours: round(requestedHours),
+      timeCoverage: round(timeCoverage),
+      sampleCount: relevantSamples.length,
+      intervalCount: clippedIntervals.length,
+      resetTransitions: usage.resetTransitions,
+      skippedLargeGaps: usage.skippedLargeGaps,
+      skippedAnomalies: usage.skippedAnomalies
+    },
+    overall: {
+      sessions: sessions.length,
+      totalWallHours: round(totalWallSeconds / HOUR_SECONDS),
+      totalEffectiveHours: round(totalEffectiveSeconds / HOUR_SECONDS),
+      totalUsagePoints: round(totalUsagePoints),
+      attributedUsagePoints: round(attributedUsagePoints),
+      unattributedUsagePoints: round(
+        Math.max(
+          unattributedUsagePoints,
+          totalUsagePoints - attributedUsagePoints
+        )
+      ),
+      attributionRate: round(attributionRate),
+      usagePerWallHour: round(
+        safeDivide(totalUsagePoints, totalWallSeconds / HOUR_SECONDS)
+      ),
+      effectiveHoursPerUsagePoint: round(
+        safeDivide(totalEffectiveSeconds / HOUR_SECONDS, totalUsagePoints)
+      ),
+      focusConversion: round(
+        safeDivide(totalEffectiveSeconds, totalWallSeconds)
+      ),
+      burnPerDay: round(burnPerHour === null ? null : burnPerHour * 24),
+      latestUsedPercent: latestSample?.usedPercent ?? null,
+      latestRemainingPercent: latestSample?.remainingPercent ?? null,
+      resetsAt: latestSample?.resetsAt ?? null,
+      projectedUsedAtReset,
+      medianSessionMinutes: round(median(sessionDurationsMinutes)),
+      sessionsPerEffectiveHour: round(
+        safeDivide(sessions.length, totalEffectiveSeconds / HOUR_SECONDS)
+      ),
+      mixedModelSessionShare: round(
+        safeDivide(mixedModelSessions, sessions.length)
+      ),
+      subagentWallShare: round(
+        safeDivide(subagentWallSeconds, totalWallSeconds)
+      ),
+      unknownModelShare: round(
+        safeDivide(unknownModelEffectiveSeconds, totalEffectiveSeconds)
+      )
+    },
+    byModel,
+    byModelEffort,
+    byEffort,
+    byProject,
+    byRole,
+    daily
+  };
+  analytics.insights = buildInsights(analytics);
+  return analytics;
+}

--- a/src/features/codex/analytics.mjs
+++ b/src/features/codex/analytics.mjs
@@ -381,6 +381,8 @@ function makeAggregate(key, label, extras = {}) {
     label,
     wallSeconds: 0,
     effectiveSeconds: 0,
+    measuredWallSeconds: 0,
+    measuredEffectiveSeconds: 0,
     usagePoints: 0,
     sessions: new Set(),
     allocatedIntervals: new Set(),
@@ -398,13 +400,23 @@ function ensureAggregate(map, key, label, extras) {
   return map.get(key);
 }
 
-function addTimeToAggregate(aggregate, segment, session, fraction) {
-  const wallSeconds = segment.wallSeconds * fraction;
-  const effectiveSeconds = segment.effectiveSeconds * fraction;
+function addTimeToAggregate(
+  aggregate,
+  segment,
+  session,
+  rangeFraction,
+  measurementFraction
+) {
+  const wallSeconds = segment.wallSeconds * rangeFraction;
+  const effectiveSeconds = segment.effectiveSeconds * rangeFraction;
   aggregate.wallSeconds += wallSeconds;
   aggregate.effectiveSeconds += effectiveSeconds;
+  aggregate.measuredWallSeconds += segment.wallSeconds * measurementFraction;
+  aggregate.measuredEffectiveSeconds +=
+    segment.effectiveSeconds * measurementFraction;
   aggregate.sessions.add(session.id);
-  aggregate.delegatedSessions += session.delegatedSessionCount * fraction;
+  aggregate.delegatedSessions +=
+    session.delegatedSessionCount * rangeFraction;
   if (segment.role === 'subagent') {
     aggregate.subagentWallSeconds += wallSeconds;
   } else {
@@ -426,17 +438,20 @@ function getSegmentWeight(segment) {
 function finalizeAggregate(aggregate, totalAttributedUsagePoints) {
   const wallHours = aggregate.wallSeconds / HOUR_SECONDS;
   const effectiveHours = aggregate.effectiveSeconds / HOUR_SECONDS;
+  const measuredWallHours = aggregate.measuredWallSeconds / HOUR_SECONDS;
+  const measuredEffectiveHours =
+    aggregate.measuredEffectiveSeconds / HOUR_SECONDS;
   const usagePoints = aggregate.usagePoints;
   let confidence = 'low';
   if (
     usagePoints >= 2 &&
-    wallHours >= 2 &&
+    measuredWallHours >= 2 &&
     aggregate.allocatedIntervals.size >= 3
   ) {
     confidence = 'high';
   } else if (
     usagePoints >= 0.5 &&
-    wallHours >= 0.5 &&
+    measuredWallHours >= 0.5 &&
     aggregate.allocatedIntervals.size >= 1
   ) {
     confidence = 'medium';
@@ -447,19 +462,23 @@ function finalizeAggregate(aggregate, totalAttributedUsagePoints) {
     allocatedIntervals: aggregate.allocatedIntervals.size,
     wallHours: round(wallHours),
     effectiveHours: round(effectiveHours),
+    measuredWallHours: round(measuredWallHours),
+    measuredEffectiveHours: round(measuredEffectiveHours),
     usagePoints: round(usagePoints),
-    usagePerWallHour: round(safeDivide(usagePoints, wallHours)),
-    usagePerEffectiveHour: round(safeDivide(usagePoints, effectiveHours)),
-    effectiveHoursPerUsagePoint: round(
-      safeDivide(effectiveHours, usagePoints)
+    usagePerWallHour: round(safeDivide(usagePoints, measuredWallHours)),
+    usagePerEffectiveHour: round(
+      safeDivide(usagePoints, measuredEffectiveHours)
     ),
-    wallHoursPerUsagePoint: round(safeDivide(wallHours, usagePoints)),
+    effectiveHoursPerUsagePoint: round(
+      safeDivide(measuredEffectiveHours, usagePoints)
+    ),
+    wallHoursPerUsagePoint: round(
+      safeDivide(measuredWallHours, usagePoints)
+    ),
     focusConversion: round(
       safeDivide(aggregate.effectiveSeconds, aggregate.wallSeconds)
     ),
-    usageShare: round(
-      safeDivide(usagePoints, totalAttributedUsagePoints)
-    ),
+    usageShare: round(safeDivide(usagePoints, totalAttributedUsagePoints)),
     subagentShare: round(
       safeDivide(
         aggregate.subagentWallSeconds,
@@ -571,11 +590,7 @@ export function buildCodexAnalytics({
   maxUsageGapHours = DEFAULT_MAX_USAGE_GAP_HOURS
 } = {}) {
   const nowMs = parseTime(now) ?? Date.now();
-  const requestedRangeDays = clamp(
-    positiveNumber(rangeDays, 7),
-    1 / 24,
-    365
-  );
+  const requestedRangeDays = clamp(positiveNumber(rangeDays, 7), 1 / 24, 365);
   const requestedStartMs = nowMs - requestedRangeDays * DAY_MS;
   const usage = computeCodexUsageIntervals(usageHistory, {
     windowKey,
@@ -628,20 +643,29 @@ export function buildCodexAnalytics({
   let unknownModelEffectiveSeconds = 0;
   let totalEffectiveSeconds = 0;
   let totalWallSeconds = 0;
+  let measuredEffectiveSeconds = 0;
+  let measuredWallSeconds = 0;
   let subagentWallSeconds = 0;
   const sessionDurationsMinutes = [];
   let mixedModelSessions = 0;
 
   sessions.forEach((session) => {
-    const clip = getSessionClip(
+    const rangeClip = getSessionClip(session, requestedStartMs, nowMs);
+    if (!rangeClip) return;
+    const measurementClip = getSessionClip(
       session,
       measurementStartMs,
       measurementEndMs
     );
-    if (!clip) return;
-    totalWallSeconds += session.wallSeconds * clip.fraction;
-    totalEffectiveSeconds += session.effectiveSeconds * clip.fraction;
-    sessionDurationsMinutes.push((session.wallSeconds * clip.fraction) / 60);
+    const measurementFraction = measurementClip?.fraction ?? 0;
+    totalWallSeconds += session.wallSeconds * rangeClip.fraction;
+    totalEffectiveSeconds += session.effectiveSeconds * rangeClip.fraction;
+    measuredWallSeconds += session.wallSeconds * measurementFraction;
+    measuredEffectiveSeconds +=
+      session.effectiveSeconds * measurementFraction;
+    sessionDurationsMinutes.push(
+      (session.wallSeconds * rangeClip.fraction) / 60
+    );
     const distinctModels = new Set(
       session.modelBreakdown
         .filter((segment) => getSegmentWeight(segment) > 0)
@@ -674,14 +698,20 @@ export function buildCodexAnalytics({
         projectAggregate,
         roleAggregate
       ].forEach((aggregate) =>
-        addTimeToAggregate(aggregate, segment, session, clip.fraction)
+        addTimeToAggregate(
+          aggregate,
+          segment,
+          session,
+          rangeClip.fraction,
+          measurementFraction
+        )
       );
       if (model === 'unknown') {
         unknownModelEffectiveSeconds +=
-          segment.effectiveSeconds * clip.fraction;
+          segment.effectiveSeconds * rangeClip.fraction;
       }
       if (role === 'subagent') {
-        subagentWallSeconds += segment.wallSeconds * clip.fraction;
+        subagentWallSeconds += segment.wallSeconds * rangeClip.fraction;
       }
     });
   });
@@ -802,27 +832,38 @@ export function buildCodexAnalytics({
       date: key,
       usagePoints: 0,
       wallSeconds: 0,
-      effectiveSeconds: 0
+      effectiveSeconds: 0,
+      measuredWallSeconds: 0,
+      measuredEffectiveSeconds: 0
     };
     row.usagePoints += interval.usagePoints;
     dailyMap.set(key, row);
   });
   sessions.forEach((session) => {
-    const clip = getSessionClip(
-      session,
-      measurementStartMs,
-      measurementEndMs
-    );
+    const clip = getSessionClip(session, requestedStartMs, nowMs);
     if (!clip) return;
-    const key = dateKey(Math.max(session.startMs, measurementStartMs));
+    const key = dateKey(Math.max(session.startMs, requestedStartMs));
     const row = dailyMap.get(key) || {
       date: key,
       usagePoints: 0,
       wallSeconds: 0,
-      effectiveSeconds: 0
+      effectiveSeconds: 0,
+      measuredWallSeconds: 0,
+      measuredEffectiveSeconds: 0
     };
     row.wallSeconds += session.wallSeconds * clip.fraction;
     row.effectiveSeconds += session.effectiveSeconds * clip.fraction;
+    const measurementClip = getSessionClip(
+      session,
+      measurementStartMs,
+      measurementEndMs
+    );
+    if (measurementClip) {
+      row.measuredWallSeconds +=
+        session.wallSeconds * measurementClip.fraction;
+      row.measuredEffectiveSeconds +=
+        session.effectiveSeconds * measurementClip.fraction;
+    }
     dailyMap.set(key, row);
   });
   const daily = [...dailyMap.values()]
@@ -832,16 +873,17 @@ export function buildCodexAnalytics({
       usagePoints: round(row.usagePoints),
       wallHours: round(row.wallSeconds / HOUR_SECONDS),
       effectiveHours: round(row.effectiveSeconds / HOUR_SECONDS),
+      measuredWallHours: round(row.measuredWallSeconds / HOUR_SECONDS),
+      measuredEffectiveHours: round(
+        row.measuredEffectiveSeconds / HOUR_SECONDS
+      ),
       usagePerWallHour: round(
-        safeDivide(row.usagePoints, row.wallSeconds / HOUR_SECONDS)
+        safeDivide(row.usagePoints, row.measuredWallSeconds / HOUR_SECONDS)
       )
     }));
 
   let measurementState = 'collecting';
-  const attributionRate = safeDivide(
-    attributedUsagePoints,
-    totalUsagePoints
-  );
+  const attributionRate = safeDivide(attributedUsagePoints, totalUsagePoints);
   const requestedHours = requestedRangeDays * 24;
   const timeCoverage = safeDivide(measurementHours, requestedHours);
   if (hasMeasurementWindow && relevantSamples.length >= 2) {
@@ -874,6 +916,10 @@ export function buildCodexAnalytics({
       sessions: sessions.length,
       totalWallHours: round(totalWallSeconds / HOUR_SECONDS),
       totalEffectiveHours: round(totalEffectiveSeconds / HOUR_SECONDS),
+      measuredWallHours: round(measuredWallSeconds / HOUR_SECONDS),
+      measuredEffectiveHours: round(
+        measuredEffectiveSeconds / HOUR_SECONDS
+      ),
       totalUsagePoints: round(totalUsagePoints),
       attributedUsagePoints: round(attributedUsagePoints),
       unattributedUsagePoints: round(
@@ -884,10 +930,10 @@ export function buildCodexAnalytics({
       ),
       attributionRate: round(attributionRate),
       usagePerWallHour: round(
-        safeDivide(totalUsagePoints, totalWallSeconds / HOUR_SECONDS)
+        safeDivide(totalUsagePoints, measuredWallSeconds / HOUR_SECONDS)
       ),
       effectiveHoursPerUsagePoint: round(
-        safeDivide(totalEffectiveSeconds / HOUR_SECONDS, totalUsagePoints)
+        safeDivide(measuredEffectiveSeconds / HOUR_SECONDS, totalUsagePoints)
       ),
       focusConversion: round(
         safeDivide(totalEffectiveSeconds, totalWallSeconds)

--- a/src/features/codex/analytics.mjs
+++ b/src/features/codex/analytics.mjs
@@ -415,8 +415,7 @@ function addTimeToAggregate(
   aggregate.measuredEffectiveSeconds +=
     segment.effectiveSeconds * measurementFraction;
   aggregate.sessions.add(session.id);
-  aggregate.delegatedSessions +=
-    session.delegatedSessionCount * rangeFraction;
+  aggregate.delegatedSessions += session.delegatedSessionCount * rangeFraction;
   if (segment.role === 'subagent') {
     aggregate.subagentWallSeconds += wallSeconds;
   } else {
@@ -472,9 +471,7 @@ function finalizeAggregate(aggregate, totalAttributedUsagePoints) {
     effectiveHoursPerUsagePoint: round(
       safeDivide(measuredEffectiveHours, usagePoints)
     ),
-    wallHoursPerUsagePoint: round(
-      safeDivide(measuredWallHours, usagePoints)
-    ),
+    wallHoursPerUsagePoint: round(safeDivide(measuredWallHours, usagePoints)),
     focusConversion: round(
       safeDivide(aggregate.effectiveSeconds, aggregate.wallSeconds)
     ),
@@ -519,10 +516,7 @@ function buildInsights(analytics) {
   const qualified = analytics.byModel.filter(
     (row) => row.confidence !== 'low' && row.usagePoints > 0
   );
-  const highestBurn = rankRows(
-    qualified,
-    (row) => row.usagePerWallHour
-  )[0];
+  const highestBurn = rankRows(qualified, (row) => row.usagePerWallHour)[0];
   if (highestBurn) {
     insights.push({
       tone: 'warning',
@@ -661,8 +655,7 @@ export function buildCodexAnalytics({
     totalWallSeconds += session.wallSeconds * rangeClip.fraction;
     totalEffectiveSeconds += session.effectiveSeconds * rangeClip.fraction;
     measuredWallSeconds += session.wallSeconds * measurementFraction;
-    measuredEffectiveSeconds +=
-      session.effectiveSeconds * measurementFraction;
+    measuredEffectiveSeconds += session.effectiveSeconds * measurementFraction;
     sessionDurationsMinutes.push(
       (session.wallSeconds * rangeClip.fraction) / 60
     );
@@ -789,9 +782,7 @@ export function buildCodexAnalytics({
 
   const finalizeMap = (map) =>
     [...map.values()]
-      .map((aggregate) =>
-        finalizeAggregate(aggregate, attributedUsagePoints)
-      )
+      .map((aggregate) => finalizeAggregate(aggregate, attributedUsagePoints))
       .sort((left, right) => right.effectiveHours - left.effectiveHours);
   const byModel = finalizeMap(maps.model);
   const byModelEffort = finalizeMap(maps.modelEffort);
@@ -859,8 +850,7 @@ export function buildCodexAnalytics({
       measurementEndMs
     );
     if (measurementClip) {
-      row.measuredWallSeconds +=
-        session.wallSeconds * measurementClip.fraction;
+      row.measuredWallSeconds += session.wallSeconds * measurementClip.fraction;
       row.measuredEffectiveSeconds +=
         session.effectiveSeconds * measurementClip.fraction;
     }
@@ -917,9 +907,7 @@ export function buildCodexAnalytics({
       totalWallHours: round(totalWallSeconds / HOUR_SECONDS),
       totalEffectiveHours: round(totalEffectiveSeconds / HOUR_SECONDS),
       measuredWallHours: round(measuredWallSeconds / HOUR_SECONDS),
-      measuredEffectiveHours: round(
-        measuredEffectiveSeconds / HOUR_SECONDS
-      ),
+      measuredEffectiveHours: round(measuredEffectiveSeconds / HOUR_SECONDS),
       totalUsagePoints: round(totalUsagePoints),
       attributedUsagePoints: round(attributedUsagePoints),
       unattributedUsagePoints: round(

--- a/src/styles/features.css
+++ b/src/styles/features.css
@@ -793,6 +793,13 @@ tr:nth-child(even) td {
   font-weight: 700;
 }
 
+.codex-page-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
 .codex-page-content {
   display: grid;
   gap: 1.5rem;

--- a/tests/smoke/timekeeper.spec.js
+++ b/tests/smoke/timekeeper.spec.js
@@ -1560,7 +1560,175 @@ test('service worker never caches private cross-origin API responses', async () 
   expect(serviceWorker).toContain(
     'if (requestUrl.origin !== sw.location.origin) return;'
   );
-  expect(serviceWorker).toContain("const CACHE_NAME = 'timekeeper-app-v19';");
+  expect(serviceWorker).toContain("const CACHE_NAME = 'timekeeper-app-v20';");
+  expect(serviceWorker).toContain("'./codex-analysis.html'");
+  expect(serviceWorker).toContain(
+    "'./src/features/codex/analysis-page.mjs?v=1'"
+  );
+  expect(serviceWorker).toContain(
+    "'./assets/timekeeper-codex-usage-history.json'"
+  );
+});
+
+test('Codex deep analysis renders windows, filters, charts, and CSV export', async ({
+  page
+}) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await freezeTime(page, '2026-08-13T12:00:00.000Z');
+  await seedLocalStorage(page, {
+    projects: [
+      projectFixture({ id: 'analysis-project', name: 'Analysis Project' })
+    ],
+    entries: [
+      {
+        id: 'analysis-session-a',
+        externalId: 'analysis-session-a',
+        source: 'Codex',
+        projectId: 'analysis-project',
+        startTime: '2026-08-13T09:00:00.000Z',
+        endTime: '2026-08-13T10:00:00.000Z',
+        elapsedSeconds: 3600,
+        duration: 2700,
+        focusFactor: 0.75,
+        codexModelBreakdown: [
+          {
+            role: 'parent',
+            model: 'model-a',
+            effort: 'high',
+            wallSeconds: 3600,
+            effectiveSeconds: 2700
+          }
+        ]
+      },
+      {
+        id: 'analysis-session-b',
+        externalId: 'analysis-session-b',
+        source: 'Codex',
+        projectId: 'analysis-project',
+        startTime: '2026-08-13T10:00:00.000Z',
+        endTime: '2026-08-13T11:00:00.000Z',
+        elapsedSeconds: 3600,
+        duration: 1800,
+        focusFactor: 0.5,
+        codexModelBreakdown: [
+          {
+            role: 'parent',
+            model: 'model-b',
+            effort: 'medium',
+            wallSeconds: 3600,
+            effectiveSeconds: 1800
+          }
+        ]
+      }
+    ],
+    codexIntegration: {
+      usageLimits: {
+        observedAt: '2026-08-13T12:00:00.000Z',
+        primary: {
+          usedPercent: 16,
+          remainingPercent: 84,
+          windowMinutes: 10080,
+          resetsAt: '2026-08-20T00:00:00.000Z'
+        },
+        secondary: {
+          usedPercent: 24,
+          remainingPercent: 76,
+          windowMinutes: 1440,
+          resetsAt: '2026-08-14T00:00:00.000Z'
+        }
+      }
+    }
+  });
+  await page.route('**/assets/timekeeper-codex-usage-history.json**', (route) =>
+    route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({
+        samples: [
+          {
+            observedAt: '2026-08-13T09:00:00.000Z',
+            primary: {
+              usedPercent: 10,
+              remainingPercent: 90,
+              windowMinutes: 10080,
+              resetsAt: '2026-08-20T00:00:00.000Z'
+            },
+            secondary: {
+              usedPercent: 20,
+              remainingPercent: 80,
+              windowMinutes: 1440,
+              resetsAt: '2026-08-14T00:00:00.000Z'
+            }
+          },
+          {
+            observedAt: '2026-08-13T10:00:00.000Z',
+            primary: {
+              usedPercent: 12,
+              remainingPercent: 88,
+              windowMinutes: 10080,
+              resetsAt: '2026-08-20T00:00:00.000Z'
+            },
+            secondary: {
+              usedPercent: 22,
+              remainingPercent: 78,
+              windowMinutes: 1440,
+              resetsAt: '2026-08-14T00:00:00.000Z'
+            }
+          }
+        ]
+      })
+    })
+  );
+
+  await page.goto('/codex-analysis.html');
+  await expect(
+    page.getByRole('heading', { name: 'Codex Analysis' })
+  ).toBeVisible();
+  await expect(page.locator('#windowSelect')).toHaveValue('primary');
+  await expect(page.locator('#modelTable tbody tr')).toHaveCount(2);
+
+  const canvasState = await page.evaluate(() =>
+    /** @type {HTMLCanvasElement[]} */ ([
+      ...document.querySelectorAll('.chart-canvas')
+    ]).map((canvas) => {
+      const context = canvas.getContext('2d');
+      const pixels = context.getImageData(
+        0,
+        0,
+        canvas.width,
+        canvas.height
+      ).data;
+      return {
+        width: canvas.width,
+        height: canvas.height,
+        hasInk: [...pixels].some((value, index) => index % 4 === 3 && value > 0)
+      };
+    })
+  );
+  expect(canvasState).toHaveLength(5);
+  expect(
+    canvasState.every(
+      (canvas) => canvas.width > 0 && canvas.height > 0 && canvas.hasInk
+    )
+  ).toBe(true);
+
+  await page.locator('#windowSelect').selectOption('secondary');
+  await expect(page.locator('#metricCards')).toContainText('24% used');
+  await page.locator('#filterModel').selectOption('model-a');
+  await expect(page.locator('#modelTable tbody tr')).toHaveCount(1);
+  await expect(page.locator('#modelTable')).toContainText('model-a');
+
+  const downloadPromise = page.waitForEvent('download');
+  await page.locator('#exportCsv').click();
+  const download = await downloadPromise;
+  expect(download.suggestedFilename()).toContain('secondary');
+  const csv = await download.createReadStream();
+  expect(csv).toBeTruthy();
+
+  expect(
+    await page.evaluate(
+      () => document.documentElement.scrollWidth <= window.innerWidth + 1
+    )
+  ).toBe(true);
 });
 
 test('mobile Company tab loads private priorities and queues safe steering', async ({
@@ -2110,7 +2278,8 @@ test('mobile Company tab presents missions before the next priority', async ({
         evidence_fingerprint: 'evidence-avantor-delivery-1',
         project: 'Avantor',
         objective: 'Finish the tested camera configuration for the customer.',
-        done_when: 'The tested configuration is available in a verified local commit.',
+        done_when:
+          'The tested configuration is available in a verified local commit.',
         status: 'active',
         step_count: 1,
         latest_update: 'Implemented the supported device configuration.',
@@ -2124,7 +2293,8 @@ test('mobile Company tab presents missions before the next priority', async ({
           evidence_fingerprint: 'evidence-avantor-delivery-1',
           project: 'Avantor',
           objective: 'Finish the tested camera configuration for the customer.',
-          done_when: 'The tested configuration is available in a verified local commit.',
+          done_when:
+            'The tested configuration is available in a verified local commit.',
           status: 'active',
           step_count: 1,
           latest_update: 'Implemented the supported device configuration.',
@@ -2248,7 +2418,9 @@ test('mobile Company tab presents missions before the next priority', async ({
     return Object.fromEntries(
       ['Working now', 'Completed for you', 'Needs you'].map((label) => [
         label,
-        headings.find((heading) => heading.textContent === label)?.getBoundingClientRect().top
+        headings
+          .find((heading) => heading.textContent === label)
+          ?.getBoundingClientRect().top
       ])
     );
   });
@@ -2277,9 +2449,13 @@ test('mobile Company tab presents missions before the next priority', async ({
     viewportWidth: window.innerWidth,
     scrollWidth: document.documentElement.scrollWidth,
     minimumActionHeight: Math.min(
-      ...[...document.querySelectorAll('#companyPageContent .company-action-grid .btn')].map(
-        (button) => button.getBoundingClientRect().height
-      ).filter((height) => height > 0)
+      ...[
+        ...document.querySelectorAll(
+          '#companyPageContent .company-action-grid .btn'
+        )
+      ]
+        .map((button) => button.getBoundingClientRect().height)
+        .filter((height) => height > 0)
     )
   }));
   expect(layout.scrollWidth).toBeLessThanOrEqual(layout.viewportWidth + 2);

--- a/tests/unit/codex-analytics.test.mjs
+++ b/tests/unit/codex-analytics.test.mjs
@@ -1,0 +1,188 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  buildCodexAnalytics,
+  computeCodexUsageIntervals,
+  normalizeCodexSessions
+} from '../../src/features/codex/analytics.mjs';
+
+const RESET_ONE = '2026-08-20T00:00:00.000Z';
+const RESET_TWO = '2026-08-27T00:00:00.000Z';
+
+function sample(observedAt, usedPercent, resetsAt = RESET_ONE) {
+  return {
+    observedAt,
+    primary: {
+      usedPercent,
+      remainingPercent: 100 - usedPercent,
+      windowMinutes: 10080,
+      resetsAt
+    }
+  };
+}
+
+function codexEntry({
+  id,
+  startTime,
+  endTime,
+  model,
+  effort = 'high',
+  wallSeconds = 3600,
+  effectiveSeconds = 1800,
+  projectId = 'project-1'
+}) {
+  return {
+    id,
+    externalId: id,
+    source: 'Codex',
+    projectId,
+    startTime,
+    endTime,
+    elapsedSeconds: wallSeconds,
+    duration: effectiveSeconds,
+    focusFactor: effectiveSeconds / wallSeconds,
+    codexModelBreakdown: [
+      {
+        role: 'parent',
+        model,
+        effort,
+        wallSeconds,
+        effectiveSeconds
+      }
+    ]
+  };
+}
+
+test('usage intervals exclude quota resets and preserve positive deltas', () => {
+  const result = computeCodexUsageIntervals([
+    sample('2026-08-13T08:00:00.000Z', 10),
+    sample('2026-08-13T09:00:00.000Z', 12),
+    sample('2026-08-13T10:00:00.000Z', 1, RESET_TWO),
+    sample('2026-08-13T11:00:00.000Z', 3, RESET_TWO)
+  ]);
+
+  assert.equal(result.intervals.length, 2);
+  assert.equal(result.totalUsagePoints, 4);
+  assert.equal(result.resetTransitions, 1);
+});
+
+test('normalizes imported TimeKeeper Codex entries and their model breakdown', () => {
+  const sessions = normalizeCodexSessions(
+    [
+      codexEntry({
+        id: 'codex-a',
+        startTime: '2026-08-13T08:00:00.000Z',
+        endTime: '2026-08-13T09:00:00.000Z',
+        model: 'GPT-5.6-Luna',
+        effectiveSeconds: 2700
+      })
+    ],
+    [{ id: 'project-1', name: 'IFLAI' }]
+  );
+
+  assert.equal(sessions.length, 1);
+  assert.equal(sessions[0].projectName, 'IFLAI');
+  assert.equal(sessions[0].modelBreakdown[0].model, 'gpt-5.6-luna');
+  assert.equal(sessions[0].modelBreakdown[0].effectiveSeconds, 2700);
+});
+
+test('ranks quota burn and effective-time yield by model', () => {
+  const entries = [
+    codexEntry({
+      id: 'codex-a',
+      startTime: '2026-08-13T08:00:00.000Z',
+      endTime: '2026-08-13T09:00:00.000Z',
+      model: 'model-a',
+      effectiveSeconds: 1800
+    }),
+    codexEntry({
+      id: 'codex-b',
+      startTime: '2026-08-13T09:00:00.000Z',
+      endTime: '2026-08-13T10:00:00.000Z',
+      model: 'model-b',
+      effectiveSeconds: 3600
+    })
+  ];
+  const usageHistory = [
+    sample('2026-08-13T08:00:00.000Z', 10),
+    sample('2026-08-13T09:00:00.000Z', 13),
+    sample('2026-08-13T10:00:00.000Z', 14)
+  ];
+  const analytics = buildCodexAnalytics({
+    entries,
+    projects: [{ id: 'project-1', name: 'IFLAI' }],
+    usageHistory,
+    rangeDays: 1,
+    now: new Date('2026-08-13T10:00:00.000Z')
+  });
+
+  const modelA = analytics.byModel.find((row) => row.key === 'model-a');
+  const modelB = analytics.byModel.find((row) => row.key === 'model-b');
+  assert.equal(modelA.usagePoints, 3);
+  assert.equal(modelB.usagePoints, 1);
+  assert.equal(modelA.usagePerWallHour, 3);
+  assert.equal(modelB.usagePerWallHour, 1);
+  assert.equal(modelA.effectiveHoursPerUsagePoint, 0.1667);
+  assert.equal(modelB.effectiveHoursPerUsagePoint, 1);
+  assert.equal(analytics.overall.attributionRate, 1);
+  assert.equal(analytics.measurementState, 'partial');
+});
+
+test('allocates a mixed-session quota delta by model active time', () => {
+  const entry = {
+    id: 'codex-mixed',
+    externalId: 'codex-mixed',
+    source: 'Codex',
+    projectId: 'project-1',
+    startTime: '2026-08-13T08:00:00.000Z',
+    endTime: '2026-08-13T09:00:00.000Z',
+    elapsedSeconds: 3600,
+    duration: 2400,
+    codexModelBreakdown: [
+      {
+        role: 'parent',
+        model: 'model-a',
+        effort: 'high',
+        wallSeconds: 2700,
+        effectiveSeconds: 1800
+      },
+      {
+        role: 'subagent',
+        model: 'model-b',
+        effort: 'medium',
+        wallSeconds: 900,
+        effectiveSeconds: 600
+      }
+    ]
+  };
+  const analytics = buildCodexAnalytics({
+    entries: [entry],
+    projects: [{ id: 'project-1', name: 'IFLAI' }],
+    usageHistory: [
+      sample('2026-08-13T08:00:00.000Z', 10),
+      sample('2026-08-13T09:00:00.000Z', 14)
+    ],
+    rangeDays: 1,
+    now: new Date('2026-08-13T09:00:00.000Z')
+  });
+
+  const modelA = analytics.byModel.find((row) => row.key === 'model-a');
+  const modelB = analytics.byModel.find((row) => row.key === 'model-b');
+  assert.equal(modelA.usagePoints, 3);
+  assert.equal(modelB.usagePoints, 1);
+  assert.equal(analytics.overall.subagentWallShare, 0.25);
+});
+
+test('reports collecting state before two usage samples exist', () => {
+  const analytics = buildCodexAnalytics({
+    entries: [],
+    usageHistory: [sample('2026-08-13T09:00:00.000Z', 10)],
+    rangeDays: 7,
+    now: new Date('2026-08-13T10:00:00.000Z')
+  });
+
+  assert.equal(analytics.measurementState, 'collecting');
+  assert.equal(analytics.overall.totalUsagePoints, 0);
+  assert.equal(analytics.coverage.sampleCount, 1);
+});

--- a/tests/unit/codex-analytics.test.mjs
+++ b/tests/unit/codex-analytics.test.mjs
@@ -186,3 +186,40 @@ test('reports collecting state before two usage samples exist', () => {
   assert.equal(analytics.overall.totalUsagePoints, 0);
   assert.equal(analytics.coverage.sampleCount, 1);
 });
+
+test('keeps full-range time totals separate from measured quota denominators', () => {
+  const entries = [
+    codexEntry({
+      id: 'codex-old',
+      startTime: '2026-08-13T02:00:00.000Z',
+      endTime: '2026-08-13T03:00:00.000Z',
+      model: 'model-a',
+      effectiveSeconds: 1800
+    }),
+    codexEntry({
+      id: 'codex-measured',
+      startTime: '2026-08-13T09:00:00.000Z',
+      endTime: '2026-08-13T10:00:00.000Z',
+      model: 'model-a',
+      effectiveSeconds: 3600
+    })
+  ];
+  const analytics = buildCodexAnalytics({
+    entries,
+    projects: [{ id: 'project-1', name: 'IFLAI' }],
+    usageHistory: [
+      sample('2026-08-13T09:00:00.000Z', 10),
+      sample('2026-08-13T10:00:00.000Z', 12)
+    ],
+    rangeDays: 1,
+    now: new Date('2026-08-13T10:00:00.000Z')
+  });
+
+  const model = analytics.byModel.find((row) => row.key === 'model-a');
+  assert.equal(model.effectiveHours, 1.5);
+  assert.equal(model.measuredEffectiveHours, 1);
+  assert.equal(model.usagePoints, 2);
+  assert.equal(model.effectiveHoursPerUsagePoint, 0.5);
+  assert.equal(analytics.overall.totalEffectiveHours, 1.5);
+  assert.equal(analytics.overall.measuredEffectiveHours, 1);
+});

--- a/tests/unit/codex-analytics.test.mjs
+++ b/tests/unit/codex-analytics.test.mjs
@@ -6,6 +6,7 @@ import {
   computeCodexUsageIntervals,
   normalizeCodexSessions
 } from '../../src/features/codex/analytics.mjs';
+import { buildCsv } from '../../src/features/codex/analysis-page.mjs';
 
 const RESET_ONE = '2026-08-20T00:00:00.000Z';
 const RESET_TWO = '2026-08-27T00:00:00.000Z';
@@ -18,6 +19,18 @@ function sample(observedAt, usedPercent, resetsAt = RESET_ONE) {
       remainingPercent: 100 - usedPercent,
       windowMinutes: 10080,
       resetsAt
+    }
+  };
+}
+
+function sampleWithSecondary(observedAt, primaryUsed, secondaryUsed) {
+  return {
+    ...sample(observedAt, primaryUsed),
+    secondary: {
+      usedPercent: secondaryUsed,
+      remainingPercent: 100 - secondaryUsed,
+      windowMinutes: 1440,
+      resetsAt: '2026-08-14T00:00:00.000Z'
     }
   };
 }
@@ -60,6 +73,19 @@ test('usage intervals exclude quota resets and preserve positive deltas', () => 
     sample('2026-08-13T09:00:00.000Z', 12),
     sample('2026-08-13T10:00:00.000Z', 1, RESET_TWO),
     sample('2026-08-13T11:00:00.000Z', 3, RESET_TWO)
+  ]);
+
+  assert.equal(result.intervals.length, 2);
+  assert.equal(result.totalUsagePoints, 4);
+  assert.equal(result.resetTransitions, 1);
+});
+
+test('tolerates small reset timestamp jitter without creating false resets', () => {
+  const result = computeCodexUsageIntervals([
+    sample('2026-08-13T08:00:00.000Z', 10, '2026-08-20T00:00:00.000Z'),
+    sample('2026-08-13T09:00:00.000Z', 12, '2026-08-20T00:00:04.000Z'),
+    sample('2026-08-13T10:00:00.000Z', 1, RESET_TWO),
+    sample('2026-08-13T11:00:00.000Z', 3, '2026-08-27T00:00:04.000Z')
   ]);
 
   assert.equal(result.intervals.length, 2);
@@ -125,6 +151,10 @@ test('ranks quota burn and effective-time yield by model', () => {
   assert.equal(modelB.usagePerWallHour, 1);
   assert.equal(modelA.effectiveHoursPerUsagePoint, 0.1667);
   assert.equal(modelB.effectiveHoursPerUsagePoint, 1);
+  assert.equal(
+    analytics.byModel.reduce((total, row) => total + row.usagePoints, 0),
+    analytics.overall.attributedUsagePoints
+  );
   assert.equal(analytics.overall.attributionRate, 1);
   assert.equal(analytics.measurementState, 'partial');
 });
@@ -172,11 +202,151 @@ test('allocates a mixed-session quota delta by model active time', () => {
   assert.equal(modelA.usagePoints, 3);
   assert.equal(modelB.usagePoints, 1);
   assert.equal(analytics.overall.subagentWallShare, 0.25);
+  assert.equal(
+    analytics.byModel.reduce((total, row) => total + row.usagePoints, 0),
+    analytics.overall.attributedUsagePoints
+  );
+});
+
+test('supports secondary quota windows through the same attribution path', () => {
+  const analytics = buildCodexAnalytics({
+    entries: [
+      codexEntry({
+        id: 'codex-secondary',
+        startTime: '2026-08-13T08:00:00.000Z',
+        endTime: '2026-08-13T10:00:00.000Z',
+        model: 'model-secondary'
+      })
+    ],
+    projects: [{ id: 'project-1', name: 'IFLAI' }],
+    usageHistory: [
+      sampleWithSecondary('2026-08-13T08:00:00.000Z', 10, 20),
+      sampleWithSecondary('2026-08-13T09:00:00.000Z', 11, 24),
+      sampleWithSecondary('2026-08-13T10:00:00.000Z', 12, 25)
+    ],
+    rangeDays: 1,
+    windowKey: 'secondary',
+    now: new Date('2026-08-13T10:00:00.000Z')
+  });
+
+  assert.equal(analytics.windowKey, 'secondary');
+  assert.equal(analytics.overall.totalUsagePoints, 5);
+  assert.equal(analytics.coverage.sampleCount, 3);
+});
+
+test('returns collecting state when the requested window has no history', () => {
+  const analytics = buildCodexAnalytics({
+    entries: [
+      codexEntry({
+        id: 'codex-no-secondary',
+        startTime: '2026-08-13T09:00:00.000Z',
+        endTime: '2026-08-13T10:00:00.000Z',
+        model: 'model-a'
+      })
+    ],
+    usageHistory: [sample('2026-08-13T09:00:00.000Z', 10)],
+    rangeDays: 1,
+    windowKey: 'secondary',
+    now: new Date('2026-08-13T10:00:00.000Z')
+  });
+
+  assert.equal(analytics.measurementState, 'collecting');
+  assert.equal(analytics.coverage.sampleCount, 0);
+  assert.equal(analytics.overall.totalUsagePoints, 0);
+});
+
+test('conserves quota allocation across concurrent sessions', () => {
+  const analytics = buildCodexAnalytics({
+    entries: [
+      codexEntry({
+        id: 'codex-concurrent-a',
+        startTime: '2026-08-13T08:00:00.000Z',
+        endTime: '2026-08-13T09:00:00.000Z',
+        model: 'model-a'
+      }),
+      codexEntry({
+        id: 'codex-concurrent-b',
+        startTime: '2026-08-13T08:00:00.000Z',
+        endTime: '2026-08-13T09:00:00.000Z',
+        model: 'model-b'
+      })
+    ],
+    projects: [{ id: 'project-1', name: 'IFLAI' }],
+    usageHistory: [
+      sample('2026-08-13T08:00:00.000Z', 10),
+      sample('2026-08-13T09:00:00.000Z', 14)
+    ],
+    rangeDays: 1,
+    now: new Date('2026-08-13T09:00:00.000Z')
+  });
+
+  assert.equal(
+    analytics.byModel.find((row) => row.key === 'model-a').usagePoints,
+    2
+  );
+  assert.equal(
+    analytics.byModel.find((row) => row.key === 'model-b').usagePoints,
+    2
+  );
+  assert.equal(analytics.overall.attributedUsagePoints, 4);
+});
+
+test('clips sessions at selected range boundaries without changing quota totals', () => {
+  const analytics = buildCodexAnalytics({
+    entries: [
+      codexEntry({
+        id: 'codex-clipped',
+        startTime: '2026-08-13T08:00:00.000Z',
+        endTime: '2026-08-13T10:00:00.000Z',
+        model: 'model-clipped'
+      })
+    ],
+    usageHistory: [
+      sample('2026-08-13T09:00:00.000Z', 10),
+      sample('2026-08-13T10:00:00.000Z', 11)
+    ],
+    rangeDays: 1 / 24,
+    now: new Date('2026-08-13T10:00:00.000Z')
+  });
+
+  assert.equal(analytics.overall.totalWallHours, 0.5);
+  assert.equal(analytics.overall.totalEffectiveHours, 0.25);
+  assert.equal(analytics.overall.measuredEffectiveHours, 0.25);
+  assert.equal(analytics.overall.totalUsagePoints, 1);
+});
+
+test('CSV export includes the selected window and measured columns', () => {
+  const csv = buildCsv({ windowKey: 'secondary' }, [
+    {
+      label: 'model-a',
+      effectiveHours: 1,
+      wallHours: 2,
+      measuredWallHours: 1.5,
+      measuredEffectiveHours: 0.75,
+      usagePoints: 3,
+      usagePerWallHour: 2,
+      effectiveHoursPerUsagePoint: 0.25,
+      focusConversion: 0.5,
+      sessions: 2,
+      confidence: 'medium'
+    }
+  ]);
+
+  assert.match(csv, /"window_key","model"/);
+  assert.match(csv, /secondary/);
+  assert.match(csv, /measured_effective_hours/);
+  assert.match(csv, /model-a/);
 });
 
 test('reports collecting state before two usage samples exist', () => {
+  const entry = codexEntry({
+    id: 'codex-unmeasured',
+    startTime: '2026-08-13T09:00:00.000Z',
+    endTime: '2026-08-13T10:00:00.000Z',
+    model: 'model-a'
+  });
   const analytics = buildCodexAnalytics({
-    entries: [],
+    entries: [entry],
     usageHistory: [sample('2026-08-13T09:00:00.000Z', 10)],
     rangeDays: 7,
     now: new Date('2026-08-13T10:00:00.000Z')
@@ -185,6 +355,37 @@ test('reports collecting state before two usage samples exist', () => {
   assert.equal(analytics.measurementState, 'collecting');
   assert.equal(analytics.overall.totalUsagePoints, 0);
   assert.equal(analytics.coverage.sampleCount, 1);
+  assert.equal(analytics.overall.measuredEffectiveHours, 0);
+  assert.equal(analytics.coverage.measurementHours, 0);
+});
+
+test('ignores zero-duration placeholder model rows', () => {
+  const entry = codexEntry({
+    id: 'codex-placeholder',
+    startTime: '2026-08-13T08:00:00.000Z',
+    endTime: '2026-08-13T09:00:00.000Z',
+    model: 'model-a'
+  });
+  entry.codexModelBreakdown.unshift({
+    role: 'parent',
+    model: 'unknown',
+    effort: 'unknown',
+    factor: 0.4,
+    wallSeconds: 0,
+    effectiveSeconds: 0
+  });
+
+  const analytics = buildCodexAnalytics({
+    entries: [entry],
+    projects: [{ id: 'project-1', name: 'IFLAI' }],
+    rangeDays: 1,
+    now: new Date('2026-08-13T10:00:00.000Z')
+  });
+
+  assert.equal(
+    analytics.byModel.some((row) => row.key === 'unknown'),
+    false
+  );
 });
 
 test('keeps full-range time totals separate from measured quota denominators', () => {

--- a/tests/unit/codex-usage-history.test.mjs
+++ b/tests/unit/codex-usage-history.test.mjs
@@ -1,0 +1,95 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  mergeUsageHistory,
+  normalizeUsageCandidate
+} from '../../scripts/codex-usage-history.mjs';
+
+function candidate(
+  observedAt,
+  usedPercent,
+  resetsAt = '2026-08-20T00:00:00.000Z'
+) {
+  return {
+    observedAt,
+    sourceMachineId: 'desktop-a',
+    primary: {
+      usedPercent,
+      remainingPercent: 100 - usedPercent,
+      windowMinutes: 10080,
+      resetsAt
+    },
+    secondary: null
+  };
+}
+
+test('normalizes the latest usage limits from a bridge inbox payload', () => {
+  const normalized = normalizeUsageCandidate(
+    {
+      machineId: 'desktop-a',
+      updatedAt: '2026-08-13T10:00:00.000Z',
+      usageLimits: {
+        observedAt: '2026-08-13T10:00:01.000Z',
+        primary: {
+          usedPercent: 18,
+          remainingPercent: 82,
+          windowMinutes: 10080,
+          resetsAt: '2026-08-20T00:00:00.000Z'
+        },
+        secondary: null
+      }
+    },
+    'desktop-a.json'
+  );
+
+  assert.equal(normalized.sourceMachineId, 'desktop-a');
+  assert.equal(normalized.primary.usedPercent, 18);
+  assert.equal(normalized.observedAt, '2026-08-13T10:00:01.000Z');
+});
+
+test('keeps state changes immediately but compresses unchanged heartbeats', () => {
+  const now = new Date('2026-08-13T12:00:00.000Z');
+  const existing = [candidate('2026-08-13T10:00:00.000Z', 18)];
+
+  const unchangedTooSoon = mergeUsageHistory(
+    existing,
+    [candidate('2026-08-13T10:20:00.000Z', 18)],
+    { now, heartbeatMinutes: 60 }
+  );
+  assert.equal(unchangedTooSoon.length, 1);
+
+  const stateChanged = mergeUsageHistory(
+    existing,
+    [candidate('2026-08-13T10:20:00.000Z', 19)],
+    { now, heartbeatMinutes: 60 }
+  );
+  assert.equal(stateChanged.length, 2);
+
+  const heartbeatDue = mergeUsageHistory(
+    existing,
+    [candidate('2026-08-13T11:01:00.000Z', 18)],
+    { now, heartbeatMinutes: 60 }
+  );
+  assert.equal(heartbeatDue.length, 2);
+});
+
+test('retains a bounded, chronological history', () => {
+  const existing = [
+    candidate('2026-08-13T08:00:00.000Z', 10),
+    candidate('2026-08-13T09:00:00.000Z', 11),
+    candidate('2026-08-13T10:00:00.000Z', 12)
+  ];
+  const merged = mergeUsageHistory(
+    existing,
+    [candidate('2026-08-13T11:00:00.000Z', 13)],
+    {
+      now: new Date('2026-08-13T12:00:00.000Z'),
+      maxSamples: 3
+    }
+  );
+
+  assert.equal(merged.length, 3);
+  assert.equal(merged[0].observedAt, '2026-08-13T09:00:00.000Z');
+  assert.equal(merged[2].primary.usedPercent, 13);
+});

--- a/tests/unit/codex-usage-history.test.mjs
+++ b/tests/unit/codex-usage-history.test.mjs
@@ -93,3 +93,30 @@ test('retains a bounded, chronological history', () => {
   assert.equal(merged[0].observedAt, '2026-08-13T09:00:00.000Z');
   assert.equal(merged[2].primary.usedPercent, 13);
 });
+
+test('backfill mode keeps historical state changes and deduplicates timestamps', () => {
+  const merged = mergeUsageHistory(
+    [candidate('2026-08-13T08:00:00.000Z', 10)],
+    [
+      candidate('2026-08-13T08:30:00.000Z', 10, '2026-08-20T00:00:04.000Z'),
+      candidate('2026-08-13T09:00:00.000Z', 11),
+      candidate('2026-08-13T09:00:00.000Z', 12),
+      candidate('2026-08-13T10:00:00.000Z', 12)
+    ],
+    {
+      now: new Date('2026-08-13T11:00:00.000Z'),
+      heartbeatMinutes: 60,
+      includeAllCandidates: true
+    }
+  );
+
+  assert.deepEqual(
+    merged.map((sample) => sample.observedAt),
+    [
+      '2026-08-13T08:00:00.000Z',
+      '2026-08-13T09:00:00.000Z',
+      '2026-08-13T10:00:00.000Z'
+    ]
+  );
+  assert.equal(merged[1].primary.usedPercent, 12);
+});


### PR DESCRIPTION
## Summary

Completes the measured Codex efficiency analysis on a dedicated route while preserving the existing local-first TimeKeeper data model.

## User-visible integration

- Adds a prominent Deep analysis action to the existing Codex page.
- Keeps direct access at `codex-analysis.html` with a clear return link.
- Adds 24-hour, 7-day, 30-day, and 90-day ranges.
- Adds primary and secondary quota-window selection; secondary is only offered when data exists.
- Adds model, effort, and project filters, minimum measured-time and quota-point thresholds, unknown-row visibility, sortable tables, charts, and filtered CSV export.
- Adds responsive mobile layout and keeps wide tables contained within their own horizontal scrollers.
- Adds quota burn, model burn/yield, model-effort time, project efficiency, and reset-safe quota trajectory charts.

## Measurement semantics

Usage means percentage points consumed in the observed Codex limit window. It is not tokens, cost, or billing, and no token estimate is invented from elapsed time or model names.

Full selected-range active/effective totals remain separate from measured active/effective time that overlaps quota history. Efficiency ratios use only measured denominators. Positive quota deltas are allocated proportionally across overlapping model activity; allocation is conserved. Resets, negative deltas, anomalous jumps, gaps over three hours, and periods without overlapping activity are excluded or reported as unattributed. Mixed-model sessions remain proportional estimates because imported model durations have no exact transition timestamps.

## History and backfill

- The scheduled collector samples primary and secondary windows every ten minutes, retains state changes immediately, compresses unchanged periods to hourly heartbeats, and keeps a bounded 90-day history.
- The one-time bounded Git backfill recovered 4,697 real usage-limit candidates and compressed them to 675 samples covering 23 July 2026 through 13 August 2026.
- Earlier inbox commits did not contain usable usage-limit snapshots and were not invented or reconstructed.
- Routine scheduled runs do not scan Git history; they read the current inbox only.

## PWA and validation

- Service-worker cache bumped to v20 and now includes the analysis route, modules, and usage-history asset.
- Offline direct-route reload was verified after the service worker took control; the dynamic history query also falls back to the cached asset.
- Local validation passed: lint, typecheck, 100 unit tests, 59 smoke tests, focused Codex tests, syntax checks, and scoped Prettier checks.
- Browser QA covered seeded persisted data, both windows, filters, nonblank chart canvases, CSV download, mobile width, and offline loading.

The PR remains a draft. The repository-wide `npm run check` still stops at the existing unrelated Prettier drift in 38 files outside this change; formatting for all touched files is clean.

## Remaining limitations

Quota efficiency becomes more trustworthy as new snapshots accumulate. Confidence and coverage diagnostics are intentionally visible, and low-confidence differences should remain directional. Exact token or billing metrics are not supported by the current imported data.