### PR TITLE
Add Company Operator request panel

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -3,7 +3,7 @@
 const sw = /** @type {ServiceWorkerGlobalScope} */ (
   /** @type {unknown} */ (self)
 );
-const CACHE_NAME = 'timekeeper-app-v24';
+const CACHE_NAME = 'timekeeper-app-v25';
 const APP_SHELL = [
   './',
   './index.html',

--- a/src/features/company-operator/core.mjs
+++ b/src/features/company-operator/core.mjs
@@ -13,6 +13,7 @@ const ALLOWED_ACTIONS = new Set([
   'mark_handled',
   'rate_result',
   'record_decision',
+  'request_work',
   'set_priority',
   'snooze',
   'work_next'
@@ -87,6 +88,17 @@ export function normalizeCompanyOperatorSnapshot(value = {}) {
     today: normalizeToday(source.today),
     companySummary: normalizeCompanySummary(companySummary),
     priorities,
+    requestProjects: Array.isArray(
+      source.request_projects || source.requestProjects
+    )
+      ? [
+          ...new Set(
+            (source.request_projects || source.requestProjects)
+              .map((value) => cleanText(value, 100))
+              .filter(Boolean)
+          )
+        ].slice(0, 20)
+      : [],
     missions: {
       status: cleanText(missions.status, 80),
       activeCount: toCount(missions.active_count ?? missions.activeCount),
@@ -315,6 +327,7 @@ export function buildCompanyOperatorCommand({
   } else {
     payload.params = {
       note: cleanText(paramsSource.note, 800),
+      project: cleanText(paramsSource.project, 100),
       until: cleanText(paramsSource.until, 80),
       dispatch_id: cleanText(paramsSource.dispatchId, 180),
       option_id: cleanText(paramsSource.optionId, 48),

--- a/src/features/company-operator/runtime.mjs
+++ b/src/features/company-operator/runtime.mjs
@@ -13,7 +13,7 @@ const SNAPSHOT_KEY = 'timekeeperCompanyOperatorSnapshot';
 const PENDING_KEY = 'timekeeperCompanyOperatorPendingCommands';
 const RECEIPTS_KEY = 'timekeeperCompanyOperatorReceipts';
 const POLL_INTERVAL_MS = 60 * 1000;
-const CODEX_ACTIONS = new Set(['add_direction', 'work_next']);
+const CODEX_ACTIONS = new Set(['add_direction', 'request_work', 'work_next']);
 const HIDE_PRIORITY_ACTIONS = new Set(['mark_handled', 'snooze', 'work_next']);
 
 export function createCompanyOperatorController({
@@ -25,6 +25,8 @@ export function createCompanyOperatorController({
   let busy = false;
   let active = false;
   let pollTimer = null;
+  let requestDraft = '';
+  let requestProject = '';
 
   connectButton?.addEventListener('click', () => configureConnection());
   refreshButton?.addEventListener('click', () => refresh({ announce: true }));
@@ -171,6 +173,59 @@ export function createCompanyOperatorController({
       showToast(priorityActionFeedback(action, params));
     } catch (error) {
       showToast(companyErrorMessage(error));
+    } finally {
+      busy = false;
+      updateButtons();
+      render();
+    }
+  }
+
+  async function queueCompanyRequest(note, project) {
+    const request = String(note || '').trim();
+    const selectedProject = String(project || '').trim();
+    if (!snapshot || !request || !selectedProject || busy) return false;
+    busy = true;
+    updateButtons();
+    const commandId = `mobile-${uuid()}`;
+    try {
+      const command = buildCompanyOperatorCommand({
+        commandId,
+        action: 'request_work',
+        snapshot,
+        params: {
+          note: request,
+          project: selectedProject
+        }
+      });
+      await writeRemoteJson(
+        `${getSettings().commandsPath}/${commandId}.json`,
+        command,
+        'Queue private TimeKeeper Company work request'
+      );
+      savePending([
+        ...loadPending(),
+        {
+          commandId,
+          action: 'request_work',
+          label: request.slice(0, 120),
+          issueId: '',
+          evidenceFingerprint: '',
+          missionId: '',
+          dispatchId: '',
+          project: command.params.project,
+          title: request.slice(0, 220),
+          status: 'queued',
+          queuedAt: new Date().toISOString()
+        }
+      ]);
+      requestDraft = '';
+      showToast(
+        'Request queued. Company Operator will apply its normal safety and verification gates.'
+      );
+      return true;
+    } catch (error) {
+      showToast(companyErrorMessage(error));
+      return false;
     } finally {
       busy = false;
       updateButtons();
@@ -492,6 +547,7 @@ export function createCompanyOperatorController({
     root.appendChild(statusBanner(freshness));
     const overview = companyOverviewCard();
     if (overview) root.appendChild(overview);
+    root.appendChild(companyRequestPanel());
     const dispatches = compactDispatchSections();
     const missions = missionSections();
     if (missions.working) root.appendChild(missions.working);
@@ -605,6 +661,102 @@ export function createCompanyOperatorController({
       section.appendChild(compactResultDestination(summary.destination));
     }
     return section;
+  }
+
+  function companyRequestPanel() {
+    const section = element('section', 'company-section company-request-panel');
+    section.appendChild(element('h3', '', 'Ask Company Operator'));
+    section.appendChild(
+      element(
+        'p',
+        'company-request-intro',
+        'Describe one concrete result. The request uses the existing Company Operator safety, approval, and verification gates.'
+      )
+    );
+
+    const form = element('form', 'company-request-form');
+    const requestLabel = element(
+      'label',
+      '',
+      'What should Company Operator do?'
+    );
+    requestLabel.htmlFor = 'companyOperatorRequest';
+    const requestInput = element('textarea', 'company-request-input');
+    requestInput.id = 'companyOperatorRequest';
+    requestInput.name = 'request';
+    requestInput.rows = 4;
+    requestInput.maxLength = 800;
+    requestInput.required = true;
+    requestInput.placeholder =
+      'Example: Update the customer delivery checklist and verify the result.';
+    requestInput.value = requestDraft;
+
+    const projectLabel = element('label', '', 'Project');
+    projectLabel.htmlFor = 'companyOperatorRequestProject';
+    const projectSelect = element('select', 'company-request-project');
+    projectSelect.id = 'companyOperatorRequestProject';
+    projectSelect.name = 'project';
+    companyRequestProjects().forEach((project) => {
+      const option = element('option', '', project);
+      option.value = project;
+      projectSelect.appendChild(option);
+    });
+    if (
+      [...projectSelect.options].some(
+        (option) => option.value === requestProject
+      )
+    ) {
+      projectSelect.value = requestProject;
+    } else {
+      requestProject = projectSelect.value;
+    }
+
+    const submit = button('Send request', 'primary', () => {});
+    submit.type = 'submit';
+    submit.disabled = busy || !requestDraft.trim() || !projectSelect.value;
+    requestInput.addEventListener('input', () => {
+      requestDraft = requestInput.value;
+      submit.disabled = busy || !requestDraft.trim() || !projectSelect.value;
+    });
+    projectSelect.addEventListener('change', () => {
+      requestProject = projectSelect.value;
+    });
+    form.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      if (busy || !requestInput.value.trim()) return;
+      submit.disabled = true;
+      await queueCompanyRequest(requestInput.value, projectSelect.value);
+    });
+
+    form.appendChild(requestLabel);
+    form.appendChild(requestInput);
+    form.appendChild(projectLabel);
+    form.appendChild(projectSelect);
+    form.appendChild(submit);
+    section.appendChild(form);
+    section.appendChild(
+      element(
+        'p',
+        'company-request-safety',
+        'This queues local, guarded Company work. It does not send email, publish, deploy, or approve commitments.'
+      )
+    );
+    return section;
+  }
+
+  function companyRequestProjects() {
+    const projects = [
+      snapshot.missions.primary?.project,
+      ...snapshot.priorities.map((priority) => priority.project),
+      ...snapshot.missions.active.map((mission) => mission.project),
+      ...snapshot.requestProjects,
+      ...snapshot.missions.completedToday.map((mission) => mission.project)
+    ];
+    return [
+      ...new Set(
+        projects.map((value) => String(value || '').trim()).filter(Boolean)
+      )
+    ].slice(0, 20);
   }
 
   function formatSourceAge(value) {
@@ -1255,6 +1407,9 @@ export function createCompanyOperatorController({
       return params.dispatchId
         ? 'Answer sent. Codex will resume this case.'
         : 'Direction sent to Codex.';
+    }
+    if (action === 'request_work') {
+      return 'Request queued. Company Operator will start it after the next bridge sync.';
     }
     if (action === 'rate_result') {
       return 'Feedback queued. It will shape future Company work after the next sync.';

--- a/src/main.mjs
+++ b/src/main.mjs
@@ -16988,7 +16988,7 @@ import {
       updatePwaStatusPanel();
     });
     navigator.serviceWorker
-      .register('./service-worker.js?v=24')
+      .register('./service-worker.js?v=25')
       .then((registration) => {
         pendingServiceWorkerRegistration = registration;
         if (registration.waiting) updatePwaStatusPanel();

--- a/src/styles/features.css
+++ b/src/styles/features.css
@@ -1085,6 +1085,68 @@ tr:nth-child(even) td {
   background: linear-gradient(145deg, #eff6ff, #ffffff 75%);
 }
 
+.company-request-panel {
+  border-color: #bfdbfe;
+  background: linear-gradient(145deg, #f8fbff, #ffffff 72%);
+}
+
+.company-request-intro,
+.company-request-safety {
+  margin: 0;
+  color: #475569;
+  line-height: 1.45;
+}
+
+.company-request-form {
+  display: grid;
+  gap: 0.55rem;
+  margin-top: 0.85rem;
+}
+
+.company-request-form label {
+  color: #334155;
+  font-size: 0.82rem;
+  font-weight: 750;
+}
+
+.company-request-input,
+.company-request-project {
+  box-sizing: border-box;
+  width: 100%;
+  min-height: 2.75rem;
+  border: 1px solid #cbd5e1;
+  border-radius: 0.7rem;
+  background: #ffffff;
+  color: #0f172a;
+  font: inherit;
+}
+
+.company-request-input {
+  min-height: 7rem;
+  padding: 0.75rem;
+  resize: vertical;
+}
+
+.company-request-project {
+  padding: 0 0.75rem;
+}
+
+.company-request-input:focus,
+.company-request-project:focus {
+  border-color: #2563eb;
+  outline: 3px solid rgba(37, 99, 235, 0.16);
+}
+
+.company-request-form .btn {
+  min-height: 2.9rem;
+  margin: 0.15rem 0 0;
+}
+
+.company-request-safety {
+  margin-top: 0.7rem;
+  font-size: 0.78rem;
+}
+
 .company-primary-card h3,
 .company-section h3,
 .company-empty-card h3 {

--- a/tests/smoke/timekeeper.spec.js
+++ b/tests/smoke/timekeeper.spec.js
@@ -1712,7 +1712,7 @@ test('service worker never caches private cross-origin API responses', async () 
   expect(serviceWorker).toContain(
     'if (requestUrl.origin !== sw.location.origin) return;'
   );
-  expect(serviceWorker).toContain("const CACHE_NAME = 'timekeeper-app-v24';");
+  expect(serviceWorker).toContain("const CACHE_NAME = 'timekeeper-app-v25';");
   expect(serviceWorker).toContain("'./src/main.mjs?v=20'");
   expect(serviceWorker).toContain(
     "url.searchParams.set('timekeeper-update', '22')"
@@ -1725,7 +1725,7 @@ test('service worker never caches private cross-origin API responses', async () 
     "'./assets/timekeeper-codex-usage-history.json'"
   );
   const mainSource = await readFile('src/main.mjs', 'utf8');
-  expect(mainSource).toContain(".register('./service-worker.js?v=24')");
+  expect(mainSource).toContain(".register('./service-worker.js?v=25')");
 });
 
 test('Codex deep analysis renders windows, filters, charts, and CSV export', async ({
@@ -1917,6 +1917,134 @@ test('Codex deep analysis renders windows, filters, charts, and CSV export', asy
   expect(
     await page.evaluate(
       () => document.documentElement.scrollWidth <= window.innerWidth + 1
+    )
+  ).toBe(true);
+});
+
+test('mobile Company request panel queues one bounded operator request', async ({
+  page
+}) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await freezeTime(page, '2026-08-14T09:30:00.000Z');
+  await seedLocalStorage(page, { projects: [], entries: [] });
+  await page.addInitScript(() => {
+    localStorage.setItem(
+      'timekeeperCompanyOperatorSettings',
+      JSON.stringify({
+        repository: 'Henrik-KM/timekeeper-private-context',
+        branch: 'main',
+        statePath: 'company-operator/state.json',
+        commandsPath: 'company-operator/commands',
+        receiptsPath: 'company-operator/receipts'
+      })
+    );
+    localStorage.setItem(
+      'timekeeperCompanyOperatorToken',
+      'github_pat_private_company_test'
+    );
+  });
+  const snapshot = {
+    schema_version: 1,
+    generated_at: '2026-08-14T09:29:00.000Z',
+    status: 'ready',
+    state_version: 'state-request-panel-1',
+    priorities: [
+      {
+        issue_id: 'priority:avantor',
+        evidence_fingerprint: 'evidence-avantor-1',
+        project: 'Avantor',
+        title: 'Prepare customer delivery',
+        next_action: 'Update the customer delivery checklist.'
+      }
+    ],
+    missions: { active: [] },
+    dispatches: { in_progress: [], recent: [] },
+    decisions: { pending: [] },
+    handled: { receipts: [] },
+    sources: { status: 'ready', attention_count: 0, items: [] }
+  };
+  const encodedSnapshot = Buffer.from(JSON.stringify(snapshot)).toString(
+    'base64'
+  );
+  await page.route('https://api.github.com/**', async (route) => {
+    const request = route.request();
+    if (
+      request.method() === 'GET' &&
+      request.url().includes('/contents/company-operator/state.json')
+    ) {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ content: encodedSnapshot, sha: 'state-sha' })
+      });
+      return;
+    }
+    if (
+      request.method() === 'GET' &&
+      request.url().includes('/contents/company-operator/receipts/')
+    ) {
+      await route.fulfill({ status: 404, body: '{}' });
+      return;
+    }
+    if (
+      request.method() === 'PUT' &&
+      request.url().includes('/contents/company-operator/commands/')
+    ) {
+      await route.fulfill({
+        status: 201,
+        contentType: 'application/json',
+        body: JSON.stringify({ content: { path: 'company-operator/commands' } })
+      });
+      return;
+    }
+    await route.fulfill({ status: 404, body: '{}' });
+  });
+
+  await page.goto('/#company');
+  const panel = page.locator('.company-request-panel');
+  await expect(
+    panel.getByRole('heading', { name: 'Ask Company Operator' })
+  ).toBeVisible();
+  const submit = panel.getByRole('button', { name: 'Send request' });
+  await expect(submit).toBeDisabled();
+  await panel.getByLabel('Project').selectOption('Avantor');
+  await panel
+    .getByLabel('What should Company Operator do?')
+    .fill('Update the customer delivery checklist and verify the result.');
+
+  const requestPromise = page.waitForRequest(
+    (request) =>
+      request.method() === 'PUT' &&
+      request.url().includes('/contents/company-operator/commands/')
+  );
+  await submit.click();
+  const queuedRequest = await requestPromise;
+  const requestBody = queuedRequest.postDataJSON();
+  const command = JSON.parse(
+    Buffer.from(requestBody.content, 'base64').toString('utf8')
+  );
+
+  expect(command.action).toBe('request_work');
+  expect(command.source).toBe('timekeeper_mobile');
+  expect(command.state_version).toBe('state-request-panel-1');
+  expect(command.target).toEqual({
+    issue_id: '',
+    evidence_fingerprint: '',
+    mission_id: ''
+  });
+  expect(command.params.project).toBe('Avantor');
+  expect(command.params.note).toBe(
+    'Update the customer delivery checklist and verify the result.'
+  );
+  await expect(page.locator('.app-toast').last()).toContainText(
+    'Request queued'
+  );
+  await expect(page.locator('#companyPageContent')).toContainText(
+    '1 Codex job queued or in progress'
+  );
+  expect(
+    await page.evaluate(
+      () => document.documentElement.scrollWidth <= window.innerWidth + 2
     )
   ).toBe(true);
 });

--- a/tests/unit/company-operator.test.mjs
+++ b/tests/unit/company-operator.test.mjs
@@ -107,6 +107,7 @@ test('normalizes a bounded mobile Company snapshot', () => {
         next_action: 'Prepare pricing and total cost.'
       }
     ],
+    request_projects: ['Avantor', 'Albany', 'Avantor'],
     work_products: {
       assets: [
         {
@@ -230,6 +231,7 @@ test('normalizes a bounded mobile Company snapshot', () => {
     2
   );
   assert.equal(snapshot.priorities[0].issueId, 'priority:avantor');
+  assert.deepEqual(snapshot.requestProjects, ['Avantor', 'Albany']);
   assert.equal(
     snapshot.workProducts.assets[0].format,
     'commercial_response_workbook'
@@ -595,6 +597,28 @@ test('builds an expiring allowlisted command without source content', () => {
   assert.equal(command.params.note, 'Focus on the pricing assumptions.');
   assert.equal(command.expires_at, '2026-08-05T12:00:00.000Z');
   assert.doesNotMatch(JSON.stringify(command), /email.body|slack.message/i);
+
+  const request = buildCompanyOperatorCommand({
+    commandId: 'mobile-request-001',
+    action: 'request_work',
+    snapshot: { stateVersion: 'state-1' },
+    params: {
+      project: 'Avantor',
+      note: 'Update the customer delivery checklist and verify it.'
+    },
+    now: new Date('2026-08-03T12:00:00.000Z')
+  });
+  assert.equal(request.action, 'request_work');
+  assert.deepEqual(request.target, {
+    issue_id: '',
+    evidence_fingerprint: '',
+    mission_id: ''
+  });
+  assert.equal(request.params.project, 'Avantor');
+  assert.equal(
+    request.params.note,
+    'Update the customer delivery checklist and verify it.'
+  );
   assert.throws(
     () =>
       buildCompanyOperatorCommand({


### PR DESCRIPTION
## Outcome

Adds a mobile-friendly “Ask Company Operator” panel to the Company tab. A user can enter a bounded request, choose a configured project, and queue one safe Company Operator command.

The panel:
- does not run work directly;
- uses the existing GitHub command queue and receipt flow;
- preserves the request on failure and clears it only after successful queueing;
- shows pending-command state;
- keeps the existing Company overview and safety boundaries intact.

## Coordinated backend

The required email-helper bridge was merged first in Henrik-KM/email-helper#16 as afa270f9b34f55c260ac8b2108fcd4bdb6097a9c.

## Local verification

- npm run check: passed before synchronization (102 unit tests and 62 browser/smoke tests)
- lint: passed after synchronization with latest main
- typecheck: passed after synchronization
- Company Operator unit tests: 9 passed after synchronization
- focused browser checks: 2 passed after synchronization
- mobile visual review at 390 × 844: passed, with no horizontal overflow

## Safety

- no email was sent or scheduled;
- no Outlook item was created, moved, or deleted;
- no TimeKeeper command was executed during tests;
- no Codex model call was made;
- request text is queued only through the existing bounded command path.