### PR TITLE
Compact Company results and clear queued questions

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -3,7 +3,7 @@
 const sw = /** @type {ServiceWorkerGlobalScope} */ (
   /** @type {unknown} */ (self)
 );
-const CACHE_NAME = 'timekeeper-app-v25';
+const CACHE_NAME = 'timekeeper-app-v26';
 const APP_SHELL = [
   './',
   './index.html',

--- a/src/features/company-operator/runtime.mjs
+++ b/src/features/company-operator/runtime.mjs
@@ -261,6 +261,7 @@ export function createCompanyOperatorController({
     const priority = {
       issueId: dispatch.issueId,
       evidenceFingerprint: dispatch.evidenceFingerprint,
+      missionId: dispatch.missionId || '',
       project: dispatch.project,
       title: dispatch.result.headline,
       userDirection: ''
@@ -630,6 +631,11 @@ export function createCompanyOperatorController({
   function companyOverviewCard() {
     const summary = snapshot.companySummary;
     if (!summary?.headline && !summary?.detail) return null;
+    const answerQueued =
+      summary.state === 'needs_you' &&
+      (summary.missionId
+        ? pendingCompanyAnswerExists('', '', summary.missionId)
+        : pendingCompanyAnswerExists());
     const labels = {
       needs_you: 'You need to do this',
       ready: 'Ready for you',
@@ -640,24 +646,36 @@ export function createCompanyOperatorController({
     };
     const section = element(
       'section',
-      `company-primary-card company-overview ${summary.state || 'clear'}`
+      `company-primary-card company-overview ${answerQueued ? 'waiting' : summary.state || 'clear'}`
     );
     section.appendChild(
       element(
         'p',
         'company-eyebrow',
-        labels[summary.state] || 'Current company status'
+        answerQueued
+          ? 'Answer queued'
+          : labels[summary.state] || 'Current company status'
       )
     );
-    if (summary.headline) {
+    if (answerQueued) {
+      section.appendChild(element('h3', '', 'Your answer is queued'));
+    } else if (summary.headline) {
       section.appendChild(element('h3', '', summary.headline));
     }
-    if (summary.detail) {
+    if (answerQueued) {
+      section.appendChild(
+        element(
+          'p',
+          'company-priority-title',
+          'Company Operator will continue after the next local sync.'
+        )
+      );
+    } else if (summary.detail) {
       section.appendChild(
         element('p', 'company-priority-title', summary.detail)
       );
     }
-    if (summary.destination) {
+    if (summary.destination && !answerQueued) {
       section.appendChild(compactResultDestination(summary.destination));
     }
     return section;
@@ -782,7 +800,12 @@ export function createCompanyOperatorController({
       ['active', 'queued', 'waiting_for_source'].includes(mission.status)
     );
     const waitingRows = active.filter(
-      (mission) => mission.status === 'waiting_for_decision'
+      (mission) =>
+        mission.status === 'waiting_for_decision' &&
+        !pendingCompanyAnswerExists(
+          mission.issueId,
+          mission.evidenceFingerprint
+        )
     );
     const sections = { working: null, completed: null, needsYou: null };
 
@@ -838,24 +861,23 @@ export function createCompanyOperatorController({
           )
         );
       }
-      section.appendChild(missionCard(completedToday.at(-1), 'completed'));
-      if (completedToday.length > 1) {
-        const more = element('details', 'company-result-backlog');
-        more.appendChild(
-          element(
-            'summary',
-            '',
-            `${completedToday.length - 1} earlier completion${completedToday.length === 2 ? '' : 's'}`
-          )
+      const completed = element(
+        'details',
+        'company-result-backlog company-completed-results'
+      );
+      completed.appendChild(
+        element(
+          'summary',
+          '',
+          `${completedToday.length} completion${completedToday.length === 1 ? '' : 's'} · View details`
+        )
+      );
+      [...completedToday]
+        .reverse()
+        .forEach((mission) =>
+          completed.appendChild(missionCard(mission, 'completed compact'))
         );
-        completedToday
-          .slice(0, -1)
-          .reverse()
-          .forEach((mission) =>
-            more.appendChild(missionCard(mission, 'completed compact'))
-          );
-        section.appendChild(more);
-      }
+      section.appendChild(completed);
       sections.completed = section;
     }
 
@@ -987,10 +1009,35 @@ export function createCompanyOperatorController({
     );
   }
 
+  function pendingCompanyAnswerExists(
+    issueId = '',
+    evidenceFingerprint = '',
+    missionId = ''
+  ) {
+    const pendingAnswers = loadPending().filter(
+      (item) => item.action === 'add_direction' && Boolean(item.dispatchId)
+    );
+    if (!issueId && !evidenceFingerprint && !missionId) {
+      return (
+        pendingAnswers.length === 1 &&
+        Number(snapshot?.companySummary?.counts?.needsYou || 0) <= 1
+      );
+    }
+    return pendingAnswers.some(
+      (item) =>
+        (!issueId || item.issueId === issueId) &&
+        (!missionId || item.missionId === missionId) &&
+        (!evidenceFingerprint ||
+          !item.evidenceFingerprint ||
+          item.evidenceFingerprint === evidenceFingerprint)
+    );
+  }
+
   async function answerMission(mission, choice = null) {
     await answerDispatch(
       {
         dispatchId: mission.userRequest?.dispatchId || '',
+        missionId: mission.missionId,
         issueId: mission.issueId,
         evidenceFingerprint: mission.evidenceFingerprint,
         project: mission.project,
@@ -1151,23 +1198,23 @@ export function createCompanyOperatorController({
     );
     if (done.length) {
       const section = sectionBlock('Recent completed work');
-      section.appendChild(compactDispatchCard(done[0], 'done'));
-      if (done.length > 1) {
-        const earlier = element('details', 'company-result-backlog');
-        earlier.appendChild(
-          element(
-            'summary',
-            '',
-            `${done.length - 1} earlier result${done.length === 2 ? '' : 's'}`
-          )
-        );
-        done.slice(1).forEach((dispatch) => {
-          const card = compactDispatchCard(dispatch, 'done');
-          card.classList.add('compact');
-          earlier.appendChild(card);
-        });
-        section.appendChild(earlier);
-      }
+      const completed = element(
+        'details',
+        'company-result-backlog company-completed-results'
+      );
+      completed.appendChild(
+        element(
+          'summary',
+          '',
+          `${done.length} recent result${done.length === 1 ? '' : 's'} · View details`
+        )
+      );
+      done.forEach((dispatch) => {
+        const card = compactDispatchCard(dispatch, 'done');
+        card.classList.add('compact');
+        completed.appendChild(card);
+      });
+      section.appendChild(completed);
       sections.done = section;
     }
     if (needsYou.length) {
@@ -1347,8 +1394,17 @@ export function createCompanyOperatorController({
 
   function commandStatus() {
     const pending = loadPending();
-    const codexPending = pending.filter((item) =>
-      CODEX_ACTIONS.has(item.action)
+    const answerPending = pending.filter(
+      (item) => item.action === 'add_direction' && item.dispatchId
+    );
+    const requestPending = pending.filter(
+      (item) => item.action === 'request_work'
+    );
+    const codexPending = pending.filter(
+      (item) =>
+        CODEX_ACTIONS.has(item.action) &&
+        !answerPending.includes(item) &&
+        !requestPending.includes(item)
     );
     const syncingPending = pending.filter(
       (item) => !CODEX_ACTIONS.has(item.action)
@@ -1361,6 +1417,24 @@ export function createCompanyOperatorController({
       return null;
     }
     const section = element('section', 'company-command-status');
+    if (answerPending.length) {
+      section.appendChild(
+        element(
+          'p',
+          'company-queued',
+          `${answerPending.length === 1 ? 'Answer' : `${answerPending.length} answers`} queued for Company Operator`
+        )
+      );
+    }
+    if (requestPending.length) {
+      section.appendChild(
+        element(
+          'p',
+          'company-queued',
+          `${requestPending.length} Company request${requestPending.length === 1 ? '' : 's'} queued`
+        )
+      );
+    }
     if (codexPending.length) {
       section.appendChild(
         element(

--- a/src/features/company-operator/runtime.mjs
+++ b/src/features/company-operator/runtime.mjs
@@ -632,10 +632,7 @@ export function createCompanyOperatorController({
     const summary = snapshot.companySummary;
     if (!summary?.headline && !summary?.detail) return null;
     const answerQueued =
-      summary.state === 'needs_you' &&
-      (summary.missionId
-        ? pendingCompanyAnswerExists('', '', summary.missionId)
-        : pendingCompanyAnswerExists());
+      summary.state === 'needs_you' && companySummaryAnswerPending(summary);
     const labels = {
       needs_you: 'You need to do this',
       ready: 'Ready for you',
@@ -1017,12 +1014,6 @@ export function createCompanyOperatorController({
     const pendingAnswers = loadPending().filter(
       (item) => item.action === 'add_direction' && Boolean(item.dispatchId)
     );
-    if (!issueId && !evidenceFingerprint && !missionId) {
-      return (
-        pendingAnswers.length === 1 &&
-        Number(snapshot?.companySummary?.counts?.needsYou || 0) <= 1
-      );
-    }
     return pendingAnswers.some(
       (item) =>
         (!issueId || item.issueId === issueId) &&
@@ -1030,6 +1021,22 @@ export function createCompanyOperatorController({
         (!evidenceFingerprint ||
           !item.evidenceFingerprint ||
           item.evidenceFingerprint === evidenceFingerprint)
+    );
+  }
+
+  function companySummaryAnswerPending(summary) {
+    if (summary.missionId) {
+      return pendingCompanyAnswerExists('', '', summary.missionId);
+    }
+    const questions = (snapshot?.dispatches?.recent || []).filter((dispatch) =>
+      ['needs_decision', 'needs_you'].includes(dispatch.result.status)
+    );
+    if (questions.length !== 1 || Number(summary.counts?.needsYou || 0) > 1) {
+      return false;
+    }
+    return pendingCompanyAnswerExists(
+      questions[0].issueId,
+      questions[0].evidenceFingerprint
     );
   }
 
@@ -1163,12 +1170,17 @@ export function createCompanyOperatorController({
     const pending = loadPending().filter((item) =>
       ['add_direction', 'work_next'].includes(item.action)
     );
-    const pendingIssues = new Set(
-      pending.map((item) => item.issueId).filter(Boolean)
-    );
     const recent = Array.isArray(snapshot?.dispatches?.recent)
       ? snapshot.dispatches.recent
-          .filter((dispatch) => !pendingIssues.has(dispatch.issueId))
+          .filter(
+            (dispatch) =>
+              !pending.some(
+                (item) =>
+                  item.issueId === dispatch.issueId &&
+                  (!item.evidenceFingerprint ||
+                    item.evidenceFingerprint === dispatch.evidenceFingerprint)
+              )
+          )
           .slice(0, 5)
       : [];
     const sections = {

--- a/src/styles/features.css
+++ b/src/styles/features.css
@@ -1217,6 +1217,19 @@ tr:nth-child(even) td {
   font-weight: 750;
 }
 
+.company-completed-results {
+  margin-top: 0.35rem;
+}
+
+.company-completed-results > summary {
+  padding: 0.15rem 0;
+  color: #166534;
+}
+
+.company-completed-results[open] > summary {
+  margin-bottom: 0.5rem;
+}
+
 .company-list-card,
 .company-receipt-card,
 .company-dispatch-card,

--- a/tests/smoke/timekeeper.spec.js
+++ b/tests/smoke/timekeeper.spec.js
@@ -1644,7 +1644,24 @@ test('mobile Company tab puts current status before dated historical work', asyn
     'Confirm the AstraZeneca launch decision'
   );
   await expect(content).toContainText('Recent completed work');
-  await expect(content).toContainText('Completed on 2026-07-29');
+  const completedResults = content.locator(
+    'section:has(> h3:text-is("Recent completed work")) .company-completed-results'
+  );
+  await expect(completedResults).not.toHaveAttribute('open', '');
+  await expect(completedResults).toContainText(
+    '1 recent result · View details'
+  );
+  await expect(
+    completedResults.getByText('Completed on 2026-07-29')
+  ).toBeHidden();
+  const compactHeight = await completedResults.evaluate(
+    (node) => node.closest('section').getBoundingClientRect().height
+  );
+  expect(compactHeight).toBeLessThan(150);
+  await completedResults.locator('> summary').click();
+  await expect(
+    completedResults.getByText('Completed on 2026-07-29')
+  ).toBeVisible();
   await expect(content).not.toContainText('Done for you');
   await expect(content).not.toContainText('Nothing needs you');
   const order = await page.evaluate(() => ({
@@ -1712,7 +1729,7 @@ test('service worker never caches private cross-origin API responses', async () 
   expect(serviceWorker).toContain(
     'if (requestUrl.origin !== sw.location.origin) return;'
   );
-  expect(serviceWorker).toContain("const CACHE_NAME = 'timekeeper-app-v25';");
+  expect(serviceWorker).toContain("const CACHE_NAME = 'timekeeper-app-v26';");
   expect(serviceWorker).toContain("'./src/main.mjs?v=20'");
   expect(serviceWorker).toContain(
     "url.searchParams.set('timekeeper-update', '22')"
@@ -2040,7 +2057,7 @@ test('mobile Company request panel queues one bounded operator request', async (
     'Request queued'
   );
   await expect(page.locator('#companyPageContent')).toContainText(
-    '1 Codex job queued or in progress'
+    '1 Company request queued'
   );
   expect(
     await page.evaluate(
@@ -2366,6 +2383,11 @@ test('mobile Company tab loads private priorities and queues safe steering', asy
       request.method() === 'PUT' &&
       request.url().includes('/contents/company-operator/commands/')
   );
+  await page
+    .locator(
+      '#companyPageContent section:has(> h3:text-is("Recent completed work")) .company-completed-results > summary'
+    )
+    .click();
   await page.getByRole('button', { name: 'Useful' }).click();
   const feedbackPayload = (await feedbackRequest).postDataJSON();
   const feedbackCommand = JSON.parse(
@@ -2402,8 +2424,14 @@ test('mobile Company tab loads private priorities and queues safe steering', asy
   );
   await expect(page.getByText('gpt-5.6-terra / medium').first()).toBeHidden();
   await page
-    .locator('#companyPageContent .company-run-details summary')
-    .first()
+    .locator(
+      '#companyPageContent section:has(> h3:text-is("Recent completed work")) .company-completed-results > summary'
+    )
+    .click();
+  await page
+    .locator(
+      '#companyPageContent .company-dispatch-card.done .company-run-details > summary'
+    )
     .click();
   await expect(page.locator('#companyPageContent')).toContainText(
     'gpt-5.6-terra / medium'
@@ -2509,6 +2537,15 @@ test('mobile Company tab loads private priorities and queues safe steering', asy
   expect(directionCommand.params.answers).toEqual([
     { field_id: 'pilot_deadline', value: '2026-09-30' }
   ]);
+  await expect(
+    page.getByRole('heading', { name: 'Needs you', exact: true })
+  ).toHaveCount(0);
+  await expect(page.locator('#companyPageContent')).not.toContainText(
+    'You need to do this'
+  );
+  await expect(page.locator('#companyPageContent')).toContainText(
+    'Answer queued for Company Operator'
+  );
   const storage = await page.evaluate(() => ({
     normalData: localStorage.getItem('timekeeperDataPro') || '',
     token: localStorage.getItem('timekeeperCompanyOperatorToken') || ''
@@ -2726,7 +2763,17 @@ test('mobile Company tab presents missions before the next priority', async ({
   await expect(content).toContainText(
     'Finish the tested camera configuration for the customer.'
   );
-  await expect(content).toContainText('Aventix local commit');
+  const completedMissions = content.locator(
+    'section:has(> h3:text-is("Completed for you")) .company-completed-results'
+  );
+  await expect(completedMissions).toContainText('1 completion · View details');
+  await expect(
+    completedMissions.getByText('Aventix local commit')
+  ).toBeHidden();
+  await completedMissions.locator('> summary').click();
+  await expect(
+    completedMissions.getByText('Aventix local commit')
+  ).toBeVisible();
   await expect(content).toContainText(
     'Choose direct delivery or partner delivery.'
   );


### PR DESCRIPTION
## Outcome
- Keeps recent completed Company work collapsed behind a compact, touch-friendly summary.
- Removes stale Needs you mission/dispatch cards immediately after an answer is queued.
- Shows truthful queued-answer and queued-request labels instead of grouping every action as a Codex job.
- Bumps the offline cache so mobile devices receive the corrected UI.

## Verification
- npm run check
- 102 unit tests passed
- 62 Playwright browser tests passed
- Focused mobile Company flows passed
- ESLint, Prettier, TypeScript, and git diff checks passed

## Safety
No external Company action behavior changed. Existing results remain available after expanding View details. This commit uses [skip ci] to conserve the repository's remaining GitHub Actions allowance; the complete gate was run locally.