### PR TITLE
Reduce GitHub integration traffic

### DIFF
--- a/.github/workflows/strava.yml
+++ b/.github/workflows/strava.yml
@@ -7,7 +7,7 @@ on:
       - "scripts/fetch_strava.py"
       - "assets/strava_overrides.json"
   schedule:
-    - cron: "17 */6 * * *"
+    - cron: "17 3 * * *"
   workflow_dispatch:
 
 permissions:

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Setup:
 npm run codex:bridge:install
 ```
 
-The task runs at logon and every 5 minutes, scans Codex session files changed during the seven-day window under `%USERPROFILE%\.codex\sessions`, writes one file per desktop under `assets/timekeeper-codex-inbox/`, and exits. To run it manually:
+The task runs at logon and every 15 minutes, scans Codex session files changed during the seven-day window under `%USERPROFILE%\.codex\sessions`, writes one file per desktop under `assets/timekeeper-codex-inbox/`, and exits. The browser checks the inbox every five minutes and reuses unchanged files. To run it manually:
 
 ```bash
 npm run codex:bridge
@@ -209,6 +209,8 @@ Before writing, TimeKeeper checks the selected folder's latest backup revision a
 ## Strava feed publishing
 
 This repo includes a GitHub Actions workflow that publishes a lightweight Strava JSON feed to `assets/strava.json`, which is rendered in the Workouts section of the app.
+
+The workflow runs once daily at 03:17 UTC and can also be started manually with **Run workflow** when a fresher feed is needed.
 
 ### Setup
 

--- a/assets/strava.json
+++ b/assets/strava.json
@@ -1,5 +1,5 @@
 {
-  "updated_utc": "2026-08-16T06:59:00.282239+00:00",
+  "updated_utc": "2026-08-16T11:56:59.750688+00:00",
   "score_model_version": 2,
   "activities": [
     {

--- a/scripts/codex-usage-bridge.mjs
+++ b/scripts/codex-usage-bridge.mjs
@@ -801,12 +801,18 @@ export async function buildCodexInboxPayload(options = buildOptions()) {
 }
 
 export function makeCodexPayloadKey(payload = {}) {
+  const usageLimits = payload.usageLimits || null;
   return crypto
     .createHash('sha256')
     .update(
       JSON.stringify({
         rangeStart: payload.rangeStart,
-        usageLimits: payload.usageLimits || null,
+        usageLimits: usageLimits
+          ? {
+              primary: usageLimits.primary || null,
+              secondary: usageLimits.secondary || null
+            }
+          : null,
         retractedExternalIds: Array.isArray(payload.retractedExternalIds)
           ? payload.retractedExternalIds
           : [],

--- a/scripts/install-codex-usage-bridge.ps1
+++ b/scripts/install-codex-usage-bridge.ps1
@@ -16,7 +16,7 @@ $TaskCommand = "wscript.exe //B //Nologo `"$ResolvedHiddenLauncherPath`""
   /Create `
   /TN $TaskName `
   /SC MINUTE `
-  /MO 5 `
+  /MO 15 `
   /TR $TaskCommand `
   /F | Out-Null
 if ($LASTEXITCODE -ne 0) {
@@ -32,7 +32,7 @@ if (-not $NoStart) {
 
 Write-Output "Installed scheduled task: $TaskName"
 if ($NoStart) {
-  Write-Output 'The task will repeat every 5 minutes.'
+  Write-Output 'The task will repeat every 15 minutes.'
 } else {
-  Write-Output 'The task was started and will repeat every 5 minutes.'
+  Write-Output 'The task was started and will repeat every 15 minutes.'
 }

--- a/src/main.mjs
+++ b/src/main.mjs
@@ -1423,7 +1423,7 @@ import {
   const CODEX_CONTEXT_PUBLISH_DEBOUNCE_MS = 5000;
   const CODEX_CONTEXT_RETRY_MS = 60 * 1000;
   const CODEX_CONTEXT_RUNNING_REFRESH_MS = 5 * 60 * 1000;
-  const CODEX_IMPORT_INTERVAL_MS = 60 * 1000;
+  const CODEX_IMPORT_INTERVAL_MS = 5 * 60 * 1000;
   const CODEX_IMPORT_LOOKBACK_DAYS = 7;
   const CODEX_USAGE_STALE_MS = 2 * 60 * 60 * 1000;
   const CODEX_FOCUS_FACTOR = 0.4;
@@ -3078,6 +3078,8 @@ import {
     skipped: 0,
     updated: 0
   };
+  let codexInboxFileCache = new Map();
+  let codexInboxCacheScope = '';
 
   function normalizeGitHubPath(value) {
     const path = String(value || 'assets/timekeeper-focus-state.json')
@@ -3959,6 +3961,15 @@ import {
 
   async function fetchCodexInboxPayloads() {
     const config = getCodexIntegrationConfig();
+    const cacheScope = [
+      normalizeGitHubRepository(config.repository),
+      config.branch || CODEX_DEFAULT_BRANCH,
+      config.inboxPath
+    ].join('|');
+    if (cacheScope !== codexInboxCacheScope) {
+      codexInboxFileCache = new Map();
+      codexInboxCacheScope = cacheScope;
+    }
     const directoryUrl = getCodexGitHubPathApiUrl(config.inboxPath, config);
     if (!directoryUrl)
       throw new Error('Enter a GitHub repository as owner/repo.');
@@ -3972,21 +3983,32 @@ import {
     const jsonItems = items.filter(
       (item) =>
         item &&
-        item.type === 'file' &&
-        String(item.name || '')
-          .toLowerCase()
-          .endsWith('.json')
+          item.type === 'file' &&
+          String(item.name || '')
+            .toLowerCase()
+            .endsWith('.json')
     );
-    const payloads = [];
+    const nextFileCache = new Map();
     await Promise.all(
       jsonItems.map(async (item) => {
+        const cacheKey = String(item.path || item.name || item.url || '');
+        const sha = String(item.sha || '');
+        const cached = cacheKey ? codexInboxFileCache.get(cacheKey) : null;
+        if (sha && cached?.sha === sha) {
+          nextFileCache.set(cacheKey, cached);
+          return;
+        }
         const itemPayload = await githubJson(item.url, {
           headers: getCodexAuthHeaders()
         });
-        payloads.push(JSON.parse(decodeUtf8Base64(itemPayload.content)));
+        nextFileCache.set(cacheKey, {
+          sha,
+          payload: JSON.parse(decodeUtf8Base64(itemPayload.content))
+        });
       })
     );
-    return payloads;
+    codexInboxFileCache = nextFileCache;
+    return [...nextFileCache.values()].map((item) => item.payload);
   }
 
   async function importCodexUsage({ quiet = false } = {}) {

--- a/tests/smoke/timekeeper.spec.js
+++ b/tests/smoke/timekeeper.spec.js
@@ -4797,6 +4797,7 @@ test('Codex inbox reconciles delegated entries and recalibrates changed records 
   });
   await page.addInitScript((inboxContent) => {
     localStorage.setItem('timekeeperCodexIntegrationToken', 'ghp_codex_test');
+    window['__codexInboxFileFetches'] = 0;
     window.fetch = (url) => {
       const value = String(url);
       if (
@@ -4810,6 +4811,7 @@ test('Codex inbox reconciles delegated entries and recalibrates changed records 
               {
                 type: 'file',
                 name: 'desktop-a.json',
+                sha: 'sha-desktop-a',
                 url: 'https://api.github.com/repos/Henrik-KM/TimeKeeper/contents/assets/timekeeper-codex-inbox/desktop-a.json'
               }
             ]),
@@ -4821,6 +4823,7 @@ test('Codex inbox reconciles delegated entries and recalibrates changed records 
         );
       }
       if (value.includes('timekeeper-codex-inbox/desktop-a.json')) {
+        window['__codexInboxFileFetches'] += 1;
         return Promise.resolve(
           new Response(JSON.stringify({ content: inboxContent }), {
             status: 200,
@@ -4967,6 +4970,9 @@ test('Codex inbox reconciles delegated entries and recalibrates changed records 
       )
     )
     .toMatchObject({ imported: 0, updated: 0 });
+  expect(
+    await page.evaluate(() => window['__codexInboxFileFetches'])
+  ).toBe(1);
   data = await page.evaluate(() =>
     JSON.parse(localStorage.getItem('timekeeperDataPro'))
   );

--- a/tests/unit/codex-usage-bridge.test.mjs
+++ b/tests/unit/codex-usage-bridge.test.mjs
@@ -302,6 +302,34 @@ test('Codex payload fingerprint changes when usage limits change', () => {
   );
 });
 
+test('Codex payload fingerprint ignores usage-limit observation timestamps', () => {
+  const payload = {
+    rangeStart: '2026-06-07T00:00:00.000Z',
+    records: [],
+    usageLimits: {
+      observedAt: '2026-06-13T09:00:00.000Z',
+      primary: {
+        usedPercent: 90,
+        remainingPercent: 10,
+        windowMinutes: 10080,
+        resetsAt: '2026-06-16T17:00:00.000Z'
+      },
+      secondary: null
+    }
+  };
+
+  assert.equal(
+    makeCodexPayloadKey(payload),
+    makeCodexPayloadKey({
+      ...payload,
+      usageLimits: {
+        ...payload.usageLimits,
+        observedAt: '2026-06-13T09:05:00.000Z'
+      }
+    })
+  );
+});
+
 test('sanitizes the canonical live Codex rate-limit bucket', () => {
   const usageLimits = sanitizeAppServerUsageLimits(
     {


### PR DESCRIPTION
## Summary

- reduce Codex bridge writes caused only by volatile usage observation timestamps
- poll the Codex inbox every five minutes and reuse unchanged files by GitHub SHA
- run the local bridge every 15 minutes
- run the Strava publishing workflow daily while retaining manual dispatch

## Validation

- `npm.cmd run test:unit` — 106 passed
- `npm.cmd run lint`
- `npm.cmd run typecheck`
- `npm.cmd run test:smoke` — 63 passed

The existing local scheduled task must be reinstalled with `npm.cmd run codex:bridge:install` for the new 15-minute interval to take effect.